### PR TITLE
fix: replace legacy in filter syntax with match expressions throughout

### DIFF
--- a/app/map-tools.js
+++ b/app/map-tools.js
@@ -78,13 +78,15 @@ export function createMapTools(mapManager, catalog) {
 
 IMPORTANT: After filtering, check 'featuresInView' in the result. If 0, the filter may be wrong.
 
-Filter syntax:
-- Equality: ["==", "property", "value"]
-- Inequality: ["!=", "property", "value"]  
-- Comparison: [">", "property", 100]
-- In list: ["in", "property", "val1", "val2", "val3"]
-- AND: ["all", ["==", "p1", "v1"], [">", "p2", 100]]
-- OR: ["any", ["==", "p", "v1"], ["==", "p", "v2"]]
+Filter syntax (use MapLibre expressions — NOT legacy filter arrays):
+- Equality: ["==", ["get", "property"], "value"]
+- Inequality: ["!=", ["get", "property"], "value"]
+- Comparison: [">", ["get", "property"], 100]
+- In list: ["match", ["get", "property"], ["val1", "val2", "val3"], true, false]
+- AND: ["all", ["==", ["get", "p1"], "v1"], [">", ["get", "p2"], 100]]
+- OR: ["any", ["==", ["get", "p"], "v1"], ["==", ["get", "p"], "v2"]]
+
+IMPORTANT: Do NOT use the legacy ["in", "property", val1, val2] form — it is silently ignored in current MapLibre. Always use ["match", ["get", "property"], [...values], true, false] for list membership.
 
 Vector layers: ${vectorLayerIds().join(', ')}
 ${getPropertyDocs()}`,

--- a/example-ghpages/system-prompt.md
+++ b/example-ghpages/system-prompt.md
@@ -52,7 +52,7 @@ WITH county_carbon AS (
 SELECT * FROM county_carbon
 ```
 
-Then visualize: `show_layer("overturemaps/overturemaps-admins")` and `set_filter("overturemaps/overturemaps-admins", ["in", "NAMELSAD", "County1", "County2", …])`.
+Then visualize: `show_layer("overturemaps/overturemaps-admins")` and `set_filter("overturemaps/overturemaps-admins", ["match", ["get", "NAMELSAD"], ["County1", "County2"], true, false])`.
 
 ## Available datasets
 

--- a/example-k8s/system-prompt.md
+++ b/example-k8s/system-prompt.md
@@ -52,7 +52,7 @@ WITH county_carbon AS (
 SELECT * FROM county_carbon
 ```
 
-Then visualize: `show_layer("overturemaps/overturemaps-admins")` and `set_filter("overturemaps/overturemaps-admins", ["in", "NAMELSAD", "County1", "County2", …])`.
+Then visualize: `show_layer("overturemaps/overturemaps-admins")` and `set_filter("overturemaps/overturemaps-admins", ["match", ["get", "NAMELSAD"], ["County1", "County2"], true, false])`.
 
 ## Available datasets
 


### PR DESCRIPTION
## Summary

The legacy `["in", "property", val1, val2]` MapLibre filter form is silently ignored in current MapLibre versions. This was the root cause of the GAP status filter not working on the Fee Lands layer.

Three places were teaching the broken syntax:

- **`app/map-tools.js`** — the `set_filter` tool description shown to the LLM agent at runtime. Updated all filter examples to use expression form (`["get", "property"]`) and replaced the `in` example with `["match", ["get", "prop"], [...values], true, false]`. Added an explicit warning not to use the legacy form.
- **`example-k8s/system-prompt.md`** — example `set_filter` call after SQL query used `["in", ...]`
- **`example-ghpages/system-prompt.md`** — same fix

## Test plan

- [ ] Ask the agent to "filter fee lands to GAP 1 and 2" — it should use `match` not `in`
- [ ] Ask the agent to filter by a single value — it should use `["==", ["get", ...], value]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)