### PR TITLE
fix: collapse chat container height when minimized

### DIFF
--- a/app/chat.css
+++ b/app/chat.css
@@ -28,6 +28,12 @@
     display: none;
 }
 
+/* !important overrides any inline style.height set by the floating-resize
+   drag handle, so the container always shrinks to just the header. */
+#chat-container.collapsed {
+    height: auto !important;
+}
+
 /* ── Resize handle ──────────────────────────────────────── */
 
 .resize-handle {


### PR DESCRIPTION
## Summary
The minimize (−) button on the floating chat window did not actually minimize the window — it only made the contents disappear, leaving an empty box at the same size. The user perceives this as "the input text was cleared".

**Root cause:** `#chat-container` has a hardcoded `height: 620px` (and may carry an even larger inline `style.height` if the user dragged the floating-resize handle). The existing `.collapsed` rule only sets `display: none` on `#chat-messages`, `#chat-input-container`, and `#chat-footer`, so the container itself stays full-height with just the header floating at the top.

**Fix:** add `height: auto !important` to `#chat-container.collapsed` so the box shrinks to wrap its only-remaining child (the header). `!important` is required to beat the inline `style.height` written by `initFloatingResize` in `app/layout-manager.js`.

Sidebar mode is unaffected — it has its own `#sidebar-hide` button that slides the sidebar off-screen, not the floating-mode `#chat-toggle`.

## Test plan
- [ ] Open a deployed app in floating-chat mode, click the `−` button → chat shrinks to just the title bar (anchored bottom-right).
- [ ] Click the same button again → chat restores to its full size.
- [ ] Drag-resize the chat to a custom height first, then minimize → still shrinks to header.
- [ ] After resize + minimize + restore, the user's resized height is preserved.