### PR TITLE
fix: use match expression for GAP_Sts filter

### DIFF
--- a/example-ghpages/layers-input.json
+++ b/example-ghpages/layers-input.json
@@ -45,7 +45,7 @@
                         ],
                         "fill-opacity": 0.7
                     },
-                    "default_filter": ["in", "GAP_Sts", "1", "2"],
+                    "default_filter": ["match", ["get", "GAP_Sts"], ["1", "2"], true, false],
                     "tooltip_fields": ["Unit_Nm", "GAP_Sts", "Mang_Type"]
                 }
             ]

--- a/example-k8s/layers-input.json
+++ b/example-k8s/layers-input.json
@@ -27,7 +27,7 @@
                         ],
                         "fill-opacity": 0.7
                     },
-                    "default_filter": ["in", "GAP_Sts", "1", "2"],
+                    "default_filter": ["match", ["get", "GAP_Sts"], ["1", "2"], true, false],
                     "tooltip_fields": ["Unit_Nm", "GAP_Sts", "Mang_Type"]
                 }
             ]


### PR DESCRIPTION
## Summary

- The legacy `["in", "GAP_Sts", "1", "2"]` filter is silently ignored by newer MapLibre versions (swallowed by the try-catch added in #12)
- Replace with the unambiguous expression form: `["match", ["get", "GAP_Sts"], ["1", "2"], true, false]`
- This shows only GAP 1 & 2 (highest protection) on the Fee Lands layer by default

## Test plan

- [ ] Only dark and medium green areas (GAP 1 & 2) visible on Fee Lands layer
- [ ] Light blue (GAP 3) and grey (GAP 4) areas not shown by default

🤖 Generated with [Claude Code](https://claude.com/claude-code)