### PR TITLE
feat: support GeoJSON source type for small vector layers

### DIFF
--- a/app/dataset-catalog.js
+++ b/app/dataset-catalog.js
@@ -5,7 +5,7 @@
  * builds a unified record containing:
  *   - Metadata (title, description, provider, license)
  *   - Parquet/H3 assets (for SQL queries via MCP)
- *   - Visual assets (PMTiles for vector, COG for raster — for map display)
+ *   - Visual assets (PMTiles/GeoJSON for vector, COG for raster — for map display)
  *   - Schema (table:columns — for filter/style guidance)
  * 
  * The catalog is the single source of truth for "what data exists"
@@ -202,7 +202,7 @@ export class DatasetCatalog {
     }
 
     /**
-     * Extract map-displayable assets (PMTiles and COGs).
+     * Extract map-displayable assets (PMTiles, GeoJSON, and COGs).
      * Each becomes a potential map layer.
      *
      * When assetConfigList is provided (filtered mode), iterates the config entries
@@ -252,6 +252,15 @@ export class DatasetCatalog {
                                 layerType: 'raster',
                                 cogUrl: vAsset.href,
                                 legendClasses: band0?.['classification:classes'] || null,
+                                description: vAsset.description || '',
+                            });
+                        } else if (vType.includes('geo+json') || vAsset.href?.endsWith('.geojson')) {
+                            versions.push({
+                                label: v.label,
+                                assetId: v.asset_id,
+                                layerType: 'vector',
+                                sourceType: 'geojson',
+                                url: vAsset.href,
                                 description: vAsset.description || '',
                             });
                         }
@@ -333,6 +342,23 @@ export class DatasetCatalog {
                         defaultVisible: config.visible === true,
                         defaultFilter: config.default_filter || null,
                     });
+                } else if (type.includes('geo+json') || asset.href?.endsWith('.geojson')) {
+                    layers.push({
+                        assetId: key,
+                        sourceAssetId: assetId,
+                        layerType: 'vector',
+                        sourceType: 'geojson',
+                        group: assetGroup,
+                        title: config.display_name || asset.title || assetId,
+                        url: asset.href,
+                        description: asset.description || '',
+                        defaultStyle: config.default_style || null,
+                        outlineStyle: config.outline_style || null,
+                        renderType: config.layer_type || null,
+                        tooltipFields: config.tooltip_fields || null,
+                        defaultVisible: config.visible === true,
+                        defaultFilter: config.default_filter || null,
+                    });
                 }
             }
         } else {
@@ -362,6 +388,19 @@ export class DatasetCatalog {
                         colormap: options.colormap || 'reds',
                         rescale: options.rescale || null,
                         description: asset.description || '',
+                        defaultVisible: false,
+                        defaultFilter: null,
+                    });
+                } else if (type.includes('geo+json') || asset.href?.endsWith('.geojson')) {
+                    layers.push({
+                        assetId,
+                        layerType: 'vector',
+                        sourceType: 'geojson',
+                        title: asset.title || assetId,
+                        url: asset.href,
+                        description: asset.description || '',
+                        defaultStyle: null,
+                        tooltipFields: null,
                         defaultVisible: false,
                         defaultFilter: null,
                     });
@@ -579,7 +618,15 @@ export class DatasetCatalog {
                 // ── Versioned layer: build per-version configs for MapManager ──
                 if (ml.versions && ml.versions.length > 0) {
                     const versionConfigs = ml.versions.map(v => {
-                        if (v.layerType === 'vector') {
+                        if (v.layerType === 'vector' && v.sourceType === 'geojson') {
+                            const srcKey = v.assetId.replace(/[^a-zA-Z0-9]/g, '-');
+                            return {
+                                label: v.label,
+                                type: 'vector',
+                                sourceId: `src-${ds.id.replace(/[^a-zA-Z0-9]/g, '-')}-${srcKey}`,
+                                source: { type: 'geojson', data: v.url },
+                            };
+                        } else if (v.layerType === 'vector') {
                             const srcKey = v.assetId.replace(/[^a-zA-Z0-9]/g, '-');
                             return {
                                 label: v.label,
@@ -643,7 +690,8 @@ export class DatasetCatalog {
                     const sourceAssetKey = (ml.sourceAssetId || ml.assetId).replace(/[^a-zA-Z0-9]/g, '-');
                     const sharedSourceId = `src-${ds.id.replace(/[^a-zA-Z0-9]/g, '-')}-${sourceAssetKey}`;
 
-                    configs.push({
+                    const isGeoJson = ml.sourceType === 'geojson';
+                    const layerConfig = {
                         layerId,
                         datasetId: ds.id,
                         group: ml.group || ds.group,
@@ -651,11 +699,9 @@ export class DatasetCatalog {
                         displayName: ml.title,
                         type: 'vector',
                         sourceId: sharedSourceId,
-                        source: {
-                            type: 'vector',
-                            url: `pmtiles://${ml.url}`,
-                        },
-                        sourceLayer: ml.sourceLayer,
+                        source: isGeoJson
+                            ? { type: 'geojson', data: ml.url }
+                            : { type: 'vector', url: `pmtiles://${ml.url}` },
                         paint: ml.defaultStyle || { 'fill-color': '#2E7D32', 'fill-opacity': 0.5 },
                         outlinePaint: ml.outlineStyle || null,
                         renderType: ml.renderType || null,
@@ -663,7 +709,10 @@ export class DatasetCatalog {
                         tooltipFields: ml.tooltipFields || null,
                         defaultVisible: ml.defaultVisible || false,
                         defaultFilter: ml.defaultFilter || null,
-                    });
+                    };
+                    if (!isGeoJson) layerConfig.sourceLayer = ml.sourceLayer;
+
+                    configs.push(layerConfig);
                 } else if (ml.layerType === 'raster') {
                     let tilesUrl = `${this.titilerUrl}/cog/tiles/WebMercatorQuad/{z}/{x}/{y}.png?url=${encodeURIComponent(ml.cogUrl)}`;
                     if (ml.legendType === 'categorical' && ml.legendClasses?.length) {

--- a/app/map-manager.js
+++ b/app/map-manager.js
@@ -181,15 +181,15 @@ export class MapManager {
                 let vOutlineLayerId = null;
                 if (v.type === 'vector' && renderType === 'line') {
                     layerDef.type = 'line';
-                    layerDef['source-layer'] = v.sourceLayer;
+                    if (v.sourceLayer) layerDef['source-layer'] = v.sourceLayer;
                     layerDef.paint = paint || { 'line-color': '#2E7D32', 'line-width': 1.5 };
                 } else if (v.type === 'vector' && renderType === 'circle') {
                     layerDef.type = 'circle';
-                    layerDef['source-layer'] = v.sourceLayer;
+                    if (v.sourceLayer) layerDef['source-layer'] = v.sourceLayer;
                     layerDef.paint = paint || { 'circle-color': '#2E7D32', 'circle-radius': 6, 'circle-opacity': 0.8 };
                 } else if (v.type === 'vector') {
                     layerDef.type = 'fill';
-                    layerDef['source-layer'] = v.sourceLayer;
+                    if (v.sourceLayer) layerDef['source-layer'] = v.sourceLayer;
                     layerDef.paint = paint || { 'fill-color': '#2E7D32', 'fill-opacity': 0.5 };
                 } else if (v.type === 'raster') {
                     layerDef.type = 'raster';
@@ -201,14 +201,15 @@ export class MapManager {
                 // Outline for vector fills
                 if (v.type === 'vector' && renderType !== 'line' && renderType !== 'circle') {
                     vOutlineLayerId = `${vMapLayerId}-outline`;
-                    this.map.addLayer({
+                    const outlineDef = {
                         id: vOutlineLayerId,
                         type: 'line',
                         source: v.sourceId,
-                        'source-layer': v.sourceLayer,
                         layout: { visibility: vis },
                         paint: outlinePaint || { 'line-color': 'rgba(0,0,0,0.4)', 'line-width': 0.5 },
-                    });
+                    };
+                    if (v.sourceLayer) outlineDef['source-layer'] = v.sourceLayer;
+                    this.map.addLayer(outlineDef);
                 }
 
                 // Default filter
@@ -285,15 +286,15 @@ export class MapManager {
         let outlineLayerId = null;
         if (type === 'vector' && renderType === 'line') {
             layerDef.type = 'line';
-            layerDef['source-layer'] = sourceLayer;
+            if (sourceLayer) layerDef['source-layer'] = sourceLayer;
             layerDef.paint = paint || { 'line-color': '#2E7D32', 'line-width': 1.5 };
         } else if (type === 'vector' && renderType === 'circle') {
             layerDef.type = 'circle';
-            layerDef['source-layer'] = sourceLayer;
+            if (sourceLayer) layerDef['source-layer'] = sourceLayer;
             layerDef.paint = paint || { 'circle-color': '#2E7D32', 'circle-radius': 6, 'circle-opacity': 0.8 };
         } else if (type === 'vector') {
             layerDef.type = 'fill';
-            layerDef['source-layer'] = sourceLayer;
+            if (sourceLayer) layerDef['source-layer'] = sourceLayer;
             layerDef.paint = paint || { 'fill-color': '#2E7D32', 'fill-opacity': 0.5 };
         } else if (type === 'raster') {
             layerDef.type = 'raster';
@@ -305,17 +306,18 @@ export class MapManager {
         // Add outline layer for vector fills (not for line or circle layers)
         if (type === 'vector' && renderType !== 'line' && renderType !== 'circle') {
             outlineLayerId = `${mapLayerId}-outline`;
-            this.map.addLayer({
+            const outlineDef = {
                 id: outlineLayerId,
                 type: 'line',
                 source: sourceId,
-                'source-layer': sourceLayer,
                 layout: { visibility: defaultVisible ? 'visible' : 'none' },
                 paint: outlinePaint || {
                     'line-color': 'rgba(0,0,0,0.4)',
                     'line-width': 0.5,
                 },
-            });
+            };
+            if (sourceLayer) outlineDef['source-layer'] = sourceLayer;
+            this.map.addLayer(outlineDef);
         }
 
         // Apply default filter if declared


### PR DESCRIPTION
## Summary
- Adds GeoJSON asset detection (`application/geo+json` MIME type or `.geojson` href) in `dataset-catalog.js` alongside existing PMTiles and COG handling
- Builds MapLibre `type: 'geojson'` sources with `data: url` instead of `type: 'vector'` with `pmtiles://` protocol — no `source-layer` property
- Makes `source-layer` conditional in `map-manager.js` (8 sites) so GeoJSON layers don't trigger MapLibre errors
- Works across all three extraction paths (versioned, standard filtered, unfiltered) and both config builders (versioned + standard)

Closes #139

## Test plan
- [x] Add a STAC collection with a `application/geo+json` asset and verify it appears as a map layer
- [x] Confirm show/hide, filter, and style tools work on the GeoJSON layer
- [x] Confirm existing PMTiles and COG layers are unaffected (no regressions)
- [x] Test versioned layer with a GeoJSON version entry