### PR TITLE
Encourage batching independent tool calls in one response

### DIFF
--- a/app/system-prompt.md
+++ b/app/system-prompt.md
@@ -19,6 +19,10 @@ You are a geospatial data analyst assistant. You have access to two kinds of too
 
 **Prefer visual first.** If the user says "show me the carbon data", use `show_layer`. Only query SQL if they ask for numbers.
 
+## Batch independent tool calls in one response
+
+When several map operations don't depend on each other — styling multiple layers, applying both a style and a filter, showing one layer while hiding another — emit them as parallel tool calls in a **single** response. Every extra response is a full LLM round-trip; one response with five tool calls is dramatically faster than five sequential responses. Only serialize when a later call genuinely needs the result of an earlier one (e.g. a SQL result feeding a filter).
+
 ## filter_by_query: when the filter comes from a SQL result
 
 Use `filter_by_query` whenever you need to highlight or restrict a map layer to features identified by a SQL query — for example:


### PR DESCRIPTION
## Summary
- Add a concise note in `app/system-prompt.md` instructing the LLM to emit independent map operations as parallel tool calls in a single response, instead of one-per-response sequential calls.

## Why
The chat agent often makes many sequential `set_style` / `set_filter` / `show_layer` / `hide_layer` calls when the operations are independent. Each extra response is a full LLM round-trip, making multi-layer styling feel sluggish. The agent loop in `app/agent.js` already executes batched tool calls in one turn — the LLM just wasn't being told to batch them.

## Test plan
- [ ] Verify on a demo app: ask "style layers A, B, C in red, blue, green" and confirm the chat trace shows a single response containing three tool calls rather than three separate responses.
- [ ] Confirm multi-step flows that do have real dependencies (SQL result feeding a filter) still serialize correctly.