### PR TITLE
feat: require plain-english explanation on all SQL tool calls, add agent-loop docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ Each client app is a tiny repo (~4–5 files) that provides:
 | `agent.js` | LLM orchestration loop — agentic while-loop with tool-use |
 | `chat-ui.js` | Chat UI with collapsible tool-call blocks |
 
+See [`docs/agent-loop.md`](docs/agent-loop.md) for a detailed walkthrough of the agentic loop, how pre-call explanations are generated, and options for extending the approval flow.
+
 ### Data flow
 
 1. **STAC catalog** is the single source of truth for dataset metadata

--- a/app/chat-ui.js
+++ b/app/chat-ui.js
@@ -435,21 +435,59 @@ export class ChatUI {
     /**
      * Generate a fallback plain-english description from tool call arguments
      * when the model does not provide reasoning text alongside tool calls.
+     * See docs/agent-loop.md for why this fallback exists and alternatives.
      */
     describeToolCalls(calls) {
         const parts = calls.map(tc => {
             let args;
             try { args = JSON.parse(tc.function.arguments); } catch { args = {}; }
             const sql = args.sql_query || args.query || args.sql;
-            if (sql) {
-                // Extract the first SELECT…FROM clause for a minimal summary
-                const m = sql.match(/SELECT\s+.+?\s+FROM\s+([\w./'"-]+)/is);
-                const table = m ? m[1].replace(/read_parquet\(['"]([^'"]+)['"]\)/i, '$1').split('/').filter(Boolean).slice(-2).join('/') : null;
-                return table ? `Will run a data query against \`${table}\`.` : 'Will run a data query.';
-            }
+            if (sql) return this.describeSql(sql);
             return `Will call \`${tc.function.name}\`.`;
         });
         return parts.join(' ');
+    }
+
+    /**
+     * Parse a SQL string and produce a concise plain-english summary.
+     * Detects tables, joins, aggregations, filtering, and grouping.
+     */
+    describeSql(sql) {
+        const s = sql.replace(/\s+/g, ' ');
+
+        // Extract all read_parquet paths → short two-segment names
+        const tableNames = [...s.matchAll(/read_parquet\s*\(\s*['"]([^'"]+)['"]\s*\)/gi)]
+            .map(m => m[1].split('/').filter(p => p && !p.includes('*')).slice(-2).join('/'));
+        const uniqueTables = [...new Set(tableNames)];
+
+        // Detect operation types
+        const hasAgg   = /\b(SUM|AVG|COUNT|MIN|MAX)\s*\(/i.test(s);
+        const hasJoin  = /\bJOIN\b/i.test(s);
+        const hasWhere = /\bWHERE\b/i.test(s);
+        const hasGroup = /\bGROUP\s+BY\b/i.test(s);
+        const hasOrder = /\bORDER\s+BY\b/i.test(s);
+        const hasLimit = /\bLIMIT\s+\d+/i.test(s);
+
+        // Build description
+        let action = hasAgg ? 'Computing aggregates' : 'Querying data';
+
+        let tableDesc = '';
+        if (uniqueTables.length === 1) {
+            tableDesc = ` from \`${uniqueTables[0]}\``;
+        } else if (uniqueTables.length === 2) {
+            tableDesc = ` joining \`${uniqueTables[0]}\` with \`${uniqueTables[1]}\``;
+        } else if (uniqueTables.length > 2) {
+            tableDesc = ` across ${uniqueTables.length} datasets`;
+        }
+
+        const qualifiers = [];
+        if (hasWhere) qualifiers.push('filtered by conditions');
+        if (hasGroup) qualifiers.push('grouped by category');
+        if (hasOrder && hasLimit) qualifiers.push('returning top results');
+
+        let desc = action + tableDesc;
+        if (qualifiers.length > 0) desc += ', ' + qualifiers.join(', ');
+        return desc + '.';
     }
 
     escapeHtml(str) {

--- a/app/system-prompt.md
+++ b/app/system-prompt.md
@@ -54,11 +54,21 @@ SELECT * FROM county_carbon
 
 Then visualize: `show_layer("overturemaps/overturemaps-admins")` and `set_filter("overturemaps/overturemaps-admins", ["in", "NAMELSAD", "County1", "County2", …])`.
 
-## Before calling a remote tool
+## Before every remote tool call — without exception
 
-Before calling the SQL `query` tool, always write a brief plain-english sentence (1–2 sentences) in your `content` describing what you are about to query and why. This text is shown to the user above the Run/Cancel approval prompt so they understand what will run before clicking.
+**Every time** you call the SQL `query` tool — including follow-up calls in a multi-step analysis — you **must** include a 1–2 sentence plain-English explanation in your message text before the tool call. This applies to the first call, the second, and every subsequent call in the same turn.
 
-Example: *"I'll query the data to find the largest county in Wyoming by area."*
+This text is shown to the user above the Run/Cancel approval prompt. Without it, the user sees only a bare "Details: query" block with no context about what will run.
+
+**Your explanation should say:**
+- What specific data you are querying (dataset or subject matter)
+- What question it will answer or what calculation it performs
+
+After receiving tool results, if you determine you need another query, explain it the same way before calling again — do not skip straight to the tool call.
+
+Examples:
+- *"I'll query the mule deer crucial range dataset to get the total area covered."*
+- *"Now I'll query the pronghorn range and join it with the mule deer result to compute the overlap fraction."*
 
 ## Available datasets
 

--- a/docs/agent-loop.md
+++ b/docs/agent-loop.md
@@ -1,0 +1,164 @@
+# Agent Loop: How the Chat Agent Works
+
+This document describes the agentic tool-use loop in detail, with a focus on how tool proposals are shown to users, how pre-call explanations are generated, and how to extend or modify this behavior.
+
+## Overview
+
+The agent runs in `app/agent.js`. When the user sends a message, `processMessage()` enters a `while` loop that:
+
+1. Calls the LLM with the full conversation history + tool schemas
+2. Inspects the response:
+   - If `tool_calls` are present → propose them to the user → (await approval if non-local) → execute → append results → **loop**
+   - If no tool calls → emit the final text response → **done**
+
+```
+user message
+    │
+    ▼
+┌─────────────────────────────────────────┐
+│ callLLM() → message                     │
+│                                         │
+│  message.content  (text, may be null)   │
+│  message.tool_calls  (may be empty)     │
+└───────────────┬─────────────────────────┘
+                │
+        tool_calls present?
+               / \
+             yes   no
+              │     └──► emit final response → done
+              ▼
+    allLocal? (map tools only)
+        / \
+      yes   no
+       │     └──► onToolProposal() → await user approval
+       │                   │
+       │          approved? no → cancelled
+       │                   │ yes
+       └──────────────────►▼
+                    execute tools
+                    append results to turnMessages
+                    loop back to callLLM()
+```
+
+## Key files
+
+| File | Role |
+|---|---|
+| `app/agent.js` | The agentic loop, LLM calls, tool dispatch |
+| `app/chat-ui.js` | All DOM rendering — proposal blocks, results, approval buttons |
+| `app/tool-registry.js` | Unified registry: local tools vs. remote (MCP) tools |
+| `app/system-prompt.md` | LLM instructions, including the pre-call explanation rule |
+
+## Local vs. remote tools
+
+Tools registered via `toolRegistry.registerLocal()` (the 9 map tools) are **auto-approved** — they run silently with a collapsed "Running: …" block. No user interaction needed.
+
+Tools registered via `toolRegistry.registerRemote()` (the MCP `query` tool) require **explicit user approval** — a "Details: query" block appears with Approve / Cancel buttons.
+
+This distinction is checked with `toolRegistry.isLocal(name)` in `agent.js:109`.
+
+## Pre-call explanation: how it works
+
+When the LLM returns a response with tool calls, it often (but not always) includes a `message.content` alongside the `tool_calls`. This text is the model's reasoning — its natural-language explanation of what it's about to do.
+
+In `agent.js`, this content is extracted and stripped of any embedded `<tool_call>` XML tags:
+
+```js
+const displayContent = message.content
+    ? message.content.replace(/<tool_call>[\s\S]*?<\/tool_call>/gi, '').trim()
+    : null;
+```
+
+`displayContent` is then passed to `onToolProposal()` → `chat-ui.js:showToolProposal()`, which renders it as a `<div class="tool-reasoning">` above the approval buttons.
+
+```
+┌──────────────────────────────────────────────┐
+│ tool-reasoning div (plain-english text)      │  ← displayContent
+│ ► Details: query                             │  ← collapsible <details>
+│   [Approve]  [Cancel]                        │
+└──────────────────────────────────────────────┘
+```
+
+## The fallback: `describeToolCalls()`
+
+When `displayContent` is null or empty (the model returned tool calls with no accompanying text), `chat-ui.js` falls back to `describeToolCalls()`. This function parses the SQL to produce a synthetic description:
+
+- Extracts `read_parquet(...)` paths → short two-segment table names
+- Detects JOINs, aggregate functions (SUM/AVG/COUNT/MIN/MAX), WHERE, GROUP BY, ORDER BY + LIMIT
+- Builds a sentence like: *"Computing aggregates joining `mule-deer/h3` with `pronghorn/h3`, filtered by conditions."*
+
+This is deterministic and always produces something meaningful, but it reads less naturally than model-generated text.
+
+## The recurring problem: silent follow-up calls
+
+The system prompt instructs the LLM to explain before every `query` call (see `app/system-prompt.md` → "Before every remote tool call"). The LLM tends to follow this for the **first** call in a turn, because it's in a "responding to the user" frame of mind. For **subsequent iterations** — after receiving tool results and deciding it needs another query — it's in a "making progress on a task" frame of mind and often emits `message.content = null` alongside the tool call.
+
+The result: the second (and later) approval prompts show only `describeToolCalls()` output, not a fluent model-written explanation.
+
+### Current approach (Plan A)
+
+The system prompt has been made more emphatic — using "**Every time**", "**without exception**", and explicit examples for follow-up calls. Combined with the improved `describeToolCalls()` fallback, this handles most cases adequately.
+
+### Alternative: per-iteration reminder injection (Plan B)
+
+A more reliable approach is to inject a brief ephemeral reminder into `turnMessages` after each tool result batch, just before the next `callLLM()`:
+
+```js
+// In agent.js, inside the while loop, after appending tool results:
+if (!allLocal) {
+    turnMessages.push({
+        role: 'user',
+        content: 'If you need another query, first explain in one sentence what it will determine, then call the tool.'
+    });
+}
+```
+
+Because `turnMessages` is a local array scoped to the current turn (not persisted in `this.messages`), this doesn't pollute the conversation history. It directly re-activates the instruction at the moment the model decides whether to make another call.
+
+**Trade-off:** Adds a synthetic user message visible to the model at each step. In practice this is very effective. We haven't done this yet because the strengthened system prompt is simpler and sufficient for well-behaved models.
+
+### Alternative: lightweight "explain" LLM call
+
+Before presenting a proposal that has no `displayContent`, make a second lightweight LLM call with a minimal prompt:
+
+```js
+// Pseudo-code
+if (!displayContent && !allLocal) {
+    displayContent = await this.getExplanation(calls, turnMessages);
+}
+```
+
+Where `getExplanation` sends just the SQL + a one-line instruction ("Summarize this query in one sentence") to the LLM with `max_tokens: 80`.
+
+**Trade-off:** Always produces fluent model-written text, but adds latency and API cost on every subsequent SQL call. Best suited if model compliance with Plan A/B is poor.
+
+### Alternative: structured `explanation` field in tool schema
+
+Add a required `explanation` parameter to the `query` tool's JSON schema:
+
+```json
+{
+    "name": "query",
+    "inputSchema": {
+        "properties": {
+            "explanation": {
+                "type": "string",
+                "description": "One sentence plain-English description of what this query will determine."
+            },
+            "sql_query": { "type": "string" }
+        },
+        "required": ["explanation", "sql_query"]
+    }
+}
+```
+
+The model is then forced to supply an explanation as a structured argument, which `showToolProposal()` can extract and display. This is the most robust approach for structured-output-capable models, but requires changes to the MCP server schema and the rendering logic.
+
+## Conversation history vs. turn messages
+
+There are two separate message arrays:
+
+- `this.messages` (persisted across turns) — stored in `Agent`, grows with each user/assistant exchange, trimmed to last 12 for context
+- `turnMessages` (ephemeral per turn) — built fresh each turn from `[system] + this.messages.slice(-12)`, extended with tool call/result pairs during the loop
+
+Only the final assistant text response is pushed into `this.messages`. Tool call/result pairs live only in `turnMessages` and are not re-used in future turns (the LLM sees a summary of previous turns via the assistant message, not raw tool results).


### PR DESCRIPTION
## Summary
- Strengthens system-prompt instruction so the LLM must explain before **every** `query` call, not just the first one in a turn
- Improves `describeToolCalls()` fallback to parse SQL structure (tables, joins, aggregates, WHERE, GROUP BY) for a more informative description when the LLM doesn't comply
- Adds `docs/agent-loop.md` documenting the agentic loop architecture, the explanation mechanism, and alternative approaches (Plan B reminder injection, lightweight explain call, structured schema field)

## Test plan
- [ ] Ask a multi-step question (e.g. "what fraction of mule deer range overlaps pronghorn range?") and verify each SQL approval prompt shows a meaningful plain-English description, not just "Details: query"
- [ ] Verify the fallback description is informative when the model provides no `message.content` alongside a tool call

🤖 Generated with [Claude Code](https://claude.com/claude-code)