### PR TITLE
fix: prompt model to include description before SQL tool calls

### DIFF
--- a/app/system-prompt.md
+++ b/app/system-prompt.md
@@ -54,6 +54,12 @@ SELECT * FROM county_carbon
 
 Then visualize: `show_layer("overturemaps/overturemaps-admins")` and `set_filter("overturemaps/overturemaps-admins", ["in", "NAMELSAD", "County1", "County2", …])`.
 
+## Before calling a remote tool
+
+Before calling the SQL `query` tool, always write a brief plain-english sentence (1–2 sentences) in your `content` describing what you are about to query and why. This text is shown to the user above the Run/Cancel approval prompt so they understand what will run before clicking.
+
+Example: *"I'll query the data to find the largest county in Wyoming by area."*
+
 ## Available datasets
 
 The section below is automatically injected at runtime with full dataset details including layer IDs, parquet paths, column schemas, and filterable properties. Use `list_datasets` or `get_dataset_details` tools for live info.


### PR DESCRIPTION
## Summary

The tool-reasoning feature (PR #28) renders `message.content` as a plain-english description above the Run/Cancel approval prompt. However, most models return `content: null` alongside `tool_calls` by default, so the description never appeared (as seen in testing).

Fix: add an explicit instruction in `system-prompt.md` telling the model to write a 1–2 sentence description in its response content before calling the SQL `query` tool.

## Test plan
- [ ] Ask a question that triggers a SQL query (e.g. "what is the largest county in Wyoming")
- [ ] Confirm a plain-english sentence appears above the collapsed Details block before Run/Cancel

🤖 Generated with [Claude Code](https://claude.com/claude-code)