### PR TITLE
feat: alias + default_filter for config-driven layer splitting/filtering

### DIFF
--- a/app/map-manager.js
+++ b/app/map-manager.js
@@ -78,7 +78,7 @@ export class MapManager {
      * Register a single layer on the map.
      */
     registerLayer(config) {
-        const { layerId, datasetId, displayName, type, source, sourceLayer, paint, columns, tooltipFields, defaultVisible } = config;
+        const { layerId, datasetId, displayName, type, source, sourceLayer, paint, columns, tooltipFields, defaultVisible, defaultFilter } = config;
         const sourceId = `src-${layerId.replace(/\//g, '-')}`;
         const mapLayerId = `layer-${layerId.replace(/\//g, '-')}`;
 
@@ -105,6 +105,11 @@ export class MapManager {
 
         this.map.addLayer(layerDef);
 
+        // Apply default filter if declared
+        if (defaultFilter) {
+            this.map.setFilter(mapLayerId, defaultFilter);
+        }
+
         // Store state
         this.layers.set(layerId, {
             layerId,
@@ -115,7 +120,7 @@ export class MapManager {
             type,
             sourceLayer: sourceLayer || null,
             visible: defaultVisible || false,
-            filter: null,
+            filter: defaultFilter || null,
             columns: columns || [],
             defaultPaint: { ...(paint || {}) },
             tooltipFields: tooltipFields || null,

--- a/example-ghpages/layers-input.json
+++ b/example-ghpages/layers-input.json
@@ -33,7 +33,8 @@
             "assets": [
                 {
                     "id": "pmtiles",
-                    "display_name": "Protected Areas (PAD-US)",
+                    "alias": "fee",
+                    "display_name": "Protected Areas - Fee (GAP 1 & 2)",
                     "visible": true,
                     "default_style": {
                         "fill-color": ["match", ["get", "GAP_Sts"],
@@ -45,6 +46,28 @@
                         ],
                         "fill-opacity": 0.7
                     },
+                    "default_filter": ["all",
+                        ["==", "FeatClass", "Fee"],
+                        ["in", "GAP_Sts", "1", "2"]
+                    ],
+                    "tooltip_fields": ["Unit_Nm", "GAP_Sts", "Mang_Type"]
+                },
+                {
+                    "id": "pmtiles",
+                    "alias": "easement",
+                    "display_name": "Protected Areas - Easement",
+                    "visible": false,
+                    "default_style": {
+                        "fill-color": ["match", ["get", "GAP_Sts"],
+                            "1", "#26633A",
+                            "2", "#3E9C47",
+                            "3", "#7EB3D3",
+                            "4", "#BDBDBD",
+                            "#888888"
+                        ],
+                        "fill-opacity": 0.7
+                    },
+                    "default_filter": ["==", "FeatClass", "Easement"],
                     "tooltip_fields": ["Unit_Nm", "GAP_Sts", "Mang_Type"]
                 }
             ]

--- a/example-k8s/layers-input.json
+++ b/example-k8s/layers-input.json
@@ -15,7 +15,8 @@
             "assets": [
                 {
                     "id": "pmtiles",
-                    "display_name": "Protected Areas (PAD-US)",
+                    "alias": "fee",
+                    "display_name": "Protected Areas - Fee (GAP 1 & 2)",
                     "visible": true,
                     "default_style": {
                         "fill-color": ["match", ["get", "GAP_Sts"],
@@ -27,6 +28,28 @@
                         ],
                         "fill-opacity": 0.7
                     },
+                    "default_filter": ["all",
+                        ["==", "FeatClass", "Fee"],
+                        ["in", "GAP_Sts", "1", "2"]
+                    ],
+                    "tooltip_fields": ["Unit_Nm", "GAP_Sts", "Mang_Type"]
+                },
+                {
+                    "id": "pmtiles",
+                    "alias": "easement",
+                    "display_name": "Protected Areas - Easement",
+                    "visible": false,
+                    "default_style": {
+                        "fill-color": ["match", ["get", "GAP_Sts"],
+                            "1", "#26633A",
+                            "2", "#3E9C47",
+                            "3", "#7EB3D3",
+                            "4", "#BDBDBD",
+                            "#888888"
+                        ],
+                        "fill-opacity": 0.7
+                    },
+                    "default_filter": ["==", "FeatClass", "Easement"],
                     "tooltip_fields": ["Unit_Nm", "GAP_Sts", "Mang_Type"]
                 }
             ]


### PR DESCRIPTION
## Summary

### New config options

| Field | Type | Effect |
|---|---|---|
| `alias` | `string` | Unique layer ID suffix, allowing the same STAC asset to appear as multiple logical layers |
| `default_filter` | MapLibre filter expression | Applied to the layer at registration time |

### Core changes

**`dataset-catalog.js`**
- `processCollection`: replaces `assetOptions` Map with an ordered `assetConfigList` array — so two entries with the same `id` but different `alias` values produce two distinct layers
- `extractMapLayers`: in filtered mode, iterates config entries (not STAC assets) to preserve order and support aliases; `default_filter` threaded through to `getMapLayerConfigs()`

**`map-manager.js`**
- `registerLayer`: destructures `defaultFilter`, calls `map.setFilter()` after `addLayer()`, stores initial filter in layer state

### Example update

PAD-US combined PMTiles split into two logical layers:
- `pad-us-4.1-combined/fee` — on by default, GAP color, filtered to `FeatClass=Fee AND GAP_Sts in ["1","2"]`
- `pad-us-4.1-combined/easement` — off by default, GAP color, filtered to `FeatClass=Easement`

🤖 Generated with [Claude Code](https://claude.com/claude-code)