### PR TITLE
Pass nodata from STAC to TiTiler for raster masking

### DIFF
--- a/app/dataset-catalog.js
+++ b/app/dataset-catalog.js
@@ -259,6 +259,7 @@ export class DatasetCatalog {
                                 layerType: 'raster',
                                 cogUrl: vAsset.href,
                                 legendClasses: band0?.['classification:classes'] || null,
+                                nodata: config.nodata ?? band0?.nodata ?? null,
                                 description: vAsset.description || '',
                             });
                         } else if (vType.includes('geo+json') || vAsset.href?.endsWith('.geojson')) {
@@ -345,6 +346,7 @@ export class DatasetCatalog {
                         legendLabel: config.legend_label || null,
                         legendType: config.legend_type || null,
                         legendClasses: band0?.['classification:classes'] || null,
+                        nodata: config.nodata ?? band0?.nodata ?? null,
                         description: asset.description || '',
                         defaultVisible: config.visible === true,
                         defaultFilter: config.default_filter || null,
@@ -667,6 +669,7 @@ export class DatasetCatalog {
                                 tilesUrl += `&colormap_name=${ml.colormap || 'reds'}`;
                                 if (ml.rescale) tilesUrl += `&rescale=${ml.rescale}`;
                             }
+                            if (v.nodata != null) tilesUrl += `&nodata=${encodeURIComponent(v.nodata)}`;
                             return {
                                 label: v.label,
                                 type: 'raster',
@@ -750,6 +753,7 @@ export class DatasetCatalog {
                         tilesUrl += `&colormap_name=${ml.colormap}`;
                         if (ml.rescale) tilesUrl += `&rescale=${ml.rescale}`;
                     }
+                    if (ml.nodata != null) tilesUrl += `&nodata=${encodeURIComponent(ml.nodata)}`;
 
                     configs.push({
                         layerId,

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -85,6 +85,7 @@ Each entry in `assets` may be a **bare string** (the STAC asset key, loaded with
 | `visible` | boolean | Default visibility. Default: `false`. |
 | `colormap` | string | TiTiler colormap name (e.g., `"reds"`, `"blues"`, `"viridis"`). Default: `"reds"`. |
 | `rescale` | string | TiTiler min,max range for color scaling (e.g., `"0,150"`). |
+| `nodata` | number\|string | Pixel value to render transparent (e.g., `0` to mask ocean/no-data). If unset, falls back to the STAC `raster:bands[0].nodata` value; omit both to leave all pixels opaque. |
 | `legend_label` | string | Label shown next to the color legend. |
 | `legend_type` | string | `"categorical"` to use STAC `classification:classes` color codes for a discrete legend. |
 


### PR DESCRIPTION
## Summary
- Reads `raster:bands[0].nodata` from STAC and forwards it to TiTiler via `&nodata=` so transparent pixels are masked instead of painted as the dark end of the colormap.
- Adds a per-layer `nodata` override in `layers-input.json` (takes precedence over STAC).
- Applied to both versioned + non-versioned raster paths, and to both categorical and continuous tile-URL branches.
- Documents the new `nodata` field in the raster asset config reference.

Fixes #156.

## Motivation
Without this, a COG whose nodata pixels are not flagged in its internal GDAL metadata (e.g. GHS-POP 2020, where ocean is value `0` but no nodata tag is set) renders the entire ocean as a dark translucent sheet over the basemap. Setting `\"nodata\": 0` in STAC or in the layer config now masks those pixels.

## Test plan
- [ ] Load a COG whose STAC asset has `raster:bands[0].nodata` set (e.g. cgls-lc100-2019) and confirm nodata pixels render transparent.
- [ ] Load a COG without a STAC nodata value and confirm behavior is unchanged (no `&nodata=` param appended).
- [ ] Set `\"nodata\": 0` on a layer in `layers-input.json` whose STAC lacks the field (e.g. GHS-POP) and confirm ocean pixels become transparent.
- [ ] Confirm the param appears on both the categorical and continuous tile-URL branches (network tab).
- [ ] Confirm versioned raster layers pass `nodata` through each version's tile URL.