### PR TITLE
feat: globe icon button inline with BASEMAP label

### DIFF
--- a/app/map-manager.js
+++ b/app/map-manager.js
@@ -566,8 +566,8 @@ export class MapManager {
     setProjection(type) {
         this._globeEnabled = type === 'globe';
         this.map.setProjection({ type });
-        const cb = document.getElementById('globe-checkbox');
-        if (cb) cb.checked = this._globeEnabled;
+        const btn = document.getElementById('globe-btn');
+        if (btn) btn.classList.toggle('active', this._globeEnabled);
     }
 
     /**
@@ -604,10 +604,22 @@ export class MapManager {
         // Basemap section
         const basemapSection = document.createElement('div');
         basemapSection.className = 'menu-section';
+
+        // Basemap header: "BASEMAP" label + globe icon button inline
+        const basemapHeader = document.createElement('div');
+        basemapHeader.className = 'basemap-section-header';
         const basemapTitle = document.createElement('label');
         basemapTitle.className = 'section-title';
         basemapTitle.textContent = 'Basemap';
-        basemapSection.appendChild(basemapTitle);
+        const globeBtn = document.createElement('button');
+        globeBtn.id = 'globe-btn';
+        globeBtn.className = 'globe-btn' + (this._globeEnabled ? ' active' : '');
+        globeBtn.title = 'Toggle globe view';
+        globeBtn.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.25" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="2" y1="12" x2="22" y2="12"/><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/></svg>`;
+        globeBtn.addEventListener('click', () => this.setProjection(this._globeEnabled ? 'mercator' : 'globe'));
+        basemapHeader.appendChild(basemapTitle);
+        basemapHeader.appendChild(globeBtn);
+        basemapSection.appendChild(basemapHeader);
 
         const btnGroup = document.createElement('div');
         btnGroup.className = 'basemap-toggle-group';
@@ -625,22 +637,6 @@ export class MapManager {
             btnGroup.appendChild(btn);
         }
         basemapSection.appendChild(btnGroup);
-
-        // Globe toggle
-        const globeRow = document.createElement('div');
-        globeRow.className = 'globe-toggle-row';
-        const globeLabel = document.createElement('label');
-        const globeCb = document.createElement('input');
-        globeCb.type = 'checkbox';
-        globeCb.id = 'globe-checkbox';
-        globeCb.checked = this._globeEnabled;
-        globeCb.addEventListener('change', e => this.setProjection(e.target.checked ? 'globe' : 'mercator'));
-        const globeSpan = document.createElement('span');
-        globeSpan.textContent = 'Globe view';
-        globeLabel.appendChild(globeCb);
-        globeLabel.appendChild(globeSpan);
-        globeRow.appendChild(globeLabel);
-        basemapSection.appendChild(globeRow);
         menuBody.appendChild(basemapSection);
 
         // Overlays section

--- a/app/style.css
+++ b/app/style.css
@@ -66,22 +66,32 @@ body {
     font-weight: 600;
 }
 
-.globe-toggle-row {
-    padding: 4px 0 0;
+.basemap-section-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
 }
 
-.globe-toggle-row label {
+.globe-btn {
+    background: none;
+    border: none;
+    padding: 2px 3px;
+    cursor: pointer;
+    color: rgba(0,0,0,0.2);
+    border-radius: 3px;
+    line-height: 1;
+    transition: color 0.15s, background 0.15s;
     display: flex;
     align-items: center;
-    font-size: 11px;
-    color: rgba(0,0,0,0.65);
-    cursor: pointer;
-    gap: 6px;
 }
 
-.globe-toggle-row input[type="checkbox"] {
-    cursor: pointer;
-    margin: 0;
+.globe-btn:hover {
+    color: rgba(0,0,0,0.55);
+}
+
+.globe-btn.active {
+    color: #000;
+    background: rgba(134,194,116,0.35);
 }
 
 .menu-header {


### PR DESCRIPTION
Replaces the 'Globe view' checkbox with a compact SVG globe-meridians icon button sitting to the right of the 'BASEMAP' section title.

- Faded (opacity 0.2) when off, bold + green highlight when active — consistent with basemap button active state
- Removes `.globe-toggle-row`; adds `.basemap-section-header` flex row + `.globe-btn`
- `setProjection()` toggles `.active` class on `#globe-btn`

Also requires MapLibre GL JS v5.22.0 in downstream app `index.html` (separate per-app PRs merged simultaneously).