### PR TITLE
feat: authenticated MCP support, UI polish, SQL highlighting

### DIFF
--- a/app/agent.js
+++ b/app/agent.js
@@ -23,7 +23,7 @@ export class Agent {
         this.systemPrompt = '';
         this.messages = [];
         this.selectedModel = config.llm_model || config.llm_models?.[0]?.value || 'default';
-        this.maxToolCalls = 8;
+        this.maxToolCalls = 20;
 
         // Event callbacks (set by chat-ui.js)
         this.onThinkingStart = () => { };


### PR DESCRIPTION
## Summary

- Add optional authenticated MCP server support
- Deduplicate parallel MCP connect calls and reset reconnect counter
- Add vector layer outlines and tooltip value formatting
- Fix SQL query display: render with real newlines and syntax highlighting instead of escaped `\n` characters
- Increase max agent steps from 8 to 20

## Test plan

- [ ] Verify SQL queries in tool call blocks render with proper line breaks and hljs highlighting
- [ ] Confirm agent can run more than 8 tool steps without hitting the limit
- [ ] Test MCP auth token flow with an authenticated server

🤖 Generated with [Claude Code](https://claude.com/claude-code)