### PR TITLE
fix: recognize sql_query field and fold SQL in tool proposals

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/app/chat-ui.js
+++ b/app/chat-ui.js
@@ -286,11 +286,12 @@ export class ChatUI {
             let argDisplay = '';
             if (typeof args === 'object' && args !== null) {
                 // Extract SQL query field and display it highlighted with real newlines
-                const sqlText = args.query || args.sql || null;
+                const sqlText = args.sql_query || args.query || args.sql || null;
+                const sqlKey = args.sql_query !== undefined ? 'sql_query' : args.query !== undefined ? 'query' : 'sql';
                 if (sqlText) {
-                    argDisplay += `<pre><code class="language-sql">${this.escapeHtml(sqlText)}</code></pre>`;
+                    argDisplay += `<details class="sql-detail"><summary>SQL</summary><pre><code class="language-sql">${this.escapeHtml(sqlText)}</code></pre></details>`;
                     const otherArgs = Object.fromEntries(
-                        Object.entries(args).filter(([k]) => k !== 'query' && k !== 'sql')
+                        Object.entries(args).filter(([k]) => k !== sqlKey)
                     );
                     if (Object.keys(otherArgs).length > 0) {
                         argDisplay += `<pre><code>${this.escapeHtml(JSON.stringify(otherArgs, null, 2))}</code></pre>`;


### PR DESCRIPTION
## Summary
- The previous fix (a6ecfe6) checked `args.query || args.sql` but the tool's actual field name is `sql_query`, so it always fell through to raw `JSON.stringify()` — producing escaped `\n` characters and no syntax highlighting
- Wraps the SQL block in a collapsed `<details>` in tool proposal blocks, matching the existing pattern in tool results, so proposals stay compact until the user chooses to inspect the query

## Test plan
- [ ] Submit a query; tool proposal should show a collapsed "SQL" disclosure triangle
- [ ] Expand it — SQL should render with real newlines and syntax highlighting
- [ ] Approve/run — tool result SQL detail should also remain collapsed as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)