### PR TITLE
Add version and type fields to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,7 @@
 {
   "name": "geo-agent",
+  "version": "1.0.0",
+  "type": "module",
   "scripts": {
     "docs:dev": "vitepress dev docs",
     "docs:build": "vitepress build docs",


### PR DESCRIPTION
## Summary
- Adds `version` and `type: module` fields to `package.json`
- Allows geo-agent to be installed as a git dependency by npm/yarn (needed by `jupyter-geoagent`)

No functional changes to the web app — these fields are ignored by the CDN/browser consumption path.