### PR TITLE
fix: preserve defaultFilter in layer state and expose reset_filter tool

### DIFF
--- a/app/dataset-catalog.js
+++ b/app/dataset-catalog.js
@@ -349,7 +349,11 @@ export class DatasetCatalog {
                 section += `\n**Map Layers (use with map tools):**\n`;
                 for (const ml of ds.mapLayers) {
                     const layerId = `${ds.id}/${ml.assetId}`;
-                    section += `- layer_id: \`${layerId}\` — ${ml.title} (${ml.layerType})\n`;
+                    let layerLine = `- layer_id: \`${layerId}\` — ${ml.title} (${ml.layerType})`;
+                    if (ml.defaultFilter) {
+                        layerLine += ` [default filter: ${JSON.stringify(ml.defaultFilter)}]`;
+                    }
+                    section += layerLine + '\n';
                 }
             }
 

--- a/app/map-manager.js
+++ b/app/map-manager.js
@@ -153,6 +153,7 @@ export class MapManager {
             sourceLayer: sourceLayer || null,
             visible: defaultVisible || false,
             filter: defaultFilter || null,
+            defaultFilter: defaultFilter || null,
             columns: columns || [],
             defaultPaint: { ...(paint || {}) },
             tooltipFields: tooltipFields || null,
@@ -255,10 +256,19 @@ export class MapManager {
     }
 
     /**
-     * Clear filter from a layer.
+     * Clear filter from a layer (show all features).
      */
     clearFilter(layerId) {
         return this.setFilter(layerId, null);
+    }
+
+    /**
+     * Reset filter to the layer's config default (or clear if no default).
+     */
+    resetFilter(layerId) {
+        const state = this.layers.get(layerId);
+        if (!state) return { success: false, error: `Unknown layer: ${layerId}` };
+        return this.setFilter(layerId, state.defaultFilter);
     }
 
     // ---- Styling ----
@@ -309,6 +319,8 @@ export class MapManager {
                 visible: state.visible,
                 hasFilter: state.filter !== null,
                 filterDescription: state.filter ? this.describeFilter(state.filter) : null,
+                hasDefaultFilter: state.defaultFilter !== null,
+                defaultFilterDescription: state.defaultFilter ? this.describeFilter(state.defaultFilter) : null,
             };
         }
         return { success: true, layers };

--- a/app/map-tools.js
+++ b/app/map-tools.js
@@ -106,7 +106,7 @@ ${getPropertyDocs()}`,
 
         {
             name: 'clear_filter',
-            description: `Remove all filters from a layer, showing all features. Use when the user asks to "clear filters", "reset", or "show all".\n\nVector layers: ${vectorLayerIds().join(', ')}`,
+            description: `Remove ALL filters from a layer, showing every feature regardless of properties. Use when the user wants to see everything (e.g. "show all GAP codes", "remove filter", "show everything").\n\nNote: some layers have a config default filter applied at startup. This tool removes that too. Use reset_filter instead if you want to restore the default.\n\nVector layers: ${vectorLayerIds().join(', ')}`,
             inputSchema: {
                 type: 'object',
                 properties: {
@@ -115,6 +115,19 @@ ${getPropertyDocs()}`,
                 required: ['layer_id']
             },
             execute: (args) => JSON.stringify(mapManager.clearFilter(args.layer_id)),
+        },
+
+        {
+            name: 'reset_filter',
+            description: `Reset a layer's filter to its config default (the filter it had when the app loaded). If the layer had no default filter, this clears all filters. Use when the user asks to "reset to default", "restore original view", or "go back to how it was".\n\nVector layers: ${vectorLayerIds().join(', ')}`,
+            inputSchema: {
+                type: 'object',
+                properties: {
+                    layer_id: { type: 'string', description: 'Layer ID to reset filter on' }
+                },
+                required: ['layer_id']
+            },
+            execute: (args) => JSON.stringify(mapManager.resetFilter(args.layer_id)),
         },
 
         {


### PR DESCRIPTION
## Summary

- **Root cause**: `defaultFilter` (from `layers-input.json` config) was applied at layer registration but then merged into `state.filter` with no separate copy preserved. After calling `clear_filter`, the default filter was gone with no way to restore it.
- **Agent info gap**: `generatePromptCatalog()` didn't mention `defaultFilter`, so the agent didn't know layers start pre-filtered. `get_map_state` also didn't distinguish config defaults from user-applied filters.

## Changes

- `map-manager.js`: Store `defaultFilter` as a separate field alongside `defaultPaint` in layer state; add `resetFilter()` method; expose `hasDefaultFilter` + `defaultFilterDescription` in `getMapState()`
- `map-tools.js`: Add `reset_filter` tool (analogous to `reset_style`); update `clear_filter` description to clarify it removes config defaults too
- `dataset-catalog.js`: Include `[default filter: ...]` annotation in `generatePromptCatalog()` map layer listings so agent knows upfront

## Test plan

- [ ] Layer with `default_filter` in config: agent can now `clear_filter` to show all features
- [ ] Agent can `reset_filter` to restore the original config default after clearing or applying a custom filter
- [ ] `get_map_state` output shows `hasDefaultFilter: true` and the filter description for layers with config defaults
- [ ] System prompt catalog text includes `[default filter: ...]` for relevant layers

🤖 Generated with [Claude Code](https://claude.com/claude-code)