### PR TITLE
map-tools: surface displayName at tool-call point (fixes #175)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,6 @@ duck.db
 
 # Superpowers brainstorming / mockups
 .superpowers/
+
+# Git worktrees
+.worktrees/

--- a/app/map-manager.js
+++ b/app/map-manager.js
@@ -602,6 +602,19 @@ export class MapManager {
     }
 
     /**
+     * Get [{id, displayName, type}, ...] for all registered layers — used to
+     * build informative layer lists in LLM tool descriptions so the agent can
+     * disambiguate siblings by displayName instead of guessing by ID suffix.
+     */
+    getLayerSummaries() {
+        return [...this.layers.entries()].map(([id, state]) => ({
+            id,
+            displayName: state.displayName,
+            type: state.type,
+        }));
+    }
+
+    /**
      * Get a layer's filterable columns.
      */
     getLayerColumns(layerId) {

--- a/app/map-tools.js
+++ b/app/map-tools.js
@@ -44,15 +44,23 @@ function extractJsonArray(text) {
  * @returns {Array<Object>} Tool definitions
  */
 export function createMapTools(mapManager, catalog, mcpClient) {
-    const allLayerIds = () => mapManager.getLayerIds();
-    const vectorLayerIds = () => mapManager.getVectorLayerIds();
+    const allLayers = () => mapManager.getLayerSummaries();
+    const vectorLayers = () => mapManager.getLayerSummaries().filter(l => l.type === 'vector');
 
-    // Build property docs for vector layers
+    const formatLayerList = (layers) => layers.map(l => `- \`${l.id}\` — ${l.displayName}`).join('\n');
+
+    const pickLayerNudge = 'Pick the layer by displayName semantic match, not by ID suffix. When several layers could plausibly match the user\'s intent (e.g. "districts" could mean congressional, state senate, or state house), choose on displayName — the ID suffix is not a reliable disambiguator.';
+
     return [
         // ---- Map Control Tools ----
         {
             name: 'show_layer',
-            description: `Show/display a layer on the map. Use when the user asks to "show", "display", or "visualize" a layer.\n\nAvailable layers: ${allLayerIds().join(', ')}`,
+            description: `Show/display a layer on the map. Use when the user asks to "show", "display", or "visualize" a layer.
+
+${pickLayerNudge}
+
+Available layers:
+${formatLayerList(allLayers())}`,
             inputSchema: {
                 type: 'object',
                 properties: {
@@ -69,7 +77,10 @@ export function createMapTools(mapManager, catalog, mcpClient) {
 
         {
             name: 'hide_layer',
-            description: `Hide/remove a layer from the map. Use when the user asks to "hide", "remove", or "turn off" a layer.\n\nAvailable layers: ${allLayerIds().join(', ')}`,
+            description: `Hide/remove a layer from the map. Use when the user asks to "hide", "remove", or "turn off" a layer.
+
+Available layers:
+${formatLayerList(allLayers())}`,
             inputSchema: {
                 type: 'object',
                 properties: {
@@ -102,7 +113,10 @@ Filter syntax (use MapLibre expressions — NOT legacy filter arrays):
 
 IMPORTANT: Do NOT use the legacy ["in", "property", val1, val2] form — it is silently ignored in current MapLibre. Always use ["match", ["get", "property"], [...values], true, false] for list membership.
 
-Vector layers: ${vectorLayerIds().join(', ')}`,
+${pickLayerNudge}
+
+Vector layers:
+${formatLayerList(vectorLayers())}`,
             inputSchema: {
                 type: 'object',
                 properties: {
@@ -119,7 +133,12 @@ Vector layers: ${vectorLayerIds().join(', ')}`,
 
         {
             name: 'clear_filter',
-            description: `Remove ALL filters from a layer, showing every feature regardless of properties. Use when the user wants to see everything (e.g. "show all GAP codes", "remove filter", "show everything").\n\nNote: some layers have a config default filter applied at startup. This tool removes that too. Use reset_filter instead if you want to restore the default.\n\nVector layers: ${vectorLayerIds().join(', ')}`,
+            description: `Remove ALL filters from a layer, showing every feature regardless of properties. Use when the user wants to see everything (e.g. "show all GAP codes", "remove filter", "show everything").
+
+Note: some layers have a config default filter applied at startup. This tool removes that too. Use reset_filter instead if you want to restore the default.
+
+Vector layers:
+${formatLayerList(vectorLayers())}`,
             inputSchema: {
                 type: 'object',
                 properties: {
@@ -132,7 +151,10 @@ Vector layers: ${vectorLayerIds().join(', ')}`,
 
         {
             name: 'reset_filter',
-            description: `Reset a layer's filter to its config default (the filter it had when the app loaded). If the layer had no default filter, this clears all filters. Use when the user asks to "reset to default", "restore original view", or "go back to how it was".\n\nVector layers: ${vectorLayerIds().join(', ')}`,
+            description: `Reset a layer's filter to its config default (the filter it had when the app loaded). If the layer had no default filter, this clears all filters. Use when the user asks to "reset to default", "restore original view", or "go back to how it was".
+
+Vector layers:
+${formatLayerList(vectorLayers())}`,
             inputSchema: {
                 type: 'object',
                 properties: {
@@ -155,7 +177,10 @@ Examples:
   Data-driven gradient: { "fill-color": ["interpolate", ["linear"], ["get", "PROP"], 0, "#low", 100, "#high"] }
   Stepped: { "fill-color": ["step", ["get", "PROP"], "#c1", 10, "#c2", 50, "#c3"] }
 
-Available layers: ${allLayerIds().join(', ')}`,
+${pickLayerNudge}
+
+Available layers:
+${formatLayerList(allLayers())}`,
             inputSchema: {
                 type: 'object',
                 properties: {
@@ -169,7 +194,10 @@ Available layers: ${allLayerIds().join(', ')}`,
 
         {
             name: 'reset_style',
-            description: `Reset a layer's style to its default appearance.\n\nAvailable layers: ${allLayerIds().join(', ')}`,
+            description: `Reset a layer's style to its default appearance.
+
+Available layers:
+${formatLayerList(allLayers())}`,
             inputSchema: {
                 type: 'object',
                 properties: {
@@ -233,7 +261,10 @@ Parameters:
 
 IMPORTANT: The sql must return only the id column — no extra columns. Write it as a plain SELECT, not wrapped in array_agg.
 
-Vector layers: ${vectorLayerIds().join(', ')}`,
+${pickLayerNudge}
+
+Vector layers:
+${formatLayerList(vectorLayers())}`,
             inputSchema: {
                 type: 'object',
                 properties: {


### PR DESCRIPTION
## Summary

- Inline each layer's `displayName` alongside its ID in every map-tool description (`show_layer`, `hide_layer`, `set_filter`, `clear_filter`, `reset_filter`, `set_style`, `reset_style`, `filter_by_query`), so the agent can disambiguate sibling layers at the moment it picks one.
- Add a short "pick by displayName, not ID suffix" nudge to the four tools where the agent actively chooses a layer (`show_layer`, `set_filter`, `set_style`, `filter_by_query`).
- New `MapManager.getLayerSummaries()` helper returning `[{id, displayName, type}, ...]`.
- Plus a small chore: `.worktrees/` added to `.gitignore`.

## Why this over the issue's proposal

Issue #175 proposed requiring `get_map_state` before the first layer-tool call in a turn. On closer look, the agent already has every layer's ID **and** displayName in its system prompt via the dataset catalog — but each map-tool description **overrode** that with an ID-only list (`Available layers: id1, id2, ...`), which is the nearest context at the tool-call moment. In TPL's config, four `-pmtiles` siblings differ only by cryptic suffix (`cd`, `county`, `sldl`, `sldu`), and the agent picked `county` for "congressional districts" because it was the closest keyword match to "political boundary".

Forcing `get_map_state` first would:
- add a mandatory LLM round-trip to every map-interaction turn to fix an edge case,
- rely on the agent reliably recognising "first call in a turn" (it doesn't),
- overload a tool whose purpose is current state (visible/filtered), not layer existence.

The cheaper fix is to put the disambiguating info where the agent needs it. No new round-trips; same cost as before.

## Test plan

- [ ] `node --check` passes on both modified files (done locally).
- [ ] Deploy to a `@main` demo app and re-run the motivating query ("Which Texas congressional districts receive the most federal funding for land conservation? Show on map") against a TPL-like layer config. Expected: the agent picks `census-2024-cd/cd-pmtiles` directly without detouring through `county-pmtiles`.
- [ ] Spot-check on an unrelated app (e.g. geo-agent-template) to confirm the new layer lists render as expected and don't blow up token budgets for configs with many layers.

## Out of scope

- The issue's secondary proposal (soft-validate `layers-input.json` `asset.id` against resolved STAC asset keys at startup) is a separate concern — worth a follow-up PR.
- No change to `get_map_state`; it stays a state-introspection tool.

Fixes #175.