### PR TITLE
fix: floating chat vertical resize and wider default width

### DIFF
--- a/app/chat-ui.js
+++ b/app/chat-ui.js
@@ -471,7 +471,7 @@ export class ChatUI {
             const maxW = window.innerWidth - 40;
             const maxH = window.innerHeight - 100;
             this.container.style.width  = Math.min(maxW, Math.max(280, startW + dx)) + 'px';
-            this.container.style.maxHeight = Math.min(maxH, Math.max(200, startH + dy)) + 'px';
+            this.container.style.height = Math.min(maxH, Math.max(200, startH + dy)) + 'px';
         };
 
         const onUp = () => {

--- a/app/chat.css
+++ b/app/chat.css
@@ -8,8 +8,8 @@
     position: fixed;
     bottom: 80px;
     right: 20px;
-    width: 420px;
-    max-height: 620px;
+    width: 500px;
+    height: 620px;
     display: flex;
     flex-direction: column;
     background: rgba(255, 255, 255, 0.05);
@@ -112,8 +112,7 @@
     display: flex;
     flex-direction: column;
     gap: 8px;
-    min-height: 200px;
-    max-height: 420px;
+    min-height: 0;
 }
 
 /* Scrollbar */


### PR DESCRIPTION
## Summary

- `#chat-container` now uses `height` instead of `max-height` so the container has a definite size the drag handler can change
- Removed `max-height: 420px` on `#chat-messages` (was capping the messages area regardless of container size); `min-height: 0` now lets it fill whatever height the container has via `flex: 1`
- `initResize`: sets `style.height` instead of `style.maxHeight` so vertical drag is effective
- Default width widened from 420px → 500px (~20%)

Replaces #160 (which accidentally included unrelated WIP sidebar work).