### PR TITLE
fix: wrap array_agg in to_json so filter_by_query can parse MCP output

### DIFF
--- a/app/map-tools.js
+++ b/app/map-tools.js
@@ -246,9 +246,12 @@ Vector layers: ${vectorLayerIds().join(', ')}`,
             execute: async (args) => {
                 if (!mcpClient) return JSON.stringify({ success: false, error: 'MCP client not available' });
 
-                // Wrap user SQL to aggregate non-null IDs into a JSON array via DuckDB
+                // Wrap user SQL to aggregate non-null IDs into a JSON array via DuckDB.
+                // to_json() is required because DuckDB's native array display format
+                // (space-separated, no commas — e.g. "[ 1  2  3]") is not valid JSON,
+                // so without it the extractJsonArray() call below fails to parse.
                 const col = args.id_property;
-                const wrappedSql = `SELECT array_agg("${col}") FILTER (WHERE "${col}" IS NOT NULL) FROM (${args.sql}) _filter_subquery`;
+                const wrappedSql = `SELECT to_json(array_agg("${col}") FILTER (WHERE "${col}" IS NOT NULL)) AS ids FROM (${args.sql}) _filter_subquery`;
 
                 let rawResult;
                 try {


### PR DESCRIPTION
## Summary

`filter_by_query` asks DuckDB for an array via `array_agg(...)`, but DuckDB's native array display format is space-separated with no commas (e.g. `[ 6398  6657  6873]`), which `JSON.parse` rejects. This silently breaks the tool: the LLM submits a valid SQL query, the MCP round-trip succeeds, and then `extractJsonArray()` fails to parse the result — surfaced to the LLM as *"Could not parse ID list from query result"*.

Wrapping with `to_json(...)` makes the result cell a valid JSON string literal that `extractJsonArray()` parses cleanly.

## Reproduction

Verified against the DuckDB MCP `query` tool used by geo-agent apps:

```
array_agg(x)                -> '| [ 1  2  3 42  7] |'
to_json(array_agg(x))       -> '| [1,2,3,42,7] |'
```

The first is rejected by `JSON.parse`; the second is accepted.

## Test plan

- [ ] Run an app that uses `filter_by_query` (e.g. geo-agent-template) and verify a non-empty query actually applies the filter to the map
- [ ] Verify the empty-result path still works (the `null`/empty array branches are unchanged)