### PR TITLE
fix: replace local get_dataset_details with MCP-sourced schemas

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -58,7 +58,7 @@ For LLM functionality, create `config.json`:
 
 **Local tools** (auto-approved, instant):
 - `show_layer`, `hide_layer`, `set_filter`, `clear_filter`, `set_style`, `reset_style`, `get_map_state`
-- `list_datasets`, `get_dataset_details`
+- `list_datasets`
 - `fly_to` — animates the map to a named place or coordinates (resolved via H3 parquet SQL)
 
 **Remote tools** (require user approval):

--- a/app/README.md
+++ b/app/README.md
@@ -58,7 +58,7 @@ For LLM functionality, create `config.json`:
 
 **Local tools** (auto-approved, instant):
 - `show_layer`, `hide_layer`, `set_filter`, `clear_filter`, `set_style`, `reset_style`, `get_map_state`
-- `list_datasets`
+- `get_schema`, `list_datasets`
 - `fly_to` — animates the map to a named place or coordinates (resolved via H3 parquet SQL)
 
 **Remote tools** (require user approval):

--- a/app/dataset-catalog.js
+++ b/app/dataset-catalog.js
@@ -551,18 +551,14 @@ export class DatasetCatalog {
     /**
      * Generate a text summary of all datasets for injection into the LLM system prompt.
      *
-     * When MCP collection data is available (preloaded at startup via get_collection),
-     * parquet paths and per-asset column schemas come from MCP — which correctly reads
-     * both collection-level and asset-level table:columns. Falls back to local
-     * extractParquetAssets/extractColumns when MCP data is unavailable.
+     * Includes paths and map layer IDs — the "table of contents" for the app.
+     * Column schemas are NOT included here; the model calls get_schema for those.
      */
     generatePromptCatalog() {
-        const preamble = 'The following datasets are pre-loaded for this app. Paths and schemas are shown below — use them directly in SQL. For full column descriptions or coded values, call `get_stac_details` with the collection ID.\n';
+        const preamble = 'The following datasets are pre-loaded for this app. Paths are shown below — use them directly in SQL. Call `get_schema(dataset_id)` before your first SQL query against a dataset to get column names and coded values.\n';
         const sections = [preamble];
 
         for (const ds of this.datasets.values()) {
-            const mcpData = this.mcpCollections.get(ds.id);
-
             // Parent container: has children but no own columns — render as directory node
             const isParentContainer = ds.columns.length === 0 && ds.childIds.length > 0;
             if (isParentContainer) {
@@ -584,8 +580,8 @@ export class DatasetCatalog {
             section += `**Description:** ${ds.description}\n`;
             section += `**Provider:** ${ds.provider}\n`;
 
-            // SQL assets with actual paths — from MCP data if available, else local extraction
-            section += this._renderSqlAssets(ds, mcpData);
+            // SQL assets with actual paths
+            section += this._renderSqlPaths(ds);
 
             // Map layers for visualization
             if (ds.mapLayers.length > 0) {
@@ -604,19 +600,6 @@ export class DatasetCatalog {
                 }
             }
 
-            // Column schema — only for datasets WITHOUT per-asset columns already rendered above
-            if (!mcpData) {
-                // No MCP data: fall back to local columns
-                if (ds.preload && ds.columns.length > 0) {
-                    section += `\n**Columns:**\n`;
-                    for (const col of ds.columns) {
-                        section += `- \`${col.name}\` (${col.type}): ${col.description}\n`;
-                    }
-                } else if (ds.columns.length > 0) {
-                    section += `→ Call \`get_stac_details("${ds.id}")\` for the full schema before writing SQL.\n`;
-                }
-            }
-
             if (ds.aboutUrl) {
                 section += `\n**More info:** ${ds.aboutUrl}\n`;
             }
@@ -628,16 +611,29 @@ export class DatasetCatalog {
     }
 
     /**
-     * Render SQL asset paths and per-asset column schemas for the prompt.
-     * Uses MCP structured data when available (correct per-asset schemas),
-     * falls back to local extractParquetAssets output.
+     * Render SQL asset paths only (no columns) for the system prompt.
+     * Uses MCP data when available, falls back to local extraction.
      * @private
      */
-    _renderSqlAssets(ds, mcpData) {
+    _renderSqlPaths(ds) {
+        const mcpData = this.mcpCollections.get(ds.id);
         if (mcpData) {
-            return this._renderSqlAssetsFromMcp(ds, mcpData);
+            const assets = mcpData.assets || {};
+            const lines = [];
+            for (const [assetId, asset] of Object.entries(assets)) {
+                const type = asset.type || '';
+                const href = asset.href || '';
+                if (!type.includes('parquet') && !href.endsWith('.parquet') &&
+                    !href.includes('/hex/') && !href.endsWith('/')) continue;
+                if (type.includes('pmtiles') || type.includes('tiff')) continue;
+                let s3Path = href;
+                if (s3Path.endsWith('/')) s3Path = s3Path.replace(/\/+$/, '') + '/**';
+                lines.push(`- ${asset.title || assetId}: \`read_parquet('${s3Path}')\``);
+            }
+            if (lines.length === 0) return '';
+            return '\n**SQL assets:**\n' + lines.join('\n') + '\n';
         }
-        // Fallback: local parquet assets (paths are correct, but no per-asset columns)
+        // Fallback: local parquet assets
         if (ds.parquetAssets.length === 0) return '';
         let out = '\n**SQL assets:**\n';
         for (const pa of ds.parquetAssets) {
@@ -647,73 +643,128 @@ export class DatasetCatalog {
     }
 
     /**
-     * Render SQL assets from MCP get_collection structured data.
-     * Includes per-asset column schemas inline — this is the fix for #163.
-     * @private
+     * Format schema info for the get_schema tool.
+     * Returns a compact, tabular representation optimized for LLM consumption:
+     * paths, column headers with representative values, and coded value lists.
+     *
+     * Uses MCP get_collection data (correct per-asset schemas).
+     * Falls back to local catalog data when MCP data is unavailable.
+     *
+     * @param {string} id - Collection ID
+     * @returns {string|null} Formatted schema text, or null if dataset not found
      */
-    _renderSqlAssetsFromMcp(ds, mcpData) {
+    formatSchema(id) {
+        const ds = this.datasets.get(id);
+        if (!ds) return null;
+
+        const mcpData = this.mcpCollections.get(id);
+        if (mcpData) {
+            return this._formatSchemaFromMcp(ds, mcpData);
+        }
+        return this._formatSchemaFallback(ds);
+    }
+
+    /** @private */
+    _formatSchemaFromMcp(ds, mcpData) {
+        const sections = [];
         const assets = mcpData.assets || {};
-        const parquetAssets = [];
 
         for (const [assetId, asset] of Object.entries(assets)) {
             const type = asset.type || '';
             const href = asset.href || '';
             if (!type.includes('parquet') && !href.endsWith('.parquet') &&
                 !href.includes('/hex/') && !href.endsWith('/')) continue;
-            // Skip PMTiles/COGs that might match loosely
             if (type.includes('pmtiles') || type.includes('tiff')) continue;
 
             let s3Path = href;
             if (s3Path.endsWith('/')) s3Path = s3Path.replace(/\/+$/, '') + '/**';
 
-            parquetAssets.push({
-                title: asset.title || assetId,
-                s3Path,
-                columns: asset['table:columns'] || [],
+            const cols = (asset['table:columns'] || []).filter(c =>
+                !['geometry', 'geom', 'bbox'].includes(c.name?.toLowerCase())
+            );
+            if (cols.length === 0) continue;
+
+            let out = `${asset.title || assetId}:\n`;
+            out += `  read_parquet('${s3Path}')\n\n`;
+
+            // Column headers
+            const names = cols.map(c => c.name);
+            const samples = cols.map(c => {
+                if (c.values?.length > 0) return String(c.values[0]);
+                return `(${c.type || '?'})`;
             });
-        }
+            out += '  ' + names.join(' | ') + '\n';
+            out += '  ' + samples.join(' | ') + '\n';
 
-        if (parquetAssets.length === 0) return '';
-
-        let out = '\n**SQL assets:**\n';
-        for (const pa of parquetAssets) {
-            out += `- ${pa.title}: \`read_parquet('${pa.s3Path}')\`\n`;
-            // Inline per-asset columns when available
-            const cols = this._filterColumns(pa.columns);
-            if (cols.length > 0 && ds.preload) {
-                // Full tier: column name, type, description
-                for (const c of cols) {
-                    const desc = c.description ? ` — ${c.description}` : '';
-                    out += `    - \`${c.name}\` (${c.type || '?'})${desc}\n`;
+            // Coded values
+            const coded = cols.filter(c => c.values?.length > 0);
+            if (coded.length > 0) {
+                out += '\n';
+                for (const c of coded) {
+                    out += `  ${c.name}: ${c.values.join(', ')}\n`;
                 }
-            } else if (cols.length > 0) {
-                // Compact tier: column names only
-                const names = cols.map(c => c.name).join(', ');
-                out += `    Columns: ${names}\n`;
             }
+
+            // Columns with descriptions but no coded values — show a compact hint
+            const described = cols.filter(c => !c.values?.length && c.description);
+            if (described.length > 0) {
+                out += '\n';
+                for (const c of described) {
+                    out += `  ${c.name}: ${c.description}\n`;
+                }
+            }
+
+            sections.push(out);
         }
 
-        // Collection-level columns (if any and not already covered per-asset)
-        const collectionCols = this._filterColumns(mcpData['table:columns'] || []);
-        if (collectionCols.length > 0 && ds.preload) {
-            out += `\n**Collection-level columns:**\n`;
-            for (const c of collectionCols) {
-                const desc = c.description ? ` — ${c.description}` : '';
-                out += `- \`${c.name}\` (${c.type || '?'})${desc}\n`;
-            }
-        }
-
-        return out;
-    }
-
-    /**
-     * Filter out geometry/geom columns from a table:columns array.
-     * @private
-     */
-    _filterColumns(columns) {
-        return (columns || []).filter(c =>
+        // Collection-level columns (when assets didn't have their own)
+        const collCols = (mcpData['table:columns'] || []).filter(c =>
             !['geometry', 'geom', 'bbox'].includes(c.name?.toLowerCase())
         );
+        if (collCols.length > 0 && sections.length === 0) {
+            let out = `${ds.title} columns:\n\n`;
+            const names = collCols.map(c => c.name);
+            const samples = collCols.map(c => {
+                if (c.values?.length > 0) return String(c.values[0]);
+                return `(${c.type || '?'})`;
+            });
+            out += '  ' + names.join(' | ') + '\n';
+            out += '  ' + samples.join(' | ') + '\n';
+            const coded = collCols.filter(c => c.values?.length > 0);
+            if (coded.length > 0) {
+                out += '\n';
+                for (const c of coded) {
+                    out += `  ${c.name}: ${c.values.join(', ')}\n`;
+                }
+            }
+            sections.push(out);
+        }
+
+        if (sections.length === 0) return `No schema available for ${id}. Try get_stac_details("${id}").`;
+        return sections.join('\n');
+    }
+
+    /** @private */
+    _formatSchemaFallback(ds) {
+        if (ds.parquetAssets.length === 0 && ds.columns.length === 0) {
+            return `No schema available for ${ds.id}. Try get_stac_details("${ds.id}").`;
+        }
+        let out = '';
+        for (const pa of ds.parquetAssets) {
+            out += `${pa.title}:\n  read_parquet('${pa.s3Path}')\n\n`;
+        }
+        if (ds.columns.length > 0) {
+            const names = ds.columns.map(c => c.name);
+            out += '  ' + names.join(' | ') + '\n';
+            const coded = ds.columns.filter(c => c.values?.length > 0);
+            if (coded.length > 0) {
+                out += '\n';
+                for (const c of coded) {
+                    out += `  ${c.name}: ${c.values.join(', ')}\n`;
+                }
+            }
+        }
+        return out;
     }
 
     /**

--- a/app/dataset-catalog.js
+++ b/app/dataset-catalog.js
@@ -611,6 +611,39 @@ export class DatasetCatalog {
     }
 
     /**
+     * Extract SQL-relevant parquet assets from MCP data.
+     * Prefers H3 hex assets over full GeoParquet — when both exist,
+     * the hex is what DuckDB queries should use (partitioned, H3-indexed).
+     * @private
+     */
+    _getSqlAssets(mcpData) {
+        const assets = mcpData.assets || {};
+        const all = [];
+        let hasHex = false;
+
+        for (const [assetId, asset] of Object.entries(assets)) {
+            const type = asset.type || '';
+            const href = asset.href || '';
+            if (!type.includes('parquet') && !href.endsWith('.parquet') &&
+                !href.includes('/hex/') && !href.endsWith('/')) continue;
+            if (type.includes('pmtiles') || type.includes('tiff')) continue;
+
+            let s3Path = href;
+            if (s3Path.endsWith('/')) s3Path = s3Path.replace(/\/+$/, '') + '/**';
+
+            const isHex = href.includes('/hex/') || href.includes('/hex') ||
+                          (asset.title || '').toLowerCase().includes('hex') ||
+                          (asset.title || '').toLowerCase().includes('h3');
+            if (isHex) hasHex = true;
+
+            all.push({ assetId, title: asset.title || assetId, s3Path, isHex, asset });
+        }
+
+        // If hex assets exist, omit full GeoParquet (model doesn't need it for SQL)
+        return hasHex ? all.filter(a => a.isHex) : all;
+    }
+
+    /**
      * Render SQL asset paths only (no columns) for the system prompt.
      * Uses MCP data when available, falls back to local extraction.
      * @private
@@ -618,19 +651,9 @@ export class DatasetCatalog {
     _renderSqlPaths(ds) {
         const mcpData = this.mcpCollections.get(ds.id);
         if (mcpData) {
-            const assets = mcpData.assets || {};
-            const lines = [];
-            for (const [assetId, asset] of Object.entries(assets)) {
-                const type = asset.type || '';
-                const href = asset.href || '';
-                if (!type.includes('parquet') && !href.endsWith('.parquet') &&
-                    !href.includes('/hex/') && !href.endsWith('/')) continue;
-                if (type.includes('pmtiles') || type.includes('tiff')) continue;
-                let s3Path = href;
-                if (s3Path.endsWith('/')) s3Path = s3Path.replace(/\/+$/, '') + '/**';
-                lines.push(`- ${asset.title || assetId}: \`read_parquet('${s3Path}')\``);
-            }
-            if (lines.length === 0) return '';
+            const sqlAssets = this._getSqlAssets(mcpData);
+            if (sqlAssets.length === 0) return '';
+            const lines = sqlAssets.map(a => `- ${a.title}: \`read_parquet('${a.s3Path}')\``);
             return '\n**SQL assets:**\n' + lines.join('\n') + '\n';
         }
         // Fallback: local parquet assets
@@ -667,27 +690,18 @@ export class DatasetCatalog {
     /** @private */
     _formatSchemaFromMcp(ds, mcpData) {
         const sections = [];
-        const assets = mcpData.assets || {};
+        const sqlAssets = this._getSqlAssets(mcpData);
 
-        for (const [assetId, asset] of Object.entries(assets)) {
-            const type = asset.type || '';
-            const href = asset.href || '';
-            if (!type.includes('parquet') && !href.endsWith('.parquet') &&
-                !href.includes('/hex/') && !href.endsWith('/')) continue;
-            if (type.includes('pmtiles') || type.includes('tiff')) continue;
-
-            let s3Path = href;
-            if (s3Path.endsWith('/')) s3Path = s3Path.replace(/\/+$/, '') + '/**';
-
+        for (const { title, s3Path, asset } of sqlAssets) {
             const cols = (asset['table:columns'] || []).filter(c =>
                 !['geometry', 'geom', 'bbox'].includes(c.name?.toLowerCase())
             );
             if (cols.length === 0) continue;
 
-            let out = `${asset.title || assetId}:\n`;
+            let out = `${title}:\n`;
             out += `  read_parquet('${s3Path}')\n\n`;
 
-            // Column headers
+            // Column headers + sample values row (like SELECT * LIMIT 1 output)
             const names = cols.map(c => c.name);
             const samples = cols.map(c => {
                 if (c.values?.length > 0) return String(c.values[0]);
@@ -712,6 +726,11 @@ export class DatasetCatalog {
                 for (const c of described) {
                     out += `  ${c.name}: ${c.description}\n`;
                 }
+            }
+
+            // If no coded values at all, suggest SELECT * LIMIT 1 to see real data
+            if (coded.length === 0) {
+                out += `\n  Tip: run SELECT * FROM read_parquet('${s3Path}') LIMIT 1 to see sample values.\n`;
             }
 
             sections.push(out);

--- a/app/dataset-catalog.js
+++ b/app/dataset-catalog.js
@@ -16,6 +16,8 @@ export class DatasetCatalog {
     constructor() {
         /** @type {Map<string, DatasetEntry>} keyed by collection ID */
         this.datasets = new Map();
+        /** @type {Map<string, Object>} MCP get_collection results, keyed by collection ID */
+        this.mcpCollections = new Map();
         this.catalogUrl = null;
         this.titilerUrl = null;
     }
@@ -505,11 +507,25 @@ export class DatasetCatalog {
         return doc?.href || null;
     }
 
+    // ---- MCP preload ----
+
+    /**
+     * Store a structured collection dict from MCP get_collection.
+     * Called at startup to cache per-asset schemas and parquet paths
+     * for system prompt generation.
+     *
+     * @param {string} id - Collection ID
+     * @param {Object} data - Structured STAC collection from MCP
+     */
+    setMcpCollection(id, data) {
+        this.mcpCollections.set(id, data);
+    }
+
     // ---- Public API ----
 
     /**
      * Get a dataset entry by collection ID.
-     * @param {string} id 
+     * @param {string} id
      * @returns {DatasetEntry|null}
      */
     get(id) {
@@ -534,13 +550,19 @@ export class DatasetCatalog {
 
     /**
      * Generate a text summary of all datasets for injection into the LLM system prompt.
-     * Includes both SQL (parquet) and map (visual) information.
+     *
+     * When MCP collection data is available (preloaded at startup via get_collection),
+     * parquet paths and per-asset column schemas come from MCP — which correctly reads
+     * both collection-level and asset-level table:columns. Falls back to local
+     * extractParquetAssets/extractColumns when MCP data is unavailable.
      */
     generatePromptCatalog() {
-        const preamble = 'The following datasets are pre-loaded for this app. Call `get_dataset_details` with a dataset ID to get its parquet paths and full schema before writing any SQL.\n';
+        const preamble = 'The following datasets are pre-loaded for this app. Paths and schemas are shown below — use them directly in SQL. For full column descriptions or coded values, call `get_stac_details` with the collection ID.\n';
         const sections = [preamble];
 
         for (const ds of this.datasets.values()) {
+            const mcpData = this.mcpCollections.get(ds.id);
+
             // Parent container: has children but no own columns — render as directory node
             const isParentContainer = ds.columns.length === 0 && ds.childIds.length > 0;
             if (isParentContainer) {
@@ -548,10 +570,10 @@ export class DatasetCatalog {
                 section += `**Collection ID:** ${ds.id}\n`;
                 section += `**Description:** ${ds.description}\n`;
                 const listed = ds.childIds.slice(0, 20);
-                section += `Sub-datasets — call \`get_dataset_details\` with one of these IDs:\n`;
+                section += `Sub-datasets — call \`get_stac_details\` with one of these IDs:\n`;
                 section += `  ${listed.join(', ')}\n`;
                 if (ds.childIds.length > 20) {
-                    section += `  (${ds.childIds.length - 20} more — call \`get_dataset_details("${ds.id}")\` for the full list)\n`;
+                    section += `  (${ds.childIds.length - 20} more — call \`get_stac_details("${ds.id}")\` for the full list)\n`;
                 }
                 sections.push(section);
                 continue;
@@ -562,11 +584,8 @@ export class DatasetCatalog {
             section += `**Description:** ${ds.description}\n`;
             section += `**Provider:** ${ds.provider}\n`;
 
-            // Parquet assets: indicate SQL-queryable but omit paths — model must call get_dataset_details
-            if (ds.parquetAssets.length > 0) {
-                const titles = ds.parquetAssets.map(pa => pa.title).join(', ');
-                section += `\n**SQL assets** (paths via \`get_dataset_details\`): ${titles}\n`;
-            }
+            // SQL assets with actual paths — from MCP data if available, else local extraction
+            section += this._renderSqlAssets(ds, mcpData);
 
             // Map layers for visualization
             if (ds.mapLayers.length > 0) {
@@ -585,24 +604,17 @@ export class DatasetCatalog {
                 }
             }
 
-            if (ds.preload && ds.columns.length > 0) {
-                // Full tier: all columns including H3, no cap
-                section += `\n**Columns:**\n`;
-                for (const col of ds.columns) {
-                    let line = `- \`${col.name}\` (${col.type}): ${col.description}`;
-                    if (col.values?.length > 0) {
-                        line += ` [${col.values.length} coded values — call \`get_dataset_details\` to see all]`;
+            // Column schema — only for datasets WITHOUT per-asset columns already rendered above
+            if (!mcpData) {
+                // No MCP data: fall back to local columns
+                if (ds.preload && ds.columns.length > 0) {
+                    section += `\n**Columns:**\n`;
+                    for (const col of ds.columns) {
+                        section += `- \`${col.name}\` (${col.type}): ${col.description}\n`;
                     }
-                    section += line + '\n';
+                } else if (ds.columns.length > 0) {
+                    section += `→ Call \`get_stac_details("${ds.id}")\` for the full schema before writing SQL.\n`;
                 }
-            } else if (ds.columns.length > 0) {
-                // Compact tier: hint to call get_dataset_details for schema
-                const codedCols = ds.columns.filter(c => c.values?.length > 0);
-                if (codedCols.length > 0) {
-                    const summary = codedCols.map(c => `${c.name} (${c.values.length})`).join(', ');
-                    section += `\n**Columns with known coded values:** ${summary}\n`;
-                }
-                section += `→ Call \`get_dataset_details("${ds.id}")\` for the full schema before writing SQL.\n`;
             }
 
             if (ds.aboutUrl) {
@@ -613,6 +625,95 @@ export class DatasetCatalog {
         }
 
         return sections.join('\n---\n\n');
+    }
+
+    /**
+     * Render SQL asset paths and per-asset column schemas for the prompt.
+     * Uses MCP structured data when available (correct per-asset schemas),
+     * falls back to local extractParquetAssets output.
+     * @private
+     */
+    _renderSqlAssets(ds, mcpData) {
+        if (mcpData) {
+            return this._renderSqlAssetsFromMcp(ds, mcpData);
+        }
+        // Fallback: local parquet assets (paths are correct, but no per-asset columns)
+        if (ds.parquetAssets.length === 0) return '';
+        let out = '\n**SQL assets:**\n';
+        for (const pa of ds.parquetAssets) {
+            out += `- ${pa.title}: \`read_parquet('${pa.s3Path}')\`\n`;
+        }
+        return out;
+    }
+
+    /**
+     * Render SQL assets from MCP get_collection structured data.
+     * Includes per-asset column schemas inline — this is the fix for #163.
+     * @private
+     */
+    _renderSqlAssetsFromMcp(ds, mcpData) {
+        const assets = mcpData.assets || {};
+        const parquetAssets = [];
+
+        for (const [assetId, asset] of Object.entries(assets)) {
+            const type = asset.type || '';
+            const href = asset.href || '';
+            if (!type.includes('parquet') && !href.endsWith('.parquet') &&
+                !href.includes('/hex/') && !href.endsWith('/')) continue;
+            // Skip PMTiles/COGs that might match loosely
+            if (type.includes('pmtiles') || type.includes('tiff')) continue;
+
+            let s3Path = href;
+            if (s3Path.endsWith('/')) s3Path = s3Path.replace(/\/+$/, '') + '/**';
+
+            parquetAssets.push({
+                title: asset.title || assetId,
+                s3Path,
+                columns: asset['table:columns'] || [],
+            });
+        }
+
+        if (parquetAssets.length === 0) return '';
+
+        let out = '\n**SQL assets:**\n';
+        for (const pa of parquetAssets) {
+            out += `- ${pa.title}: \`read_parquet('${pa.s3Path}')\`\n`;
+            // Inline per-asset columns when available
+            const cols = this._filterColumns(pa.columns);
+            if (cols.length > 0 && ds.preload) {
+                // Full tier: column name, type, description
+                for (const c of cols) {
+                    const desc = c.description ? ` — ${c.description}` : '';
+                    out += `    - \`${c.name}\` (${c.type || '?'})${desc}\n`;
+                }
+            } else if (cols.length > 0) {
+                // Compact tier: column names only
+                const names = cols.map(c => c.name).join(', ');
+                out += `    Columns: ${names}\n`;
+            }
+        }
+
+        // Collection-level columns (if any and not already covered per-asset)
+        const collectionCols = this._filterColumns(mcpData['table:columns'] || []);
+        if (collectionCols.length > 0 && ds.preload) {
+            out += `\n**Collection-level columns:**\n`;
+            for (const c of collectionCols) {
+                const desc = c.description ? ` — ${c.description}` : '';
+                out += `- \`${c.name}\` (${c.type || '?'})${desc}\n`;
+            }
+        }
+
+        return out;
+    }
+
+    /**
+     * Filter out geometry/geom columns from a table:columns array.
+     * @private
+     */
+    _filterColumns(columns) {
+        return (columns || []).filter(c =>
+            !['geometry', 'geom', 'bbox'].includes(c.name?.toLowerCase())
+        );
     }
 
     /**

--- a/app/dataset-catalog.js
+++ b/app/dataset-catalog.js
@@ -689,78 +689,74 @@ export class DatasetCatalog {
 
     /** @private */
     _formatSchemaFromMcp(ds, mcpData) {
-        const sections = [];
         const sqlAssets = this._getSqlAssets(mcpData);
-
-        for (const { title, s3Path, asset } of sqlAssets) {
-            const cols = (asset['table:columns'] || []).filter(c =>
-                !['geometry', 'geom', 'bbox'].includes(c.name?.toLowerCase())
-            );
-            if (cols.length === 0) continue;
-
-            let out = `${title}:\n`;
-            out += `  read_parquet('${s3Path}')\n\n`;
-
-            // Column headers + sample values row (like SELECT * LIMIT 1 output)
-            const names = cols.map(c => c.name);
-            const samples = cols.map(c => {
-                if (c.values?.length > 0) return String(c.values[0]);
-                return `(${c.type || '?'})`;
-            });
-            out += '  ' + names.join(' | ') + '\n';
-            out += '  ' + samples.join(' | ') + '\n';
-
-            // Coded values
-            const coded = cols.filter(c => c.values?.length > 0);
-            if (coded.length > 0) {
-                out += '\n';
-                for (const c of coded) {
-                    out += `  ${c.name}: ${c.values.join(', ')}\n`;
-                }
-            }
-
-            // Columns with descriptions but no coded values — show a compact hint
-            const described = cols.filter(c => !c.values?.length && c.description);
-            if (described.length > 0) {
-                out += '\n';
-                for (const c of described) {
-                    out += `  ${c.name}: ${c.description}\n`;
-                }
-            }
-
-            // If no coded values at all, suggest SELECT * LIMIT 1 to see real data
-            if (coded.length === 0) {
-                out += `\n  Tip: run SELECT * FROM read_parquet('${s3Path}') LIMIT 1 to see sample values.\n`;
-            }
-
-            sections.push(out);
-        }
-
-        // Collection-level columns (when assets didn't have their own)
         const collCols = (mcpData['table:columns'] || []).filter(c =>
             !['geometry', 'geom', 'bbox'].includes(c.name?.toLowerCase())
         );
-        if (collCols.length > 0 && sections.length === 0) {
-            let out = `${ds.title} columns:\n\n`;
-            const names = collCols.map(c => c.name);
-            const samples = collCols.map(c => {
-                if (c.values?.length > 0) return String(c.values[0]);
-                return `(${c.type || '?'})`;
-            });
-            out += '  ' + names.join(' | ') + '\n';
-            out += '  ' + samples.join(' | ') + '\n';
-            const coded = collCols.filter(c => c.values?.length > 0);
-            if (coded.length > 0) {
-                out += '\n';
-                for (const c of coded) {
-                    out += `  ${c.name}: ${c.values.join(', ')}\n`;
-                }
-            }
-            sections.push(out);
+
+        // Determine which columns to use: per-asset if available, else collection-level
+        const sections = [];
+        for (const { title, s3Path, asset } of sqlAssets) {
+            const assetCols = (asset['table:columns'] || []).filter(c =>
+                !['geometry', 'geom', 'bbox'].includes(c.name?.toLowerCase())
+            );
+            // Use per-asset columns if available, fall back to collection-level
+            const cols = assetCols.length > 0 ? assetCols : collCols;
+            sections.push(this._renderOneAssetSchema(title, s3Path, cols));
         }
 
-        if (sections.length === 0) return `No schema available for ${id}. Try get_stac_details("${id}").`;
+        // If no SQL assets found at all, render collection-level columns standalone
+        if (sections.length === 0 && collCols.length > 0) {
+            sections.push(this._renderOneAssetSchema(ds.title, null, collCols));
+        }
+
+        if (sections.length === 0) return `No schema available for ${ds.id}. Try get_stac_details("${ds.id}").`;
         return sections.join('\n');
+    }
+
+    /**
+     * Render one asset's schema in tabular format.
+     * @private
+     */
+    _renderOneAssetSchema(title, s3Path, cols) {
+        let out = `${title}:\n`;
+        if (s3Path) out += `  read_parquet('${s3Path}')\n\n`;
+
+        if (cols.length === 0) return out;
+
+        // Column headers + sample values row (like SELECT * LIMIT 1 output)
+        const names = cols.map(c => c.name);
+        const samples = cols.map(c => {
+            if (c.values?.length > 0) return String(c.values[0]);
+            return `(${c.type || '?'})`;
+        });
+        out += '  ' + names.join(' | ') + '\n';
+        out += '  ' + samples.join(' | ') + '\n';
+
+        // Coded values
+        const coded = cols.filter(c => c.values?.length > 0);
+        if (coded.length > 0) {
+            out += '\n';
+            for (const c of coded) {
+                out += `  ${c.name}: ${c.values.join(', ')}\n`;
+            }
+        }
+
+        // Columns with descriptions but no coded values — show a compact hint
+        const described = cols.filter(c => !c.values?.length && c.description);
+        if (described.length > 0) {
+            out += '\n';
+            for (const c of described) {
+                out += `  ${c.name}: ${c.description}\n`;
+            }
+        }
+
+        // If no coded values at all, suggest SELECT * LIMIT 1 to see real data
+        if (coded.length === 0 && s3Path) {
+            out += `\n  Tip: run SELECT * FROM read_parquet('${s3Path}') LIMIT 1 to see sample values.\n`;
+        }
+
+        return out;
     }
 
     /** @private */

--- a/app/main.js
+++ b/app/main.js
@@ -216,6 +216,37 @@ async function main() {
         }], mcp);
     }
 
+    /* ── 5b. Preload MCP collection data for system prompt ──────────── */
+    // Call get_collection for each configured dataset to get correct per-asset
+    // schemas and parquet paths. This data enriches the system prompt.
+    // Falls back gracefully if MCP is unavailable.
+    try {
+        const collectionIds = appConfig.collections.map(c =>
+            typeof c === 'string' ? c : c.collection_id
+        );
+        const preloadResults = await Promise.allSettled(
+            collectionIds.map(id =>
+                mcp.callTool('get_collection', { collection_id: id })
+            )
+        );
+        let preloaded = 0;
+        for (let i = 0; i < collectionIds.length; i++) {
+            const r = preloadResults[i];
+            if (r.status === 'fulfilled' && r.value) {
+                try {
+                    const data = JSON.parse(r.value);
+                    if (!data.error) {
+                        catalog.setMcpCollection(collectionIds[i], data);
+                        preloaded++;
+                    }
+                } catch { /* not JSON — skip */ }
+            }
+        }
+        console.log(`[main] Preloaded ${preloaded}/${collectionIds.length} collections from MCP`);
+    } catch (err) {
+        console.warn('[main] MCP preload failed, using local catalog data:', err.message);
+    }
+
     /* ── 6. Build system prompt ────────────────────────────────────────── */
     const basePrompt = await fetchText('system-prompt.md');
     const catalogText = catalog.generatePromptCatalog();

--- a/app/map-tools.js
+++ b/app/map-tools.js
@@ -12,6 +12,7 @@
  *     - get_map_state
  *     - fly_to
  *   Dataset knowledge:
+ *     - get_schema
  *     - list_datasets
  */
 
@@ -280,8 +281,30 @@ Vector layers: ${vectorLayerIds().join(', ')}`,
 
         // ---- Dataset Knowledge Tools ----
         {
+            name: 'get_schema',
+            description: 'Get column names, types, sample values, and coded value lists for a dataset — formatted like SELECT * LIMIT 1 output. Also includes the read_parquet() path. **Call this before your first SQL query against a dataset.** Instant, no approval needed. For datasets outside your app, use `get_stac_details` instead.',
+            inputSchema: {
+                type: 'object',
+                properties: {
+                    dataset_id: { type: 'string', description: 'Collection ID of the dataset' }
+                },
+                required: ['dataset_id']
+            },
+            execute: (args) => {
+                const result = catalog.formatSchema(args.dataset_id);
+                if (result === null) {
+                    return JSON.stringify({
+                        success: false,
+                        error: `Dataset not found: ${args.dataset_id}. Available: ${catalog.getIds().join(', ')}. For datasets outside this app, use get_stac_details.`
+                    });
+                }
+                return result;
+            },
+        },
+
+        {
             name: 'list_datasets',
-            description: 'List all datasets pre-loaded for this app. Paths and schemas are in your system prompt. To discover datasets outside your app, use `browse_stac_catalog` instead.',
+            description: 'List all dataset IDs and titles pre-loaded for this app. Paths are in your system prompt; call `get_schema` for column details. To discover datasets outside your app, use `browse_stac_catalog` instead.',
             inputSchema: {
                 type: 'object',
                 properties: {},
@@ -291,13 +314,6 @@ Vector layers: ${vectorLayerIds().join(', ')}`,
                 const datasets = catalog.getAll().map(ds => ({
                     id: ds.id,
                     title: ds.title,
-                    description: ds.description.substring(0, 200),
-                    provider: ds.provider,
-                    mapLayers: ds.mapLayers.map(a => ({
-                        layerId: `${ds.id}/${a.assetId}`,
-                        title: a.title,
-                        type: a.layerType
-                    })),
                 }));
                 return JSON.stringify({ success: true, datasets });
             },

--- a/app/map-tools.js
+++ b/app/map-tools.js
@@ -13,7 +13,6 @@
  *     - fly_to
  *   Dataset knowledge:
  *     - list_datasets
- *     - get_dataset_details
  */
 
 /**
@@ -88,7 +87,7 @@ export function createMapTools(mapManager, catalog, mcpClient) {
             name: 'set_filter',
             description: `Apply a MapLibre filter expression to a vector layer. Use when the user asks to filter features by property values.
 
-IMPORTANT: Never guess categorical values used in filters. Call get_dataset_details first to find documented coded values; only use SELECT DISTINCT via SQL if the metadata doesn't cover it.
+IMPORTANT: Never guess categorical values used in filters. Check the dataset catalog in your system prompt for documented coded values, or call get_stac_details for full column details. Only use SELECT DISTINCT via SQL if the metadata doesn't cover it.
 
 IMPORTANT: After filtering, check 'featuresInView' in the result. If 0, the filter may be wrong.
 
@@ -147,7 +146,7 @@ Vector layers: ${vectorLayerIds().join(', ')}`,
             name: 'set_style',
             description: `Update a layer's paint/style properties. Provide MapLibre paint properties.
 
-IMPORTANT: For categorical coloring (e.g., a "match" expression), never guess or assume valid values. Always call get_dataset_details first — most categorical columns list every valid code there. Only fall back to SELECT DISTINCT via SQL if the metadata doesn't cover it.
+IMPORTANT: For categorical coloring (e.g., a "match" expression), never guess or assume valid values. Check the dataset catalog in your system prompt for documented coded values, or call get_stac_details for full column details. Only fall back to SELECT DISTINCT via SQL if the metadata doesn't cover it.
 
 Examples:
   Simple: { "fill-color": "red", "fill-opacity": 0.5 }
@@ -229,7 +228,7 @@ How it works:
 Parameters:
 - layer_id: the vector layer to filter (must already be loaded)
 - sql: a SELECT query returning ONE column — the feature ID values to keep. Alias that column to match id_property exactly. Example: SELECT GEOID FROM read_parquet('s3://...') WHERE ...
-- id_property: the property name in the vector tile features to match against. Check get_dataset_details or get_stac_details for the correct column — CNG-processed datasets use "_cng_fid"; source datasets vary (e.g. "OBJECTID", "HOLDING_ID").
+- id_property: the property name in the vector tile features to match against. Check get_stac_details for the correct column — CNG-processed datasets use "_cng_fid"; source datasets vary (e.g. "OBJECTID", "HOLDING_ID").
 
 IMPORTANT: The sql must return only the id column — no extra columns. Write it as a plain SELECT, not wrapped in array_agg.
 
@@ -239,7 +238,7 @@ Vector layers: ${vectorLayerIds().join(', ')}`,
                 properties: {
                     layer_id: { type: 'string', description: 'Vector layer ID to filter' },
                     sql: { type: 'string', description: 'SELECT query returning a single column of ID values to keep' },
-                    id_property: { type: 'string', description: 'Feature property name in the vector tile to match against — check get_dataset_details or get_stac_details (CNG-processed datasets use "_cng_fid"; source datasets vary)' },
+                    id_property: { type: 'string', description: 'Feature property name in the vector tile to match against — check get_stac_details (CNG-processed datasets use "_cng_fid"; source datasets vary)' },
                 },
                 required: ['layer_id', 'sql', 'id_property'],
             },
@@ -266,7 +265,7 @@ Vector layers: ${vectorLayerIds().join(', ')}`,
                 if (!ids) {
                     return JSON.stringify({
                         success: false,
-                        error: `Could not parse ID list from query result. Check that id_property ("${col}") exactly matches the column name in the SQL output — verify via get_dataset_details or get_stac_details (CNG-processed datasets use "_cng_fid"). Raw: ${rawResult.substring(0, 300)}`
+                        error: `Could not parse ID list from query result. Check that id_property ("${col}") exactly matches the column name in the SQL output — verify via get_stac_details (CNG-processed datasets use "_cng_fid"). Raw: ${rawResult.substring(0, 300)}`
                     });
                 }
                 if (ids.length === 0) {
@@ -282,7 +281,7 @@ Vector layers: ${vectorLayerIds().join(', ')}`,
         // ---- Dataset Knowledge Tools ----
         {
             name: 'list_datasets',
-            description: 'List all datasets pre-loaded for this app. Their schemas are already in your context — use `get_dataset_details` to look up columns and paths. To discover datasets outside your app, use `browse_stac_catalog` instead.',
+            description: 'List all datasets pre-loaded for this app. Paths and schemas are in your system prompt. To discover datasets outside your app, use `browse_stac_catalog` instead.',
             inputSchema: {
                 type: 'object',
                 properties: {},
@@ -294,7 +293,6 @@ Vector layers: ${vectorLayerIds().join(', ')}`,
                     title: ds.title,
                     description: ds.description.substring(0, 200),
                     provider: ds.provider,
-                    parquetAssets: ds.parquetAssets.map(a => ({ title: a.title, s3Path: a.s3Path })),
                     mapLayers: ds.mapLayers.map(a => ({
                         layerId: `${ds.id}/${a.assetId}`,
                         title: a.title,
@@ -325,48 +323,5 @@ Vector layers: ${vectorLayerIds().join(', ')}`,
             },
         },
 
-        {
-            name: 'get_dataset_details',
-            description: 'Get full schema (columns, parquet paths, coded values) for a pre-loaded dataset. **Always call this before writing SQL against any dataset in your app** — it is instant and requires no approval. For datasets outside your app config, use `get_stac_details` instead.',
-            inputSchema: {
-                type: 'object',
-                properties: {
-                    dataset_id: { type: 'string', description: 'Collection ID of the dataset' }
-                },
-                required: ['dataset_id']
-            },
-            execute: (args) => {
-                const ds = catalog.get(args.dataset_id);
-                if (!ds) {
-                    return JSON.stringify({
-                        success: false,
-                        error: `Dataset not found: ${args.dataset_id}. Available: ${catalog.getIds().join(', ')}`
-                    });
-                }
-                const columnsWithValues = ds.columns
-                    .filter(c => c.values?.length > 0)
-                    .map(c => ({ name: c.name, valueCount: c.values.length }));
-                return JSON.stringify({
-                    success: true,
-                    id: ds.id,
-                    title: ds.title,
-                    description: ds.description,
-                    provider: ds.provider,
-                    license: ds.license,
-                    columnsWithValues,
-                    columns: ds.columns,
-                    parquetAssets: ds.parquetAssets.map(a => ({ title: a.title, s3Path: a.s3Path, description: a.description })),
-                    mapLayers: ds.mapLayers.map(a => ({
-                        layerId: `${ds.id}/${a.assetId}`,
-                        title: a.title,
-                        type: a.layerType,
-                        description: a.description
-                    })),
-                    aboutUrl: ds.aboutUrl,
-                    documentationUrl: ds.documentationUrl,
-                    summaries: ds.summaries,
-                });
-            },
-        },
     ];
 }

--- a/app/system-prompt.md
+++ b/app/system-prompt.md
@@ -40,20 +40,19 @@ When calling `filter_by_query`:
 
 **Never** invent or assume categorical field values — not for `set_style` match expressions, not for `set_filter`, not anywhere. Always look them up first:
 
-1. Check the dataset catalog below — columns with descriptions list their coded values and meanings.
-2. If the catalog doesn't cover it, call `get_stac_details(collection_id)` for the full schema.
+1. Call `get_schema(dataset_id)` — it lists coded values for categorical columns.
+2. If `get_schema` doesn't cover it, call `get_stac_details(collection_id)` for the full STAC metadata.
 3. Only as a last resort, fall back to `SELECT DISTINCT field FROM read_parquet(…) LIMIT 100`.
 
 This applies equally when styling (e.g., building a `match` expression to color by `protected_type`) and when filtering.
 
 ## Using dataset paths and schemas
 
-The dataset catalog below lists `read_parquet()` paths and column schemas for every pre-loaded dataset. **These paths are authoritative — never guess, construct, or modify S3 paths.** Use them directly in SQL.
+The dataset catalog below lists `read_parquet()` paths for every pre-loaded dataset. **These paths are authoritative — never guess, construct, or modify S3 paths.** Use them directly in SQL.
 
-If you need to verify column names or types during a long conversation, you can:
-1. Re-read the dataset catalog section above
-2. Call `get_stac_details(collection_id)` for the full schema with descriptions
-3. Run `DESCRIBE SELECT * FROM read_parquet(...)` for a quick schema check
+**Before your first SQL query against a dataset, call `get_schema(dataset_id)`.** It returns column names, types, representative values, and coded value lists — instant, no approval needed. You don't need to call it again for follow-up queries on the same dataset unless you're unsure about column names.
+
+For datasets outside your app config, use `get_stac_details(collection_id)` instead.
 
 ## Recovering from SQL errors
 
@@ -77,5 +76,5 @@ Examples:
 
 ## Available datasets
 
-The section below is automatically injected at runtime with full dataset details including layer IDs, parquet paths, column schemas, and filterable properties. Use `list_datasets` for a quick listing, or `get_stac_details` for datasets outside your app config.
+The section below is automatically injected at runtime with dataset paths and map layer IDs. Call `get_schema(dataset_id)` for column details before writing SQL.
 

--- a/app/system-prompt.md
+++ b/app/system-prompt.md
@@ -34,38 +34,30 @@ Use `filter_by_query` whenever you need to highlight or restrict a map layer to 
 When calling `filter_by_query`:
 - Write `sql` as `SELECT id_col FROM ... WHERE ...` — a plain SELECT returning only the ID column
 - Alias the column in SQL to exactly match `id_property` (e.g., `SELECT GEOID FROM ... WHERE ...` when `id_property` is `"GEOID"`)
-- You still need to call `get_dataset_details` or `get_stac_details` first to get the correct parquet path
+- Use the `read_parquet()` paths from the dataset catalog below
 
 ## Never guess categorical values
 
 **Never** invent or assume categorical field values — not for `set_style` match expressions, not for `set_filter`, not anywhere. Always look them up first:
 
-1. Call `get_dataset_details(dataset_id)` — columns with a `values` array list every valid code and its meaning. Columns without one may still describe codes in the `description` text.
-2. Only if the metadata doesn't cover it, fall back to `SELECT DISTINCT field FROM read_parquet(…) LIMIT 100`.
+1. Check the dataset catalog below — columns with descriptions list their coded values and meanings.
+2. If the catalog doesn't cover it, call `get_stac_details(collection_id)` for the full schema.
+3. Only as a last resort, fall back to `SELECT DISTINCT field FROM read_parquet(…) LIMIT 100`.
 
 This applies equally when styling (e.g., building a `match` expression to color by `protected_type`) and when filtering.
 
-## Before writing any SQL — mandatory first step
+## Using dataset paths and schemas
 
-**STOP. Before writing any SQL query, you MUST call `get_dataset_details(dataset_id)` first.** This returns the exact S3 parquet paths and full column schema. It is instant, requires no user approval, and prevents path errors.
+The dataset catalog below lists `read_parquet()` paths and column schemas for every pre-loaded dataset. **These paths are authoritative — never guess, construct, or modify S3 paths.** Use them directly in SQL.
 
-- **Never guess or construct S3 paths.** S3 bucket names, directory structures, and partition layouts vary arbitrarily — there is no pattern you can infer. Even if you think you recognize a naming convention, you are wrong. **Only** use paths returned by a tool.
-- **Never skip this step**, even if you think you know the path from a previous conversation or from the dataset name.
-- The SQL `query` tool description contains detailed optimization rules (h0 joins, geographic scoping, etc.) — read those when writing queries.
-
-### If `get_dataset_details` returns "not found"
-
-`get_dataset_details` only knows about datasets pre-configured in this app's catalog. If it returns a "not found" error:
-
-1. **Immediately call `get_stac_details(collection_id)`** — this searches the broader STAC catalog and returns the correct parquet paths and schema.
-2. Use only the paths returned by `get_stac_details`. **Do not guess.**
-3. If `get_stac_details` also returns nothing, tell the user the dataset is unavailable — **do not fabricate S3 paths**.
-
-If a query fails with a 404 or "No files found" error, call `get_dataset_details` for that dataset to get the correct path. Do **not** call `list_datasets` — you already know which dataset you need.
+If you need to verify column names or types during a long conversation, you can:
+1. Re-read the dataset catalog section above
+2. Call `get_stac_details(collection_id)` for the full schema with descriptions
+3. Run `DESCRIBE SELECT * FROM read_parquet(...)` for a quick schema check
 
 ## Recovering from SQL errors
 
-If a query fails with a 404, "No files found", or path-not-found error, call `get_dataset_details` with the collection ID you were using to get the correct parquet path. If that returns "not found", call `get_stac_details` as the next fallback. Do **not** call `list_datasets` — you already know which dataset you need. Do **not** guess or modify the S3 path yourself.
+If a query fails with a 404, "No files found", or path-not-found error, call `get_stac_details` with the collection ID to get the correct parquet path. Do **not** guess or modify the S3 path yourself. Do **not** call `list_datasets` — you already know which dataset you need.
 
 ## Before every remote tool call — without exception
 
@@ -85,5 +77,5 @@ Examples:
 
 ## Available datasets
 
-The section below is automatically injected at runtime with full dataset details including layer IDs, parquet paths, column schemas, and filterable properties. Use `list_datasets` or `get_dataset_details` tools for live info.
+The section below is automatically injected at runtime with full dataset details including layer IDs, parquet paths, column schemas, and filterable properties. Use `list_datasets` for a quick listing, or `get_stac_details` for datasets outside your app config.
 


### PR DESCRIPTION
## Summary

- **Remove `get_dataset_details` local tool** — it returned incomplete column schemas (only collection-level `table:columns`, missing per-asset schemas like the hex-specific columns on `svi-2022`). The MCP `get_stac_details` and `get_collection` tools read both levels correctly.
- **Preload MCP `get_collection` at startup** for each configured dataset. Cache structured results on `DatasetCatalog` for prompt generation. Falls back gracefully when MCP is unavailable.
- **Inject `read_parquet()` paths directly into the system prompt** — eliminates the #1 failure mode (hallucinated S3 paths) without requiring a mandatory tool call before every query.
- **Per-asset column schemas in prompt** — from MCP data, so `svi-2022` hex columns show `RPL_THEMES`, `FIPS`, etc. (not the full GeoParquet columns like `ST_ABBR` that don't exist in the hex).
- **Rewrite system-prompt.md** — remove "STOP, call `get_dataset_details` before every SQL query" mandate; paths and schemas are now authoritative in the prompt; `get_stac_details` for interactive refresh.
- **Remove `parquetAssets` from `list_datasets`** output — paths are in the prompt, having them in `list_datasets` without schemas creates a half-correct state that tempts the model to guess columns.

Depends on boettiger-lab/mcp-data-server#57 (`get_collection` tool), merged to dev.

Closes #163, closes #162

## Test plan

- [ ] App loads and map renders (STAC fetch for map layers unchanged)
- [ ] System prompt contains actual `read_parquet('s3://...')` paths for each dataset
- [ ] System prompt contains per-asset column schemas from MCP (verify svi-2022 hex columns)
- [ ] `get_dataset_details` tool no longer appears in tool list
- [ ] `get_stac_details` still works for interactive schema lookup
- [ ] If MCP unavailable at startup: app still loads, prompt falls back to local paths/columns
- [ ] SQL queries work using paths from the system prompt (no 404s)