### PR TITLE
docs: update README and AGENTS.md for current deployment state

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,14 +1,14 @@
 # Project Context & Instructions
 
 ## Overview
-Map-based application for exploring California's protected lands. Interactive MapLibre GL JS map with an LLM-powered chatbot for natural language data queries and map control.
+Core library for map-based applications with LLM-powered data analysis. Interactive MapLibre GL JS map with an agentic chatbot for natural language data queries and map control. Individual apps (different datasets, branding, deployments) import this library from the CDN and provide their own configuration.
 
 ## Key Technologies
 - **Frontend**: MapLibre GL JS, PMTiles (vectors), COG + TiTiler (rasters), ES modules
 - **Data**: STAC catalog → unified dataset records with visual + parquet assets
 - **Analytics**: SQL queries via MCP (Model Context Protocol) to DuckDB on H3-indexed parquet
 - **LLM**: OpenAI-compatible Chat Completions API (multiple models via proxy)
-- **Deployment**: App JS/CSS is loaded from jsDelivr CDN (`@main` or a pinned tag). Downstream apps only need a static HTML file — see `example-k8s/` and `example-ghpages/`.
+- **Deployment**: App JS/CSS is loaded from jsDelivr CDN (`@main` or a pinned tag). Downstream apps only need a static HTML file — see `example-k8s/` and `example-ghpages/`, or the [geo-agent-template](https://github.com/boettiger-lab/geo-agent-template) repo.
 
 ## Architecture (app/ modules)
 - `main.js` — Bootstrap: loads config, initializes catalog → map → tools → agent → UI
@@ -64,9 +64,12 @@ https://purge.jsdelivr.net/gh/boettiger-lab/geo-agent@main/app/chat-ui.js
 https://purge.jsdelivr.net/gh/boettiger-lab/geo-agent@main/app/chat.css
 ```
 
-**Kubernetes resources for specific deployments (e.g. padus):**
-- Manifests live in [boettiger-lab/geo-agent-template](https://github.com/boettiger-lab/geo-agent-template), not in this repo.
-- Those deployments serve a static HTML file that loads app code from jsDelivr, so a `kubectl rollout restart` is not required after merging here.
+**Live deployments and their source repos:**
+- `example-ghpages/` in this repo → [boettiger-lab.github.io/geo-agent](https://boettiger-lab.github.io/geo-agent/) (GitHub Pages, user-provided API key)
+- `example-k8s/` in this repo → [padus.nrp-nautilus.io](https://padus.nrp-nautilus.io) (Kubernetes, server-provided keys via ConfigMap + init container git clone)
+- [boettiger-lab/geo-agent-template](https://github.com/boettiger-lab/geo-agent-template) → separate repo users can fork/template; currently hosts a calenviroscreen deployment
+
+All downstream apps serve a static HTML file that loads app code from jsDelivr, so a `kubectl rollout restart` is not required after merging changes here.
 
 ## Development
 - Local: `cd app && python -m http.server 8000`

--- a/README.md
+++ b/README.md
@@ -8,14 +8,13 @@ A reusable JavaScript library for interactive map applications with LLM-powered 
 
 ## Quick start: create a new app
 
-1. Copy one of the example templates into a new repo
-2. Edit `layers-input.json` — choose your STAC collections, assets, and LLM config
-3. Edit `index.html` — set page title, pin CDN version
-4. Deploy (see options below)
+**The easiest way to start a new app is to use [boettiger-lab/geo-agent-template](https://github.com/boettiger-lab/geo-agent-template)** — click "Use this template" on GitHub. It gives you a ready-to-deploy repo with `index.html`, `layers-input.json`, `system-prompt.md`, and `k8s/` manifests pre-wired. Edit those four files for your dataset and you're done.
+
+Alternatively, you can copy one of the example templates in this repo manually:
 
 | Template | Deployment | API key handling | Live demo |
 |---|---|---|---|
-| [`example-k8s/`](example-k8s/) | Kubernetes / managed host | Injected server-side via `config.json` | not currently deployed |
+| [`example-k8s/`](example-k8s/) | Kubernetes / managed host | Injected server-side via `config.json` | [live (padus)](https://padus.nrp-nautilus.io) |
 | [`example-ghpages/`](example-ghpages/) | GitHub Pages / any static host | Entered by the user in-browser | [live](https://boettiger-lab.github.io/geo-agent/) |
 
 See the [example-k8s README](example-k8s/README.md) or [example-ghpages README](example-ghpages/README.md) for full details.
@@ -158,7 +157,7 @@ The `app/` directory includes its own `index.html`, `layers-input.json`, and `sy
 |---|---|---|---|
 | **GitHub Pages** (or any static host) | [`example-ghpages/`](example-ghpages/) | User enters their own API key in-browser | [live](https://boettiger-lab.github.io/geo-agent/) |
 | **Hugging Face Spaces** | Start from either example | Mount a `config.json` as a Space secret-file | — |
-| **Kubernetes** | [`example-k8s/`](example-k8s/) with [`k8s/`](example-k8s/k8s/) | Secrets injected into `config.json` via ConfigMap + init container | not currently deployed |
+| **Kubernetes** | [`example-k8s/`](example-k8s/) with [`k8s/`](example-k8s/k8s/) | Secrets injected into `config.json` via ConfigMap + init container | [live (padus)](https://padus.nrp-nautilus.io) |
 
 See [`example-k8s/k8s/`](example-k8s/k8s/) for the client app Kubernetes deployment template, and [`example-k8s/README.md`](example-k8s/README.md) for a full walkthrough of all three options.
 


### PR DESCRIPTION
## Summary
- README quick-start now leads with `geo-agent-template` as the recommended starting point
- Both example deployments marked as live (padus k8s, GitHub Pages)
- AGENTS.md overview updated to reflect core library role (not CA-specific app)
- AGENTS.md deployment section lists all three live deployments with source repos and URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)