### PR TITLE
feat: animated trajectory layers (#144)

### DIFF
--- a/app/animation-manager.js
+++ b/app/animation-manager.js
@@ -1,0 +1,397 @@
+/**
+ * animation-manager.js — Temporal animation layers
+ *
+ * TrajectoryAnimation: animates points along timestamped LineString
+ * trajectories. Each input feature is a LineString with a parallel array
+ * of ISO timestamps (one per coordinate). The animation loops the
+ * combined time range, interpolating each entity's position linearly
+ * between waypoints.
+ *
+ * Owns three MapLibre sublayers (track-lines, dots, labels) and a small
+ * playback-controls panel. Lifecycle methods (setVisible / setFilter /
+ * destroy) let MapManager treat it like any other layer.
+ */
+
+const DEFAULTS = {
+    loop: true,
+    duration_seconds: 30,
+    dot_radius: 7,
+    show_track_line: true,
+    track_line_opacity: 0.35,
+    show_labels: true,
+    timestamp_field: 'timestamps',
+    id_field: 'id',
+};
+
+export class TrajectoryAnimation {
+    /**
+     * @param {maplibregl.Map} map
+     * @param {Object} opts
+     * @param {string}  opts.layerId       — logical layer id from catalog
+     * @param {string}  opts.displayName   — label for the controls panel
+     * @param {string}  opts.tracksUrl     — URL of trajectory GeoJSON (LineStrings)
+     * @param {string} [opts.staticUrl]    — URL of static-positions GeoJSON
+     * @param {Object}  opts.config        — `animation` block from layers-input.json
+     * @param {Object} [opts.paint]        — `default_style` from asset config
+     */
+    constructor(map, opts) {
+        this.map = map;
+        this.layerId = opts.layerId;
+        this.displayName = opts.displayName || opts.layerId;
+        this.config = { ...DEFAULTS, ...opts.config };
+        this.paint = opts.paint || {};
+
+        const safe = this.layerId.replace(/[^a-zA-Z0-9]/g, '-');
+        this.sourceIds = {
+            lines: `src-${safe}-anim-lines`,
+            dots:  `src-${safe}-anim-dots`,
+            labels: `src-${safe}-anim-labels`,
+        };
+        this.layerIds = {
+            lines: `layer-${safe}-anim-lines`,
+            dots:  `layer-${safe}-anim-dots`,
+            labels: `layer-${safe}-anim-labels`,
+        };
+
+        this.tracksByEntity = new Map();   // id → { coords, times }
+        this.staticPositions = new Map();  // id → [lon, lat]
+        this.allEntities = [];
+        this.globalStart = Infinity;
+        this.globalEnd = -Infinity;
+
+        this.playing = true;
+        this.visible = true;
+        this.speed = 1;
+        this.animTime = 0;
+        this.lastFrame = null;
+        this.rafId = null;
+        this.filterExpr = null;
+        this.allowedIds = null;   // null = all allowed
+        this.destroyed = false;
+
+        this._panel = null;
+        this._ready = this._init(opts.tracksUrl, opts.staticUrl);
+    }
+
+    get ready() { return this._ready; }
+
+    async _init(tracksUrl, staticUrl) {
+        const fetches = [fetch(tracksUrl).then(r => r.json())];
+        if (staticUrl) fetches.push(fetch(staticUrl).then(r => r.json()));
+        const [tracksData, staticData] = await Promise.all(fetches);
+
+        this._parseTracks(tracksData);
+        if (staticData) this._parseStatic(staticData);
+
+        this.allEntities = [
+            ...new Set([...this.tracksByEntity.keys(), ...this.staticPositions.keys()]),
+        ];
+
+        if (this.globalStart === Infinity) {
+            // No trajectories — fall back to static dots at their latest position
+            this.globalStart = 0;
+            this.globalEnd = 1;
+        }
+        this.animTime = this.globalStart;
+
+        this._addLayers(tracksData);
+        this._buildControls();
+        this._tick = this._tick.bind(this);
+        this.rafId = requestAnimationFrame(this._tick);
+    }
+
+    _parseTracks(geojson) {
+        const { id_field, timestamp_field } = this.config;
+        for (const feat of geojson.features || []) {
+            if (!feat.geometry || feat.geometry.type !== 'LineString') continue;
+            const id = feat.properties?.[id_field];
+            const rawTimes = feat.properties?.[timestamp_field];
+            if (id == null || !Array.isArray(rawTimes)) continue;
+            const coords = feat.geometry.coordinates;
+            const times = rawTimes.map(t => new Date(t).getTime());
+            if (coords.length !== times.length || coords.length < 2) continue;
+            this.tracksByEntity.set(id, { coords, times });
+            this.globalStart = Math.min(this.globalStart, times[0]);
+            this.globalEnd   = Math.max(this.globalEnd, times[times.length - 1]);
+        }
+    }
+
+    _parseStatic(geojson) {
+        const { id_field } = this.config;
+        for (const feat of geojson.features || []) {
+            const id = feat.properties?.[id_field];
+            if (id == null) continue;
+            const centroid = this._featureCentroid(feat);
+            if (centroid) this.staticPositions.set(id, centroid);
+        }
+    }
+
+    _featureCentroid(feat) {
+        const g = feat.geometry;
+        if (!g) return null;
+        if (g.type === 'Point') return g.coordinates;
+        if (g.type === 'Polygon') return _ringCentroid(g.coordinates[0]);
+        if (g.type === 'MultiPolygon') return _ringCentroid(g.coordinates[0][0]);
+        return null;
+    }
+
+    _addLayers(tracksData) {
+        const map = this.map;
+        const { dot_radius, show_track_line, track_line_opacity, show_labels, id_field } = this.config;
+        const lineColor = this.paint['line-color'] || '#1976d2';
+        const circleColor = this.paint['circle-color'] || '#1976d2';
+        const circleStroke = this.paint['circle-stroke-color'] || '#ffffff';
+        const lineWidth = this.paint['line-width'] ?? 2;
+
+        if (show_track_line) {
+            map.addSource(this.sourceIds.lines, { type: 'geojson', data: tracksData });
+            map.addLayer({
+                id: this.layerIds.lines,
+                source: this.sourceIds.lines,
+                type: 'line',
+                paint: {
+                    'line-color': lineColor,
+                    'line-width': lineWidth,
+                    'line-opacity': track_line_opacity,
+                },
+            });
+        }
+
+        const emptyFC = { type: 'FeatureCollection', features: [] };
+
+        map.addSource(this.sourceIds.dots, { type: 'geojson', data: emptyFC });
+        map.addLayer({
+            id: this.layerIds.dots,
+            source: this.sourceIds.dots,
+            type: 'circle',
+            paint: {
+                'circle-radius': dot_radius,
+                'circle-color': circleColor,
+                'circle-stroke-width': 2,
+                'circle-stroke-color': circleStroke,
+            },
+        });
+
+        if (show_labels) {
+            map.addSource(this.sourceIds.labels, { type: 'geojson', data: emptyFC });
+            map.addLayer({
+                id: this.layerIds.labels,
+                source: this.sourceIds.labels,
+                type: 'symbol',
+                layout: {
+                    'text-field': ['get', id_field],
+                    'text-size': 11,
+                    'text-offset': [0, 1.4],
+                    'text-anchor': 'top',
+                    'text-allow-overlap': false,
+                },
+                paint: {
+                    'text-color': '#222',
+                    'text-halo-color': '#ffffff',
+                    'text-halo-width': 1,
+                },
+            });
+        }
+    }
+
+    _buildControls() {
+        const panel = document.createElement('div');
+        panel.className = 'anim-controls';
+        panel.dataset.layerId = this.layerId;
+        panel.innerHTML = `
+            <span class="anim-label" title="${this.displayName}">${this.displayName}</span>
+            <button class="anim-play" title="Play / Pause">❚❚</button>
+            <span class="anim-time"></span>
+            <select class="anim-speed" title="Speed">
+                <option value="1">1×</option>
+                <option value="2">2×</option>
+                <option value="4">4×</option>
+            </select>
+        `;
+        // Stack multiple panels vertically
+        const existing = document.querySelectorAll('.anim-controls').length;
+        panel.style.bottom = (12 + existing * 44) + 'px';
+        document.body.appendChild(panel);
+
+        this._panel = panel;
+        this._playBtn = panel.querySelector('.anim-play');
+        this._timeEl = panel.querySelector('.anim-time');
+        this._speedEl = panel.querySelector('.anim-speed');
+
+        this._playBtn.addEventListener('click', () => {
+            this.playing = !this.playing;
+            this._playBtn.textContent = this.playing ? '❚❚' : '▶';
+            if (this.playing) this.lastFrame = null;
+        });
+        this._speedEl.addEventListener('change', () => {
+            this.speed = Number(this._speedEl.value) || 1;
+        });
+    }
+
+    _tick(now) {
+        if (this.destroyed) return;
+        if (this.visible && this.playing && this.lastFrame !== null) {
+            const delta = now - this.lastFrame;
+            const durationMs = this.config.duration_seconds * 1000;
+            const timeRange = Math.max(1, this.globalEnd - this.globalStart);
+            this.animTime += (delta / durationMs) * timeRange * this.speed;
+            if (this.animTime > this.globalEnd) {
+                this.animTime = this.config.loop ? this.globalStart : this.globalEnd;
+                if (!this.config.loop) this.playing = false;
+            }
+        }
+        this.lastFrame = now;
+
+        if (this.visible) this._renderFrame();
+        this.rafId = requestAnimationFrame(this._tick);
+    }
+
+    _renderFrame() {
+        const fc = this._buildFrame(this.animTime);
+        const dotsSrc = this.map.getSource(this.sourceIds.dots);
+        if (dotsSrc) dotsSrc.setData(fc);
+        if (this.config.show_labels) {
+            const labelsSrc = this.map.getSource(this.sourceIds.labels);
+            if (labelsSrc) labelsSrc.setData(fc);
+        }
+        if (this._timeEl) this._timeEl.textContent = this._formatTime(this.animTime);
+    }
+
+    _buildFrame(time) {
+        const { id_field } = this.config;
+        const features = [];
+        for (const id of this.allEntities) {
+            if (this.allowedIds && !this.allowedIds.has(id)) continue;
+            let pos;
+            const track = this.tracksByEntity.get(id);
+            if (track) {
+                pos = interpolate(track, time);
+            } else {
+                pos = this.staticPositions.get(id);
+            }
+            if (!pos) continue;
+            features.push({
+                type: 'Feature',
+                geometry: { type: 'Point', coordinates: pos },
+                properties: { [id_field]: id },
+            });
+        }
+        return { type: 'FeatureCollection', features };
+    }
+
+    _formatTime(epochMs) {
+        if (!isFinite(epochMs) || this.globalEnd === 1) return '';
+        const d = new Date(epochMs);
+        return d.toLocaleString(undefined, {
+            month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit',
+        });
+    }
+
+    // ---- Lifecycle ----
+
+    setVisible(visible) {
+        this.visible = visible;
+        const vis = visible ? 'visible' : 'none';
+        for (const id of Object.values(this.layerIds)) {
+            if (this.map.getLayer(id)) this.map.setLayoutProperty(id, 'visibility', vis);
+        }
+        if (this._panel) this._panel.style.display = visible ? '' : 'none';
+        if (visible) this.lastFrame = null;
+    }
+
+    /**
+     * Apply a filter expression to the animated layers. The track-lines
+     * sublayer gets the filter directly (MapLibre handles it). For
+     * setData-driven dots/labels we derive the set of entity IDs that
+     * pass the filter by querying the tracks source with MapLibre's own
+     * expression evaluator — no JS re-implementation of filter semantics.
+     */
+    setFilter(expr) {
+        this.filterExpr = expr;
+        if (this.map.getLayer(this.layerIds.lines)) {
+            this.map.setFilter(this.layerIds.lines, expr);
+        }
+        if (!expr) {
+            this.allowedIds = null;
+            return;
+        }
+        this.allowedIds = new Set();
+        const { id_field } = this.config;
+        if (!this.map.getSource(this.sourceIds.lines)) {
+            // No track-lines source (show_track_line: false) — best-effort:
+            // if the filter is a simple equality/in against id_field, honour it.
+            this._fallbackFilterIds(expr);
+            return;
+        }
+        const matched = this.map.querySourceFeatures(this.sourceIds.lines, { filter: expr });
+        for (const f of matched) {
+            const id = f.properties?.[id_field];
+            if (id != null) this.allowedIds.add(id);
+        }
+    }
+
+    _fallbackFilterIds(expr) {
+        // Handles ["==", ["get", field], val], legacy ["==", field, val],
+        // and ["match", ["get", field], [vals], true, false] — the forms the
+        // agent's set_filter tool actually emits. Unknown shapes → permissive.
+        const { id_field } = this.config;
+        const getField = (e) => Array.isArray(e) && e[0] === 'get' ? e[1] : e;
+        if (!Array.isArray(expr)) { this.allowedIds = null; return; }
+        const [op, a, ...rest] = expr;
+        if ((op === '==' || op === '!=') && getField(a) === id_field) {
+            for (const id of this.allEntities) {
+                const hit = op === '==' ? id == rest[0] : id != rest[0];
+                if (hit) this.allowedIds.add(id);
+            }
+            return;
+        }
+        if (op === 'match' && getField(a) === id_field && Array.isArray(rest[0])) {
+            const values = new Set(rest[0]);
+            for (const id of this.allEntities) {
+                if (values.has(id)) this.allowedIds.add(id);
+            }
+            return;
+        }
+        this.allowedIds = null;
+    }
+
+    destroy() {
+        this.destroyed = true;
+        if (this.rafId) cancelAnimationFrame(this.rafId);
+        for (const id of Object.values(this.layerIds)) {
+            if (this.map.getLayer(id)) this.map.removeLayer(id);
+        }
+        for (const id of Object.values(this.sourceIds)) {
+            if (this.map.getSource(id)) this.map.removeSource(id);
+        }
+        if (this._panel) this._panel.remove();
+    }
+}
+
+// ---- helpers ----
+
+function _ringCentroid(ring) {
+    const n = ring.length - 1;   // skip closing vertex
+    let lon = 0, lat = 0;
+    for (let i = 0; i < n; i++) { lon += ring[i][0]; lat += ring[i][1]; }
+    return [lon / n, lat / n];
+}
+
+function lerp(a, b, t) {
+    return [a[0] + t * (b[0] - a[0]), a[1] + t * (b[1] - a[1])];
+}
+
+function interpolate(track, time) {
+    const { coords, times } = track;
+    if (time <= times[0]) return coords[0];
+    if (time >= times[times.length - 1]) return coords[coords.length - 1];
+    // Binary search would be faster for very long tracks; linear is fine here.
+    for (let i = 0; i < times.length - 1; i++) {
+        if (time >= times[i] && time < times[i + 1]) {
+            const frac = (time - times[i]) / (times[i + 1] - times[i]);
+            return lerp(coords[i], coords[i + 1], frac);
+        }
+    }
+    return coords[coords.length - 1];
+}
+

--- a/app/dataset-catalog.js
+++ b/app/dataset-catalog.js
@@ -343,6 +343,17 @@ export class DatasetCatalog {
                         defaultFilter: config.default_filter || null,
                     });
                 } else if (type.includes('geo+json') || asset.href?.endsWith('.geojson')) {
+                    // Resolve static_positions_asset reference (another STAC asset
+                    // in this same collection) to a URL, so MapManager doesn't
+                    // need to know about STAC.
+                    let animation = null;
+                    if (config.animation && typeof config.animation === 'object') {
+                        animation = { ...config.animation };
+                        const staticKey = config.animation.static_positions_asset;
+                        if (staticKey && stacAssets[staticKey]?.href) {
+                            animation.static_positions_url = stacAssets[staticKey].href;
+                        }
+                    }
                     layers.push({
                         assetId: key,
                         sourceAssetId: assetId,
@@ -358,6 +369,7 @@ export class DatasetCatalog {
                         tooltipFields: config.tooltip_fields || null,
                         defaultVisible: config.visible === true,
                         defaultFilter: config.default_filter || null,
+                        animation,
                     });
                 }
             }
@@ -709,6 +721,8 @@ export class DatasetCatalog {
                         tooltipFields: ml.tooltipFields || null,
                         defaultVisible: ml.defaultVisible || false,
                         defaultFilter: ml.defaultFilter || null,
+                        animation: ml.animation || null,
+                        tracksUrl: isGeoJson ? ml.url : null,
                     };
                     if (!isGeoJson) layerConfig.sourceLayer = ml.sourceLayer;
 

--- a/app/map-manager.js
+++ b/app/map-manager.js
@@ -159,6 +159,12 @@ export class MapManager {
     registerLayer(config) {
         const { layerId, datasetId, group, groupCollapsed, displayName, type, paint, outlinePaint, renderType, columns, tooltipFields, defaultVisible, defaultFilter, colormap, rescale, legendLabel, legendType, legendClasses } = config;
 
+        // ── Animated layer: delegate to TrajectoryAnimation ──
+        if (config.animation && config.animation.type === 'trajectory') {
+            this._registerTrajectoryLayer(config);
+            return;
+        }
+
         // ── Versioned layer: register N underlying MapLibre layers, one logical entry ──
         if (config.versions && config.versions.length > 0) {
             const versionStates = config.versions.map((v, i) => {
@@ -361,6 +367,58 @@ export class MapManager {
         }
     }
 
+    /**
+     * Register an animated trajectory layer. Creates a TrajectoryAnimation
+     * instance that owns its own sources, layers, and RAF loop; stores a
+     * layer-state record so it shows up in the layer panel and works with
+     * showLayer / hideLayer / setFilter.
+     */
+    async _registerTrajectoryLayer(config) {
+        const { layerId, datasetId, group, groupCollapsed, displayName, animation, defaultVisible, defaultFilter, tracksUrl, paint } = config;
+
+        // Store the state synchronously so generateControls can find it even
+        // while the module + GeoJSON are still loading.
+        const state = {
+            layerId,
+            mapLayerId: null,
+            outlineLayerId: null,
+            sourceId: null,
+            datasetId,
+            group: group || null,
+            groupCollapsed: groupCollapsed || false,
+            displayName,
+            type: 'animation',
+            sourceLayer: null,
+            visible: defaultVisible || false,
+            filter: defaultFilter || null,
+            defaultFilter: defaultFilter || null,
+            columns: [],
+            defaultPaint: { ...(paint || {}) },
+            tooltipFields: null,
+            animation: null,   // filled in below
+        };
+        this.layers.set(layerId, state);
+
+        try {
+            const { TrajectoryAnimation } = await import('./animation-manager.js');
+            const anim = new TrajectoryAnimation(this.map, {
+                layerId,
+                displayName,
+                tracksUrl,
+                staticUrl: animation.static_positions_url || null,
+                config: animation,
+                paint,
+            });
+            await anim.ready;
+            state.animation = anim;
+            // Apply deferred visibility/filter requested before init finished
+            anim.setVisible(state.visible);
+            if (state.filter) anim.setFilter(state.filter);
+        } catch (err) {
+            console.error(`[Map] Failed to init trajectory animation for ${layerId}:`, err);
+        }
+    }
+
     // ---- Layer Visibility ----
 
     /**
@@ -372,9 +430,13 @@ export class MapManager {
         const state = this.layers.get(layerId);
         if (!state) return { success: false, error: `Unknown layer: ${layerId}. Available: ${this.getLayerIds().join(', ')}` };
 
+        state.visible = true;
+        if (state.type === 'animation') {
+            if (state.animation) state.animation.setVisible(true);
+            return { success: true, layer: layerId, displayName: state.displayName, visible: true };
+        }
         this.map.setLayoutProperty(state.mapLayerId, 'visibility', 'visible');
         if (state.outlineLayerId) this.map.setLayoutProperty(state.outlineLayerId, 'visibility', 'visible');
-        state.visible = true;
         if (state.type === 'raster') this._showRasterLegend(layerId);
         return { success: true, layer: layerId, displayName: state.displayName, visible: true };
     }
@@ -388,9 +450,13 @@ export class MapManager {
         const state = this.layers.get(layerId);
         if (!state) return { success: false, error: `Unknown layer: ${layerId}. Available: ${this.getLayerIds().join(', ')}` };
 
+        state.visible = false;
+        if (state.type === 'animation') {
+            if (state.animation) state.animation.setVisible(false);
+            return { success: true, layer: layerId, displayName: state.displayName, visible: false };
+        }
         this.map.setLayoutProperty(state.mapLayerId, 'visibility', 'none');
         if (state.outlineLayerId) this.map.setLayoutProperty(state.outlineLayerId, 'visibility', 'none');
-        state.visible = false;
         if (state.type === 'raster') this._hideRasterLegend(layerId);
         return { success: true, layer: layerId, displayName: state.displayName, visible: false };
     }
@@ -406,6 +472,17 @@ export class MapManager {
     setFilter(layerId, filter) {
         const state = this.layers.get(layerId);
         if (!state) return { success: false, error: `Unknown layer: ${layerId}` };
+        if (state.type === 'animation') {
+            state.filter = filter;
+            if (state.animation) state.animation.setFilter(filter);
+            return {
+                success: true,
+                layer: layerId,
+                displayName: state.displayName,
+                filter,
+                filterDescription: filter ? this.describeFilter(filter) : 'No filter (showing all)',
+            };
+        }
         if (state.type !== 'vector') return { success: false, error: `Layer '${layerId}' is raster — filtering only works on vector layers` };
 
         this.map.setFilter(state.mapLayerId, filter);

--- a/app/style.css
+++ b/app/style.css
@@ -516,3 +516,60 @@ details.layer-group:not([open]) .layer-group-title::before {
     color: #3b82f6;
     background: rgba(59, 130, 246, 0.1);
 }
+
+/* Animated trajectory layer controls */
+.anim-controls {
+    position: absolute;
+    left: 12px;
+    z-index: 2;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 10px;
+    background: rgba(255, 255, 255, 0.92);
+    backdrop-filter: blur(6px);
+    -webkit-backdrop-filter: blur(6px);
+    border: 1px solid rgba(0, 0, 0, 0.15);
+    border-radius: 6px;
+    font-family: 'Open Sans', sans-serif;
+    font-size: 12px;
+    color: #222;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.15);
+}
+
+.anim-controls .anim-label {
+    font-weight: 600;
+    max-width: 160px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.anim-controls .anim-play {
+    border: 1px solid rgba(0, 0, 0, 0.2);
+    background: #fff;
+    border-radius: 4px;
+    width: 26px;
+    height: 26px;
+    cursor: pointer;
+    font-size: 11px;
+    line-height: 1;
+}
+
+.anim-controls .anim-play:hover {
+    background: #f5f5f5;
+}
+
+.anim-controls .anim-time {
+    font-variant-numeric: tabular-nums;
+    min-width: 120px;
+    color: #555;
+}
+
+.anim-controls .anim-speed {
+    border: 1px solid rgba(0, 0, 0, 0.2);
+    border-radius: 4px;
+    padding: 2px 4px;
+    background: #fff;
+    font-size: 12px;
+}

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -87,6 +87,52 @@ Each entry in `assets` may be a **bare string** (the STAC asset key, loaded with
 | `legend_label` | string | Label shown next to the color legend. |
 | `legend_type` | string | `"categorical"` to use STAC `classification:classes` color codes for a discrete legend. |
 
+## Animated trajectory layers
+
+For GeoJSON assets containing `LineString` features with a parallel timestamp array, set `animation` on the asset config to turn it into an animated point-along-line layer. The framework adds a play/pause controller, renders a faint static track line, and emits colored dots that interpolate linearly between waypoints. The layer appears in the layer menu like any other layer; the LLM agent's `show_layer` / `hide_layer` / `set_filter` tools work on it directly.
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `type` | string | — | **Required.** Currently only `"trajectory"` is supported. |
+| `timestamp_field` | string | `"timestamps"` | Feature property holding an array of ISO timestamps — one per coordinate in the LineString. |
+| `id_field` | string | `"id"` | Feature property used to group features (one animated dot per unique value). Also used by `set_filter`. |
+| `loop` | boolean | `true` | Restart at `globalStart` when reaching `globalEnd`. |
+| `duration_seconds` | number | `30` | Real-time seconds for one pass through the time range. |
+| `dot_radius` | number | `7` | Animated dot radius (px). |
+| `show_track_line` | boolean | `true` | Draw a faint static line of the full trajectory underneath. |
+| `track_line_opacity` | number | `0.35` | Opacity of the static track line. |
+| `show_labels` | boolean | `true` | Render each dot's `id_field` value as a text label. |
+| `static_positions_asset` | string | — | STAC asset key (in the same collection) for a GeoJSON of static positions. Entities present only in this dataset render as non-moving dots. |
+
+`default_style` on the asset supplies paint overrides — `line-color` and `circle-color` are the common cases, and MapLibre `match` expressions against `id_field` let you color-code per entity.
+
+```json
+{
+  "collection_id": "ca-wolves",
+  "group": { "name": "Wolf Activity" },
+  "assets": [
+    {
+      "id": "tracks",
+      "display_name": "Wolf Movement",
+      "visible": true,
+      "animation": {
+        "type": "trajectory",
+        "timestamp_field": "timestamps",
+        "id_field": "pack",
+        "duration_seconds": 30,
+        "static_positions_asset": "bins-latest"
+      },
+      "default_style": {
+        "line-color":   ["match", ["get", "pack"], "Whaleback 1", "#E65100", "Harvey 1", "#1565C0", "#888"],
+        "circle-color": ["match", ["get", "pack"], "Whaleback 1", "#E65100", "Harvey 1", "#1565C0", "#888"]
+      }
+    }
+  ]
+}
+```
+
+Only point-trajectory animation is supported today. Raster time-series playback and temporal filtering of static features are tracked as future work in [#144](https://github.com/boettiger-lab/geo-agent/issues/144).
+
 ## Collapsed groups
 
 By default, layer groups in the panel start expanded. To start a group folded (useful when a collection has many layers), use the object form for `group`:


### PR DESCRIPTION
Closes #144 (point-trajectory scope only — see "future work" below).

## Summary
- Adds an `animation` config block on GeoJSON assets in `layers-input.json` that turns a LineString-with-timestamps collection into an animated point-along-line layer.
- New `app/animation-manager.js` — `TrajectoryAnimation` class: owns its own MapLibre sources/layers (track-lines, dots, labels), RAF loop, and a per-layer play/pause + speed controls panel.
- `dataset-catalog.js` passes the config through and resolves `static_positions_asset` (a STAC asset key in the same collection) to a URL; MapManager stays STAC-agnostic.
- `map-manager.js::registerLayer` branches on `animation.type === "trajectory"` and delegates visibility + filter to the animation instance. Layers still appear in the layer panel; the agent's `show_layer` / `hide_layer` / `set_filter` tools work on them directly.
- Filter handling uses `map.querySourceFeatures(..., { filter })` on the static tracks source to derive the set of animated entity ids — avoids re-implementing MapLibre filter semantics in JS. A small fallback handles the `show_track_line: false` case for the common `==` / `match` shapes.
- CSS for the controls panel; `configuration.md` documents the new block.

## Config shape

```json
{
  "id": "tracks",
  "display_name": "Wolf Movement",
  "visible": true,
  "animation": {
    "type": "trajectory",
    "timestamp_field": "timestamps",
    "id_field": "pack",
    "duration_seconds": 30,
    "static_positions_asset": "bins-latest"
  },
  "default_style": {
    "line-color":   ["match", ["get", "pack"], "Whaleback 1", "#E65100", "#888"],
    "circle-color": ["match", ["get", "pack"], "Whaleback 1", "#E65100", "#888"]
  }
}
```

## Design notes
- **Lazy import** of `animation-manager.js` via dynamic `import()` in MapManager — zero page-load cost for apps without animated layers.
- **Per-layer controller**, stacked vertically when multiple animations exist. Multi-layer sync is explicitly out of scope (adds complexity that isn't needed for the ca-wolves use case).
- **Setdata-driven dots + labels** (required for interpolation) + a MapLibre-filtered track-lines layer. Using `querySourceFeatures` as the filter evaluator keeps the two in sync.
- **Fallback filter evaluator** only handles the shapes the agent's `set_filter` tool actually emits (`==` / `!=` / `match` over `id_field`) — unknown shapes pass permissively rather than silently hiding everything.

## Future work (deferred per #144)
- `animation.type: "raster-sequence"` — COG URL swapping for weather radar / satellite time-series.
- `animation.type: "temporal-filter"` — time slider over feature `time` property.
- Timeline scrubber UI and multi-layer playback sync.
- Deck.gl TripsLayer integration for high-cardinality trajectories.

## Test plan
- [ ] Pin a test app (likely ca-wolves) to this commit SHA; verify animated dots, track lines, labels, and the play/pause controller render.
- [ ] Confirm the layer appears in the layer menu and the checkbox toggle hides/shows all three sublayers and the controls panel.
- [ ] Ask the agent to filter the animated layer by `pack` and confirm only the matching entities animate.
- [ ] Confirm apps without any `animation` config still load normally (no module import, no dead code paths).