### PR TITLE
feat: native basemap toggle (NatGeo / Satellite / Plain) with terrain

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -49,6 +49,14 @@
 
     <!-- Layer controls -->
     <div id="menu">
+        <div class="menu-section">
+            <label class="section-title">Basemap</label>
+            <div class="basemap-toggle-group">
+                <button class="basemap-btn active" data-basemap="natgeo"    onclick="window._setBasemap('natgeo')">NatGeo</button>
+                <button class="basemap-btn"         data-basemap="satellite" onclick="window._setBasemap('satellite')">Satellite</button>
+                <button class="basemap-btn"         data-basemap="plain"     onclick="window._setBasemap('plain')">Plain</button>
+            </div>
+        </div>
         <div class="menu-header">
             <label class="section-title">Overlays</label>
             <button id="menu-toggle" title="Toggle overlays">−</button>

--- a/app/main.js
+++ b/app/main.js
@@ -54,10 +54,14 @@ async function main() {
         center: appConfig.view?.center || [-119.4, 36.8],
         zoom: appConfig.view?.zoom || 6,
         titilerUrl: appConfig.titiler_url || 'https://titiler.nrp-nautilus.io',
+        maptilerKey: runtimeConfig?.maptiler_key || '',
     });
     await mapManager.ready;                        // wait for style to load
     mapManager.addLayersFromCatalog(catalog.getMapLayerConfigs());
     mapManager.generateControls('layer-controls-container');
+
+    // Expose basemap switcher for HTML button onclick handlers
+    window._setBasemap = name => mapManager.setBasemap(name);
 
     // Wire overlays panel toggle
     const menuToggle = document.getElementById('menu-toggle');

--- a/app/map-manager.js
+++ b/app/map-manager.js
@@ -1,6 +1,6 @@
 /**
  * MapManager - Map initialization and layer control API
- * 
+ *
  * Owns the MapLibre map instance and provides a clean API for:
  * - Initializing layers from DatasetCatalog configs
  * - Show/hide layers
@@ -8,14 +8,47 @@
  * - Apply paint/style properties
  * - Query visible features
  * - Generate layer control UI
- * 
+ *
  * No knowledge of LLMs, tools, or chat — pure map operations.
  */
+
+const BASEMAPS = {
+    natgeo: {
+        source: {
+            type: 'raster',
+            tiles: ['https://services.arcgisonline.com/ArcGIS/rest/services/NatGeo_World_Map/MapServer/tile/{z}/{y}/{x}'],
+            tileSize: 256,
+            maxzoom: 16,
+            attribution: 'Tiles &copy; Esri &mdash; National Geographic, Esri, DeLorme, NAVTEQ, UNEP-WCMC, USGS, NASA, ESA, METI, NRCAN, GEBCO, NOAA'
+        },
+        terrain: true
+    },
+    satellite: {
+        source: {
+            type: 'raster',
+            tiles: ['https://services.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}'],
+            tileSize: 256,
+            maxzoom: 19,
+            attribution: 'Tiles &copy; Esri &mdash; Source: Esri, i-cubed, USDA, USGS, AEX, GeoEye, Getmapping, Aerogrid, IGN, IGP, UPR-EGP, and the GIS User Community'
+        },
+        terrain: true
+    },
+    plain: {
+        source: {
+            type: 'raster',
+            tiles: ['https://a.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png'],
+            tileSize: 256,
+            maxzoom: 19,
+            attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/">CARTO</a>'
+        },
+        terrain: false
+    }
+};
 
 export class MapManager {
     /**
      * @param {string} containerId - DOM element ID for the map
-     * @param {Object} options - { center, zoom }
+     * @param {Object} options - { center, zoom, maptilerKey, pitch, maxPitch }
      */
     constructor(containerId, options = {}) {
         /** @type {Map<string, LayerState>} */
@@ -27,41 +60,56 @@ export class MapManager {
         this._legendItems = new Map();   // layerId → DOM element
         this._colormapCache = new Map(); // colormap name → CSS gradient string
         this.titilerUrl = options.titilerUrl || 'https://titiler.nrp-nautilus.io';
+        this._maptilerKey = options.maptilerKey || '';
+        this._currentBasemap = 'natgeo';
 
         // Register PMTiles protocol
         const protocol = new pmtiles.Protocol();
         maplibregl.addProtocol('pmtiles', protocol.tile);
 
-        // Create map
+        // Create map with all three basemap sources; natgeo visible by default
         this.map = new maplibregl.Map({
             container: containerId,
             style: {
                 version: 8,
                 glyphs: 'https://demotiles.maplibre.org/font/{fontstack}/{range}.pbf',
                 sources: {
-                    'carto-light': {
-                        type: 'raster',
-                        tiles: [
-                            'https://a.basemaps.cartocdn.com/light_all/{z}/{x}/{y}@2x.png',
-                            'https://b.basemaps.cartocdn.com/light_all/{z}/{x}/{y}@2x.png',
-                            'https://c.basemaps.cartocdn.com/light_all/{z}/{x}/{y}@2x.png',
-                        ],
-                        tileSize: 256,
-                        attribution: '© <a href="https://carto.com/">CARTO</a> © <a href="https://www.openstreetmap.org/copyright">OSM</a>',
-                    }
+                    natgeo:    BASEMAPS.natgeo.source,
+                    satellite: BASEMAPS.satellite.source,
+                    plain:     BASEMAPS.plain.source,
                 },
-                layers: [{ id: 'carto-light', type: 'raster', source: 'carto-light' }],
+                layers: [
+                    { id: 'natgeo-base',    type: 'raster', source: 'natgeo',    layout: { visibility: 'visible' } },
+                    { id: 'satellite-base', type: 'raster', source: 'satellite', layout: { visibility: 'none' } },
+                    { id: 'plain-base',     type: 'raster', source: 'plain',     layout: { visibility: 'none' } },
+                ],
             },
             center: options.center || [-119.4, 36.8],
             zoom: options.zoom || 6,
+            pitch: options.pitch ?? 20,
+            maxPitch: options.maxPitch ?? 75,
             renderWorldCopies: false,
         });
 
         this.map.addControl(new maplibregl.NavigationControl(), 'top-left');
 
-        // Promise that resolves when the map style is loaded
+        // Promise that resolves when the map style is loaded (and terrain is set up)
         this.ready = new Promise(resolve => {
-            this.map.on('load', resolve);
+            this.map.on('load', async () => {
+                if (this._maptilerKey) {
+                    try {
+                        this.map.addSource('terrain-dem', {
+                            type: 'raster-dem',
+                            url: `https://api.maptiler.com/tiles/terrain-rgb-v2/tiles.json?key=${this._maptilerKey}`,
+                            tileSize: 256
+                        });
+                        this.map.setTerrain({ source: 'terrain-dem', exaggeration: 1.5 });
+                    } catch (e) {
+                        console.warn('[MapManager] terrain setup failed:', e);
+                    }
+                }
+                resolve();
+            });
         });
 
         // Shared hover tooltip element
@@ -352,6 +400,32 @@ export class MapManager {
     }
 
     // ---- UI Generation ----
+
+    /**
+     * Switch the active basemap by name ('natgeo' | 'satellite' | 'plain').
+     * Also toggles 3D terrain on/off based on the basemap's terrain flag.
+     * @param {string} name
+     */
+    setBasemap(name) {
+        if (!BASEMAPS[name]) return;
+        this._currentBasemap = name;
+        Object.keys(BASEMAPS).forEach(key => {
+            const vis = key === name ? 'visible' : 'none';
+            if (this.map.getLayer(key + '-base')) {
+                this.map.setLayoutProperty(key + '-base', 'visibility', vis);
+            }
+        });
+        if (this._maptilerKey && this.map.getSource('terrain-dem')) {
+            if (BASEMAPS[name].terrain) {
+                this.map.setTerrain({ source: 'terrain-dem', exaggeration: 1.5 });
+            } else {
+                this.map.setTerrain(null);
+            }
+        }
+        document.querySelectorAll('.basemap-btn').forEach(btn => {
+            btn.classList.toggle('active', btn.dataset.basemap === name);
+        });
+    }
 
     /**
      * Generate checkbox controls in a container element.

--- a/app/style.css
+++ b/app/style.css
@@ -34,6 +34,38 @@ body {
     margin-bottom: 0;
 }
 
+.basemap-toggle-group {
+    display: flex;
+    gap: 4px;
+    padding: 4px 0;
+}
+
+.basemap-btn {
+    flex: 1;
+    padding: 5px 6px;
+    font-size: 11px;
+    font-weight: 500;
+    border: 1px solid rgba(255,255,255,0.2);
+    border-radius: 4px;
+    background: rgba(255,255,255,0.06);
+    color: rgba(0,0,0,0.75);
+    cursor: pointer;
+    transition: background 0.15s, color 0.15s, border-color 0.15s;
+    white-space: nowrap;
+}
+
+.basemap-btn:hover {
+    background: rgba(255,255,255,0.14);
+    color: #000;
+}
+
+.basemap-btn.active {
+    background: rgba(134,194,116,0.35);
+    border-color: #86C274;
+    color: #000;
+    font-weight: 600;
+}
+
 .menu-header {
     display: flex;
     justify-content: space-between;


### PR DESCRIPTION
## Summary

- `MapManager` now initializes with NatGeo, Satellite, and Plain basemap sources baked into the style; NatGeo is visible by default
- Accepts `maptilerKey` option and sets up MapTiler terrain-RGB on load when a key is provided
- New `setBasemap(name)` method on `MapManager` switches layer visibility and toggles 3D terrain
- `main.js` passes `maptiler_key` from runtime config and exposes `window._setBasemap` for HTML button onclick handlers
- `index.html` adds a Basemap section with NatGeo / Satellite / Plain toggle buttons above the Overlays section
- `style.css` adds `.basemap-toggle-group` / `.basemap-btn` / `.basemap-btn.active` styles

This replaces the monkey-patch approach used in downstream apps (e.g. wyoming, wyoming-public-demo) with proper first-class support in geo-agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)