### PR TITLE
config: PAD-US 4.1, vulnerable carbon 2024, US-wide default view

### DIFF
--- a/example-ghpages/layers-input.json
+++ b/example-ghpages/layers-input.json
@@ -4,10 +4,10 @@
     "mcp_url": "https://duckdb-mcp.nrp-nautilus.io/mcp",
     "view": {
         "center": [
-            -119.4179,
-            36.7783
+            -98,
+            39
         ],
-        "zoom": 6
+        "zoom": 4
     },
     "llm": {
         "user_provided": true,
@@ -29,26 +29,17 @@
     },
     "collections": [
         {
-            "collection_id": "cpad-2025b",
+            "collection_id": "pad-us-4.1-combined",
             "assets": [
-                "cpad-holdings-pmtiles",
-                "cpad-units-pmtiles"
+                "pmtiles"
             ]
         },
         {
             "collection_id": "irrecoverable-carbon",
             "assets": [
                 {
-                    "id": "irrecoverable-total-2018-cog",
-                    "display_name": "Irrecoverable Carbon (2018)"
-                },
-                {
-                    "id": "manageable-total-2018-cog",
-                    "display_name": "Manageable Carbon (2018)"
-                },
-                {
-                    "id": "vulnerable-total-2018-cog",
-                    "display_name": "Vulnerable Carbon (2018)"
+                    "id": "v2-vulnerable-2024-cog",
+                    "display_name": "Vulnerable Carbon (2024)"
                 }
             ]
         }

--- a/example-k8s/layers-input.json
+++ b/example-k8s/layers-input.json
@@ -4,33 +4,24 @@
     "mcp_url": "https://duckdb-mcp.nrp-nautilus.io/mcp",
     "view": {
         "center": [
-            -119.4179,
-            36.7783
+            -98,
+            39
         ],
-        "zoom": 6
+        "zoom": 4
     },
     "collections": [
         {
-            "collection_id": "cpad-2025b",
+            "collection_id": "pad-us-4.1-combined",
             "assets": [
-                "cpad-holdings-pmtiles",
-                "cpad-units-pmtiles"
+                "pmtiles"
             ]
         },
         {
             "collection_id": "irrecoverable-carbon",
             "assets": [
                 {
-                    "id": "irrecoverable-total-2018-cog",
-                    "display_name": "Irrecoverable Carbon (2018)"
-                },
-                {
-                    "id": "manageable-total-2018-cog",
-                    "display_name": "Manageable Carbon (2018)"
-                },
-                {
-                    "id": "vulnerable-total-2018-cog",
-                    "display_name": "Vulnerable Carbon (2018)"
+                    "id": "v2-vulnerable-2024-cog",
+                    "display_name": "Vulnerable Carbon (2024)"
                 }
             ]
         }


### PR DESCRIPTION
## Summary

- Replace `cpad-2025b` with `pad-us-4.1-combined` (PAD-US national protected areas database)
- Replace irrecoverable/manageable carbon layers with `v2-vulnerable-2024-cog` (Vulnerable Carbon 2024, v2)
- Update default map view to show full contiguous US (center `[-98, 39]`, zoom 4)

Applied to both `example-ghpages/` and `example-k8s/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)