### PR TITLE
chore: ignore docs/superpowers/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,7 @@ duck.db
 
 # Superpowers brainstorming / mockups
 .superpowers/
+docs/superpowers/
 
 # Git worktrees
 .worktrees/


### PR DESCRIPTION
Design specs and implementation plans under `docs/superpowers/` are internal brainstorming artefacts that shouldn't be committed. `.superpowers/` was already ignored; this adds the `docs/` variant used by the superpowers skill set.