### PR TITLE
feat: filter STAC child links by id before fetching

### DIFF
--- a/app/dataset-catalog.js
+++ b/app/dataset-catalog.js
@@ -75,8 +75,15 @@ export class DatasetCatalog {
             .map(c => c.collection_id));
         const catalogIds = new Set([...requestedIds].filter(id => !directIds.has(id)));
 
-        // Fetch all child collections in parallel
-        const fetchPromises = childLinks.map(async (link) => {
+        // When child links carry an `id` field (see boettiger-lab/data-workflows#105),
+        // filter before fetching so we only request the collections we need.
+        // Falls back to fetching all children for catalogs without IDs.
+        const linksToFetch = childLinks.filter(link =>
+            !link.id || catalogIds.has(link.id)
+        );
+
+        // Fetch matching child collections in parallel
+        const fetchPromises = linksToFetch.map(async (link) => {
             try {
                 const url = new URL(link.href, this.catalogUrl).href;
                 const collection = await this.fetchJson(url);


### PR DESCRIPTION
## Summary

- When the root STAC catalog includes `id` fields on child links, only fetch the collections the app actually needs instead of all children (~31 → ~2 for the default config)
- Falls back to current fetch-all behavior for catalogs that don't include IDs on links (backwards-compatible)
- Server-side counterpart: boettiger-lab/data-workflows#105 (add `id` to child links in `catalog.json`)

Closes #150