### PR TITLE
feat: support categorical legend for discrete raster layers

### DIFF
--- a/app/dataset-catalog.js
+++ b/app/dataset-catalog.js
@@ -193,6 +193,7 @@ export class DatasetCatalog {
                         defaultFilter: config.default_filter || null,
                     });
                 } else if (type.includes('geotiff') || type.includes('tiff')) {
+                    const band0 = asset['raster:bands']?.[0];
                     layers.push({
                         assetId: key,
                         layerType: 'raster',
@@ -203,6 +204,8 @@ export class DatasetCatalog {
                         rescale: config.rescale || options.rescale || null,
                         paint: config.paint || null,
                         legendLabel: config.legend_label || null,
+                        legendType: config.legend_type || null,
+                        legendClasses: band0?.['classification:classes'] || null,
                         description: asset.description || '',
                         defaultVisible: config.visible === true,
                         defaultFilter: config.default_filter || null,
@@ -464,6 +467,8 @@ export class DatasetCatalog {
                         colormap: ml.colormap,
                         rescale: ml.rescale,
                         legendLabel: ml.legendLabel,
+                        legendType: ml.legendType,
+                        legendClasses: ml.legendClasses,
                         source: {
                             type: 'raster',
                             tiles: [tilesUrl],

--- a/app/map-manager.js
+++ b/app/map-manager.js
@@ -133,7 +133,7 @@ export class MapManager {
      * Register a single layer on the map.
      */
     registerLayer(config) {
-        const { layerId, datasetId, group, displayName, type, source, sourceLayer, paint, columns, tooltipFields, defaultVisible, defaultFilter, colormap, rescale, legendLabel } = config;
+        const { layerId, datasetId, group, displayName, type, source, sourceLayer, paint, columns, tooltipFields, defaultVisible, defaultFilter, colormap, rescale, legendLabel, legendType, legendClasses } = config;
         // Use pre-computed sourceId (shared between alias layers) or derive from layerId
         const sourceId = config.sourceId || `src-${layerId.replace(/\//g, '-')}`;
         const mapLayerId = `layer-${layerId.replace(/\//g, '-')}`;
@@ -208,6 +208,8 @@ export class MapManager {
             colormap: colormap || null,
             rescale: rescale || null,
             legendLabel: legendLabel || null,
+            legendType: legendType || null,
+            legendClasses: legendClasses || null,
         });
 
         // Wire hover tooltip if fields are declared
@@ -557,20 +559,30 @@ export class MapManager {
             return;
         }
 
-        const gradient = await this._getColormapGradient(state.colormap || 'reds');
-        const [minVal, maxVal] = (state.rescale || '0,1').split(',');
-        const unit = state.legendLabel ? ` ${state.legendLabel}` : '';
-
         const item = document.createElement('div');
         item.className = 'legend-section';
-        item.innerHTML = `
-            <h4>${state.displayName}</h4>
-            <div class="legend-colorbar" style="background: ${gradient};"></div>
-            <div class="legend-labels">
-                <span>${minVal}${unit}</span>
-                <span>${maxVal}${unit}</span>
-            </div>
-        `;
+
+        if (state.legendType === 'categorical' && state.legendClasses?.length) {
+            const rows = state.legendClasses.map(cls => {
+                const color = cls.color_hint ? `#${cls.color_hint}` : '#888888';
+                const label = cls.name || `Class ${cls.value}`;
+                return `<div class="legend-item"><span style="background:${color};"></span>${label}</div>`;
+            }).join('');
+            item.innerHTML = `<h4>${state.displayName}</h4>${rows}`;
+        } else {
+            const gradient = await this._getColormapGradient(state.colormap || 'reds');
+            const [minVal, maxVal] = (state.rescale || '0,1').split(',');
+            const unit = state.legendLabel ? ` ${state.legendLabel}` : '';
+            item.innerHTML = `
+                <h4>${state.displayName}</h4>
+                <div class="legend-colorbar" style="background: ${gradient};"></div>
+                <div class="legend-labels">
+                    <span>${minVal}${unit}</span>
+                    <span>${maxVal}${unit}</span>
+                </div>
+            `;
+        }
+
         this._legendContent.appendChild(item);
         this._legendItems.set(layerId, item);
     }


### PR DESCRIPTION
## Summary

- Add `legend_type: "categorical"` support for raster layers with discrete class values
- `dataset-catalog.js`: extract `classification:classes` from STAC `raster:bands` metadata and pass `legendType` + `legendClasses` through the layer config pipeline
- `map-manager.js`: branch in `_showRasterLegend` — when `legendType === "categorical"`, render a list of color swatches (from `color_hint` in the STAC classification extension) with class names instead of a continuous gradient bar

## Motivation

NLCD land cover (and similar classified rasters) are discrete — a continuous gradient legend is meaningless. This change enables any layer to opt into a proper categorical swatch legend by setting `legend_type: "categorical"` in `layers-input.json` and storing `classification:classes` with `color_hint` values in the STAC collection.

Continuous-gradient layers (RAP cover, sagebrush, etc.) are unaffected.

## Test plan
- [ ] NLCD layer renders correct MRLC colors on map (`colormap_name=nlcd`)
- [ ] Legend shows 20 colored swatches with class names, scrollable
- [ ] Continuous layers (RAP, sagebrush) show gradient legend as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)