### PR TITLE
fix: hide Layers title when menu is expanded

### DIFF
--- a/app/style.css
+++ b/app/style.css
@@ -100,6 +100,16 @@ body {
     display: none;
 }
 
+/* Hide the "Layers" title when expanded — only show it in the collapsed state */
+#menu:not(.collapsed) .menu-header .section-title {
+    display: none;
+}
+
+#menu:not(.collapsed) .menu-header {
+    justify-content: flex-end;
+    margin-bottom: 4px;
+}
+
 .radio-group label,
 .checkbox-group label {
     display: flex;


### PR DESCRIPTION
## Summary
- When expanded, the `.menu-header` now only shows the `−` toggle button (right-aligned); the "Layers" label is hidden
- When collapsed, "LAYERS +" remains as the compact indicator
- Pure CSS change, no HTML updates needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)