### PR TITLE
Fix LLM timeout: move session ID from header to body user field

### DIFF
--- a/app/agent.js
+++ b/app/agent.js
@@ -209,6 +209,7 @@ export class Agent {
             messages,
             tools: tools.length > 0 ? tools : undefined,
             tool_choice: tools.length > 0 ? 'auto' : undefined,
+            user: this.sessionId,
         };
 
         const controller = new AbortController();
@@ -220,7 +221,6 @@ export class Agent {
                 headers: {
                     'Content-Type': 'application/json',
                     'Authorization': `Bearer ${modelConfig.api_key}`,
-                    'X-Session-Id': this.sessionId,
                 },
                 body: JSON.stringify(payload),
                 signal: controller.signal,


### PR DESCRIPTION
## Summary
- Custom `X-Session-Id` header triggered CORS preflight; proxy allowlist didn't include it, causing immediate request failure
- Moves session ID to the standard OpenAI `user` body field — no CORS impact, proxy passes it through for log grouping

## Test plan
- [ ] Send a message in the app and confirm the LLM responds normally
- [ ] Verify session ID still appears in proxy logs under the `user` field