### PR TITLE
config: rename k8s deployment from ca-lands to padus

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,75 @@
+# Project Context & Instructions
+
+## Overview
+Map-based application for exploring California's protected lands. Interactive MapLibre GL JS map with an LLM-powered chatbot for natural language data queries and map control.
+
+## Key Technologies
+- **Frontend**: MapLibre GL JS, PMTiles (vectors), COG + TiTiler (rasters), ES modules
+- **Data**: STAC catalog → unified dataset records with visual + parquet assets
+- **Analytics**: SQL queries via MCP (Model Context Protocol) to DuckDB on H3-indexed parquet
+- **LLM**: OpenAI-compatible Chat Completions API (multiple models via proxy)
+- **Deployment**: Kubernetes (nginx + git-clone init container)
+
+## Architecture (app/ modules)
+- `main.js` — Bootstrap: loads config, initializes catalog → map → tools → agent → UI
+- `dataset-catalog.js` — Fetches STAC collections, builds unified records
+- `map-manager.js` — Creates MapLibre map, manages layers/filters/styles
+- `map-tools.js` — 9 local tools the LLM agent can call
+- `tool-registry.js` — Unified dispatch for local + remote (MCP) tools
+- `mcp-client.js` — MCP transport wrapper (connect once, lazy reconnect)
+- `agent.js` — LLM orchestration loop (agentic tool-use cycle)
+- `chat-ui.js` — Chat UI with collapsible tool-call blocks
+
+## Configuration
+- `app/layers-input.json` — Static config: STAC catalog URL, collection IDs, map view
+- `config.json` — Generated at deploy time by k8s (LLM models + API keys from secrets)
+- Both are merged by `main.js` at startup; runtime config overrides static config
+
+## Git workflow — branch protection
+
+The `main` branch is protected: **direct pushes are rejected**. All changes must go through a pull request.
+
+**Committing and pushing changes:**
+1. Make changes, then commit:
+   ```bash
+   git add <files>
+   git commit -m "<message>"
+   ```
+2. Create a feature branch and push:
+   ```bash
+   git checkout -b <branch-name>
+   git push -u origin <branch-name>
+   ```
+3. The push output includes a PR URL — open it to create the pull request:
+   ```
+   remote: Create a pull request ... by visiting:
+   remote:   https://github.com/boettiger-lab/geo-agent/pull/new/<branch-name>
+   ```
+4. After the PR is merged, **always clean up**:
+   ```bash
+   git checkout main
+   git pull
+   git branch -d <branch-name>
+   ```
+
+> If the user confirms the PR has been merged and asks to "clean up" or "switch back to main", run all three cleanup commands together.
+
+## Deployment
+Deployment is managed via Kubernetes. The application runs in an nginx container that clones the repo on startup.
+
+**To deploy changes:**
+1. Merge changes to `main` via PR (see above).
+2. Restart the deployment:
+   ```bash
+   kubectl rollout restart deployment/padus
+   ```
+
+**Kubernetes Resources:**
+- Manifests are in the `k8s/` directory.
+- See `k8s/README.md` for detailed deployment and secret management instructions.
+
+## Development
+- Local: `cd app && python -m http.server 8000`
+- Create a local `app/config.json` with LLM model configs for development
+- `config.json` is in `.gitignore` — never committed (contains API keys)
+

--- a/example-k8s/k8s/configmap.yaml
+++ b/example-k8s/k8s/configmap.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: ca-lands-config
+  name: padus-config
 data:
   config.template.json: |
     {
@@ -35,7 +35,7 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: ca-lands-nginx
+  name: padus-nginx
 data:
   nginx.conf: |
     server {

--- a/example-k8s/k8s/deployment.yaml
+++ b/example-k8s/k8s/deployment.yaml
@@ -1,9 +1,9 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: ca-lands
+  name: padus
   labels:
-    app: ca-lands
+    app: padus
 spec:
   replicas: 2
   strategy:
@@ -13,11 +13,11 @@ spec:
       maxSurge: 1
   selector:
     matchLabels:
-      app: ca-lands
+      app: padus
   template:
     metadata:
       labels:
-        app: ca-lands
+        app: padus
     spec:
       initContainers:
       - name: git-clone
@@ -28,7 +28,7 @@ spec:
         - |
           # Clone this app repo (tiny — just HTML + config files)
           # Replace URL with your own app repo:
-          git clone --depth 1 https://github.com/boettiger-lab/ca-lands-app.git /tmp/repo
+          git clone --depth 1 https://github.com/boettiger-lab/padus-app.git /tmp/repo
           cp /tmp/repo/index.html /usr/share/nginx/html/
           cp /tmp/repo/layers-input.json /usr/share/nginx/html/
           cp /tmp/repo/system-prompt.md /usr/share/nginx/html/
@@ -101,7 +101,7 @@ spec:
         emptyDir: {}
       - name: config-template
         configMap:
-          name: ca-lands-config
+          name: padus-config
       - name: nginx-config
         configMap:
-          name: ca-lands-nginx
+          name: padus-nginx

--- a/example-k8s/k8s/ingress.yaml
+++ b/example-k8s/k8s/ingress.yaml
@@ -1,7 +1,7 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: ca-lands-ingress
+  name: padus-ingress
   annotations:
     haproxy-ingress.github.io/cors-enable: "true"
     haproxy-ingress.github.io/cors-allow-origin: "*"
@@ -15,15 +15,15 @@ spec:
   ingressClassName: haproxy
   tls:
     - hosts:
-        - ca-lands.nrp-nautilus.io
+        - padus.nrp-nautilus.io
   rules:
-    - host: ca-lands.nrp-nautilus.io
+    - host: padus.nrp-nautilus.io
       http:
         paths:
           - path: /
             pathType: Prefix
             backend:
               service:
-                name: ca-lands
+                name: padus
                 port:
                   number: 80

--- a/example-k8s/k8s/service.yaml
+++ b/example-k8s/k8s/service.yaml
@@ -1,13 +1,13 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: ca-lands
+  name: padus
   labels:
-    app: ca-lands
+    app: padus
 spec:
   type: ClusterIP
   selector:
-    app: ca-lands
+    app: padus
   ports:
     - protocol: TCP
       port: 80


### PR DESCRIPTION
## Summary

Renames all Kubernetes resources and the deployment URL from `ca-lands` → `padus`.

- `deployment.yaml`: name, labels, selector, configMap volume references
- `service.yaml`: name, labels, selector
- `ingress.yaml`: name, host (`padus.nrp-nautilus.io`), backend service reference
- `configmap.yaml`: ConfigMap names (`padus-config`, `padus-nginx`)
- `AGENTS.md`: rollout restart command updated

After merging: apply new manifests, then delete old `ca-lands` resources.

🤖 Generated with [Claude Code](https://claude.com/claude-code)