### PR TITLE
feat: config-driven default style, hover tooltip, and default visibility

### DIFF
--- a/app/dataset-catalog.js
+++ b/app/dataset-catalog.js
@@ -156,6 +156,9 @@ export class DatasetCatalog {
                     url: asset.href,
                     sourceLayer: asset['vector:layers']?.[0] || asset['pmtiles:layer'] || assetId,
                     description: asset.description || '',
+                    defaultStyle: perAsset.default_style || null,
+                    tooltipFields: perAsset.tooltip_fields || null,
+                    defaultVisible: perAsset.visible === true,
                 });
             } else if (type.includes('geotiff') || type.includes('tiff')) {
                 const colormap = perAsset.colormap || options.colormap || 'reds';
@@ -357,8 +360,10 @@ export class DatasetCatalog {
                             url: `pmtiles://${ml.url}`,
                         },
                         sourceLayer: ml.sourceLayer,
-                        paint: { 'fill-color': '#2E7D32', 'fill-opacity': 0.5 },
+                        paint: ml.defaultStyle || { 'fill-color': '#2E7D32', 'fill-opacity': 0.5 },
                         columns: ds.columns,
+                        tooltipFields: ml.tooltipFields || null,
+                        defaultVisible: ml.defaultVisible || false,
                     });
                 } else if (ml.layerType === 'raster') {
                     let tilesUrl = `${this.titilerUrl}/cog/tiles/WebMercatorQuad/{z}/{x}/{y}.png?url=${encodeURIComponent(ml.cogUrl)}&colormap_name=${ml.colormap}`;

--- a/app/style.css
+++ b/app/style.css
@@ -251,6 +251,44 @@ body {
     border-color: rgba(0, 124, 191, 0.35);
 }
 
+/* Hover tooltip */
+.map-tooltip {
+    display: none;
+    position: fixed;
+    z-index: 100;
+    background: rgba(255, 255, 255, 0.95);
+    -webkit-backdrop-filter: blur(4px);
+    backdrop-filter: blur(4px);
+    border: 1px solid rgba(0, 0, 0, 0.2);
+    border-radius: 4px;
+    padding: 8px 10px;
+    font-family: 'Open Sans', sans-serif;
+    font-size: 12px;
+    color: #333;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+    pointer-events: none;
+    max-width: 260px;
+}
+
+.map-tooltip table {
+    border-collapse: collapse;
+    width: 100%;
+}
+
+.map-tooltip th {
+    font-weight: 600;
+    color: #666;
+    text-align: left;
+    padding: 2px 10px 2px 0;
+    white-space: nowrap;
+}
+
+.map-tooltip td {
+    color: #333;
+    padding: 2px 0;
+    word-break: break-word;
+}
+
 #h3-res-badge {
     position: absolute;
     z-index: 1;

--- a/example-ghpages/layers-input.json
+++ b/example-ghpages/layers-input.json
@@ -31,7 +31,22 @@
         {
             "collection_id": "pad-us-4.1-combined",
             "assets": [
-                "pmtiles"
+                {
+                    "id": "pmtiles",
+                    "display_name": "Protected Areas (PAD-US)",
+                    "visible": true,
+                    "default_style": {
+                        "fill-color": ["match", ["get", "GAP_Sts"],
+                            1, "#26633A",
+                            2, "#3E9C47",
+                            3, "#7EB3D3",
+                            4, "#BDBDBD",
+                            "#888888"
+                        ],
+                        "fill-opacity": 0.7
+                    },
+                    "tooltip_fields": ["Unit_Nm", "GAP_Sts", "Mang_Type"]
+                }
             ]
         },
         {

--- a/example-k8s/layers-input.json
+++ b/example-k8s/layers-input.json
@@ -13,7 +13,22 @@
         {
             "collection_id": "pad-us-4.1-combined",
             "assets": [
-                "pmtiles"
+                {
+                    "id": "pmtiles",
+                    "display_name": "Protected Areas (PAD-US)",
+                    "visible": true,
+                    "default_style": {
+                        "fill-color": ["match", ["get", "GAP_Sts"],
+                            1, "#26633A",
+                            2, "#3E9C47",
+                            3, "#7EB3D3",
+                            4, "#BDBDBD",
+                            "#888888"
+                        ],
+                        "fill-opacity": 0.7
+                    },
+                    "tooltip_fields": ["Unit_Nm", "GAP_Sts", "Mang_Type"]
+                }
             ]
         },
         {


### PR DESCRIPTION
## Summary

Adds three new per-asset options to `layers-input.json` — all optional, backward-compatible.

### New config options (per-asset in `collections`)

| Field | Type | Effect |
|---|---|---|
| `visible` | `boolean` | Layer is toggled on when the map loads |
| `default_style` | MapLibre paint object | Applied as the layer's initial paint (replaces hardcoded green) |
| `tooltip_fields` | `string[]` | Hovering a feature shows a small tooltip with those property values |

### Core changes (`app/`)

- **`dataset-catalog.js`**: reads the three new fields from per-asset config and forwards them through `mapLayers` → `getMapLayerConfigs()`
- **`map-manager.js`**: `registerLayer` honours `defaultVisible` (initial layout visibility + state); uses `defaultStyle` as paint; wires `mousemove`/`mouseleave` on the MapLibre layer ID for any layer that declares `tooltipFields`; creates a single shared tooltip `<div>` in the constructor
- **`style.css`**: `.map-tooltip` — fixed-position, glass-effect card, `pointer-events: none`

### Example update (`example-ghpages/`, `example-k8s/`)

PAD-US `pmtiles` asset expanded to show the three options in action:
- On by default
- Colored by `GAP_Sts` (1=dark green, 2=medium green, 3=blue, 4=gray)
- Tooltip shows `Unit_Nm`, `GAP_Sts`, `Mang_Type` on hover

🤖 Generated with [Claude Code](https://claude.com/claude-code)