### PR TITLE
fix: correct TiTiler colormap endpoint URL

### DIFF
--- a/app/map-manager.js
+++ b/app/map-manager.js
@@ -444,7 +444,7 @@ export class MapManager {
     async _getColormapGradient(colormap) {
         if (this._colormapCache.has(colormap)) return this._colormapCache.get(colormap);
         try {
-            const resp = await fetch(`${this.titilerUrl}/colormap?colormap_name=${colormap}`);
+            const resp = await fetch(`${this.titilerUrl}/colorMaps/${colormap}`);
             if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
             const data = await resp.json();
             const stops = [0, 28, 57, 85, 113, 141, 170, 198, 226, 255].map(i => {


### PR DESCRIPTION
TiTiler's colormap API is `/colorMaps/{name}` not `/colormap?colormap_name={name}`. The wrong URL caused a 404, which triggered the grey fallback gradient in all raster legends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)