### PR TITLE
Auto-retry once on transient LLM errors + vitest test suite

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,18 @@
+name: Test
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - run: npm ci
+      - run: npm test

--- a/app/agent.js
+++ b/app/agent.js
@@ -36,6 +36,7 @@ export class Agent {
         this.onToolResults = () => { };
         this.onResponse = () => { };
         this.onError = () => { };
+        this.onRetry = () => { };
     }
 
     /**
@@ -236,7 +237,9 @@ export class Agent {
     }
 
     /**
-     * Call the LLM API.
+     * Call the LLM API, with one auto-retry on transient errors (gateway 5xx,
+     * network blips, client-side timeout). The retry uses a tight 90s timeout
+     * so a still-dead model fails fast instead of burning another 5 minutes.
      */
     async callLLM(endpoint, modelConfig, messages, tools) {
         const payload = {
@@ -247,15 +250,40 @@ export class Agent {
             user: this.sessionId,
         };
 
-        // Share the turn-scoped controller so user-pressed Stop and the
-        // 5-min timeout both route through one abort path. timedOut lets
-        // us distinguish the two when the fetch rejects with AbortError.
-        const controller = this.abortController ?? new AbortController();
+        try {
+            return await this._attemptLLMCall(endpoint, modelConfig, payload, 300000);
+        } catch (error) {
+            if (!this._isTransientLLMError(error)) throw error;
+            if (this.abortController?.signal.aborted) throw error; // user-Stop, don't retry
+
+            console.warn('[Agent] Transient LLM error, retrying with 90s timeout:', error.message);
+            this.onRetry?.(error);
+
+            return await this._attemptLLMCall(endpoint, modelConfig, payload, 90000);
+        }
+    }
+
+    /**
+     * Single attempt of the LLM fetch. Uses a per-attempt internal AbortController
+     * so the timeout doesn't disturb the turn-level abortController (which the
+     * outer loop's withAbort race depends on). User-pressed Stop is forwarded
+     * from this.abortController to the internal controller.
+     */
+    async _attemptLLMCall(endpoint, modelConfig, payload, timeoutMs) {
+        const internal = new AbortController();
         let timedOut = false;
+
+        const userSignal = this.abortController?.signal;
+        const forwardAbort = () => internal.abort();
+        if (userSignal) {
+            if (userSignal.aborted) internal.abort();
+            else userSignal.addEventListener('abort', forwardAbort, { once: true });
+        }
+
         const timeout = setTimeout(() => {
             timedOut = true;
-            controller.abort();
-        }, 300000); // 5 min
+            internal.abort();
+        }, timeoutMs);
 
         try {
             const response = await fetch(endpoint, {
@@ -265,25 +293,45 @@ export class Agent {
                     'Authorization': `Bearer ${modelConfig.api_key}`,
                 },
                 body: JSON.stringify(payload),
-                signal: controller.signal,
+                signal: internal.signal,
             });
 
             if (!response.ok) {
                 const errorText = await response.text();
-                throw new Error(`LLM API error (${response.status}): ${errorText.substring(0, 200)}`);
+                const err = new Error(`LLM API error (${response.status}): ${errorText.substring(0, 200)}`);
+                err.status = response.status;
+                throw err;
             }
 
             const data = await response.json();
             return data.choices[0].message;
         } catch (error) {
             if (error.name === 'AbortError') {
-                if (timedOut) throw new Error('Request timed out after 5 minutes');
+                if (timedOut) {
+                    const err = new Error(`Request timed out after ${Math.round(timeoutMs / 1000)} seconds`);
+                    err.timedOut = true;
+                    throw err;
+                }
                 throw error; // user-pressed Stop — let AbortError propagate
             }
             throw error;
         } finally {
             clearTimeout(timeout);
+            userSignal?.removeEventListener('abort', forwardAbort);
         }
+    }
+
+    /**
+     * Classify an LLM error as transient (worth retrying) or permanent.
+     * Retry on: client timeout, network errors, HTTP 5xx.
+     * Skip on: user-pressed Stop (real AbortError), HTTP 4xx, anything else.
+     */
+    _isTransientLLMError(error) {
+        if (error.name === 'AbortError') return false;
+        if (error.timedOut) return true;
+        if (error.name === 'TypeError') return true;
+        if (typeof error.status === 'number' && error.status >= 500 && error.status < 600) return true;
+        return false;
     }
 
     /**

--- a/app/chat-ui.js
+++ b/app/chat-ui.js
@@ -98,6 +98,10 @@ export class ChatUI {
         this.agent.onToolExecuting = (calls) => this.showToolExecuting(calls);
         this.agent.onToolResults = (results, iter) => this.showToolResults(results, iter);
         this.agent.onError = (err) => this.addMessage('error', err);
+        this.agent.onRetry = (err) => {
+            const reason = err?.timedOut ? 'timeout' : (err?.status ? `HTTP ${err.status}` : 'network error');
+            this.addMessage('system', `Transient ${reason} — retrying with shorter timeout...`);
+        };
 
         // Render welcome message if configured
         this.renderWelcome();

--- a/app/map-tools.js
+++ b/app/map-tools.js
@@ -24,7 +24,7 @@
  * @param {string} text
  * @returns {Array|null}
  */
-function extractJsonArray(text) {
+export function extractJsonArray(text) {
     const start = text.indexOf('[');
     const end = text.lastIndexOf(']');
     if (start === -1 || end === -1 || end <= start) return null;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,15 @@
 {
   "name": "geo-agent",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "geo-agent",
+      "version": "1.0.0",
       "devDependencies": {
-        "vitepress": "^1.6.3"
+        "vitepress": "^1.6.3",
+        "vitest": "^2.1.9"
       }
     },
     "node_modules/@algolia/abtesting": {
@@ -1307,6 +1310,129 @@
         "vue": "^3.2.25"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/@vue/compiler-core": {
       "version": "3.5.30",
       "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.30.tgz",
@@ -1584,6 +1710,16 @@
         "node": ">= 14.0.0"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/birpc": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/birpc/-/birpc-2.9.0.tgz",
@@ -1592,6 +1728,16 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/ccount": {
@@ -1603,6 +1749,23 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/character-entities-html4": {
@@ -1625,6 +1788,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/comma-separated-tokens": {
@@ -1660,6 +1833,34 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/dequal": {
       "version": "2.0.3",
@@ -1704,6 +1905,13 @@
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.21.5",
@@ -1750,6 +1958,16 @@
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/focus-trap": {
       "version": "7.8.0",
@@ -1844,6 +2062,13 @@
       "funding": {
         "url": "https://github.com/sponsors/mesqueeb"
       }
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/magic-string": {
       "version": "0.30.21",
@@ -1992,6 +2217,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/nanoid": {
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
@@ -2021,6 +2253,23 @@
         "emoji-regex-xs": "^1.0.0",
         "regex": "^6.0.1",
         "regex-recursion": "^6.0.2"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
       }
     },
     "node_modules/perfect-debounce": {
@@ -2192,6 +2441,13 @@
         "@types/hast": "^3.0.4"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -2222,6 +2478,20 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stringify-entities": {
       "version": "4.0.4",
@@ -2257,6 +2527,50 @@
       "integrity": "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/trim-lines": {
       "version": "3.0.1",
@@ -2432,6 +2746,29 @@
         }
       }
     },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/vitepress": {
       "version": "1.6.4",
       "resolved": "https://registry.npmjs.org/vitepress/-/vitepress-1.6.4.tgz",
@@ -2474,6 +2811,72 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/vue": {
       "version": "3.5.30",
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.30.tgz",
@@ -2494,6 +2897,23 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/zwitch": {

--- a/package.json
+++ b/package.json
@@ -3,11 +3,14 @@
   "version": "1.0.0",
   "type": "module",
   "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest",
     "docs:dev": "vitepress dev docs",
     "docs:build": "vitepress build docs",
     "docs:preview": "vitepress preview docs"
   },
   "devDependencies": {
-    "vitepress": "^1.6.3"
+    "vitepress": "^1.6.3",
+    "vitest": "^2.1.9"
   }
 }

--- a/test/agent-retry.test.js
+++ b/test/agent-retry.test.js
@@ -1,0 +1,229 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { Agent } from '../app/agent.js';
+
+const stubToolRegistry = {
+    getToolsForLLM: () => [],
+    isLocal: () => true,
+    execute: async () => ({ result: '' }),
+};
+
+const makeAgent = () => {
+    const agent = new Agent(
+        { llm_models: [{ value: 'm', endpoint: 'https://x/v1', api_key: 'k' }] },
+        stubToolRegistry,
+    );
+    return agent;
+};
+
+const okResponse = (content = 'hello') => ({
+    ok: true,
+    json: async () => ({ choices: [{ message: { role: 'assistant', content } }] }),
+});
+
+const errResponse = (status, body = 'oops') => ({
+    ok: false,
+    status,
+    text: async () => body,
+});
+
+describe('Agent._isTransientLLMError', () => {
+    const agent = makeAgent();
+
+    it('returns true for client-side timeout', () => {
+        const err = new Error('Request timed out after 300 seconds');
+        err.timedOut = true;
+        expect(agent._isTransientLLMError(err)).toBe(true);
+    });
+
+    it('returns true for network TypeError', () => {
+        const err = new TypeError('fetch failed');
+        expect(agent._isTransientLLMError(err)).toBe(true);
+    });
+
+    it.each([500, 502, 503, 504, 599])('returns true for HTTP %i', (status) => {
+        const err = new Error('LLM API error');
+        err.status = status;
+        expect(agent._isTransientLLMError(err)).toBe(true);
+    });
+
+    it.each([400, 401, 403, 404, 429])('returns false for HTTP %i', (status) => {
+        const err = new Error('LLM API error');
+        err.status = status;
+        expect(agent._isTransientLLMError(err)).toBe(false);
+    });
+
+    it('returns false for AbortError (user-pressed Stop)', () => {
+        const err = new DOMException('Aborted', 'AbortError');
+        expect(agent._isTransientLLMError(err)).toBe(false);
+    });
+
+    it('returns false for plain Error with no transient signal', () => {
+        expect(agent._isTransientLLMError(new Error('parse error'))).toBe(false);
+    });
+});
+
+describe('Agent._attemptLLMCall', () => {
+    let agent;
+
+    beforeEach(() => {
+        agent = makeAgent();
+        agent.abortController = new AbortController();
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+        vi.useRealTimers();
+    });
+
+    it('returns the LLM message on success', async () => {
+        global.fetch = vi.fn(async () => okResponse('hi'));
+        const msg = await agent._attemptLLMCall('https://x/chat/completions', { api_key: 'k' }, {}, 1000);
+        expect(msg.content).toBe('hi');
+    });
+
+    it('throws timeout error with timedOut=true after timeoutMs', async () => {
+        vi.useFakeTimers();
+        // Hang the fetch indefinitely; we'll abort via the timeout
+        global.fetch = vi.fn((url, opts) => new Promise((_, reject) => {
+            opts.signal.addEventListener('abort', () => {
+                reject(new DOMException('Aborted', 'AbortError'));
+            });
+        }));
+        const settled = agent._attemptLLMCall('https://x', { api_key: 'k' }, {}, 5000)
+            .then(() => null, (e) => e);
+        await vi.advanceTimersByTimeAsync(5000);
+        const error = await settled;
+        expect(error).toMatchObject({
+            timedOut: true,
+            message: expect.stringContaining('timed out after 5 seconds'),
+        });
+    });
+
+    it('throws AbortError (no timedOut) when user-pressed Stop fires during fetch', async () => {
+        global.fetch = vi.fn((url, opts) => new Promise((_, reject) => {
+            opts.signal.addEventListener('abort', () => {
+                reject(new DOMException('Aborted', 'AbortError'));
+            });
+        }));
+        const promise = agent._attemptLLMCall('https://x', { api_key: 'k' }, {}, 60000);
+        // User-pressed Stop forwards through this.abortController
+        agent.abortController.abort();
+        await expect(promise).rejects.toMatchObject({ name: 'AbortError' });
+    });
+
+    it('does not abort the turn-level abortController when timeout fires', async () => {
+        vi.useFakeTimers();
+        global.fetch = vi.fn((url, opts) => new Promise((_, reject) => {
+            opts.signal.addEventListener('abort', () => {
+                reject(new DOMException('Aborted', 'AbortError'));
+            });
+        }));
+        const settled = agent._attemptLLMCall('https://x', { api_key: 'k' }, {}, 1000)
+            .then(() => null, (e) => e);
+        await vi.advanceTimersByTimeAsync(1000);
+        const error = await settled;
+        expect(error).toMatchObject({ timedOut: true });
+        // Critical: turn-level controller stays un-aborted so the outer loop's
+        // withAbort race remains valid for downstream tool execution on retry.
+        expect(agent.abortController.signal.aborted).toBe(false);
+    });
+
+    it('throws err with .status on HTTP non-OK', async () => {
+        global.fetch = vi.fn(async () => errResponse(503, 'no available server'));
+        await expect(
+            agent._attemptLLMCall('https://x', { api_key: 'k' }, {}, 1000),
+        ).rejects.toMatchObject({
+            status: 503,
+            message: expect.stringContaining('503'),
+        });
+    });
+});
+
+describe('Agent.callLLM retry orchestration', () => {
+    let agent;
+
+    beforeEach(() => {
+        agent = makeAgent();
+        agent.abortController = new AbortController();
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('returns first-attempt success without retry', async () => {
+        global.fetch = vi.fn(async () => okResponse('first ok'));
+        const onRetry = vi.fn();
+        agent.onRetry = onRetry;
+
+        const msg = await agent.callLLM('https://x/v1', { api_key: 'k' }, [], []);
+        expect(msg.content).toBe('first ok');
+        expect(global.fetch).toHaveBeenCalledOnce();
+        expect(onRetry).not.toHaveBeenCalled();
+    });
+
+    it('retries on HTTP 503 and returns retry success', async () => {
+        global.fetch = vi.fn()
+            .mockResolvedValueOnce(errResponse(503, 'no available server'))
+            .mockResolvedValueOnce(okResponse('retry ok'));
+        const onRetry = vi.fn();
+        agent.onRetry = onRetry;
+
+        const msg = await agent.callLLM('https://x/v1', { api_key: 'k' }, [], []);
+        expect(msg.content).toBe('retry ok');
+        expect(global.fetch).toHaveBeenCalledTimes(2);
+        expect(onRetry).toHaveBeenCalledOnce();
+        expect(onRetry.mock.calls[0][0]).toMatchObject({ status: 503 });
+    });
+
+    it('retries on TypeError (network) and returns retry success', async () => {
+        global.fetch = vi.fn()
+            .mockRejectedValueOnce(new TypeError('fetch failed'))
+            .mockResolvedValueOnce(okResponse('retry ok'));
+        const onRetry = vi.fn();
+        agent.onRetry = onRetry;
+
+        const msg = await agent.callLLM('https://x/v1', { api_key: 'k' }, [], []);
+        expect(msg.content).toBe('retry ok');
+        expect(onRetry).toHaveBeenCalledOnce();
+    });
+
+    it('does NOT retry on HTTP 401', async () => {
+        global.fetch = vi.fn(async () => errResponse(401, 'unauthorized'));
+        const onRetry = vi.fn();
+        agent.onRetry = onRetry;
+
+        await expect(agent.callLLM('https://x/v1', { api_key: 'k' }, [], []))
+            .rejects.toMatchObject({ status: 401 });
+        expect(global.fetch).toHaveBeenCalledOnce();
+        expect(onRetry).not.toHaveBeenCalled();
+    });
+
+    it('does NOT retry on user-pressed Stop (real AbortError)', async () => {
+        global.fetch = vi.fn((url, opts) => new Promise((_, reject) => {
+            opts.signal.addEventListener('abort', () => {
+                reject(new DOMException('Aborted', 'AbortError'));
+            });
+        }));
+        const onRetry = vi.fn();
+        agent.onRetry = onRetry;
+
+        const promise = agent.callLLM('https://x/v1', { api_key: 'k' }, [], []);
+        agent.abortController.abort();
+        await expect(promise).rejects.toMatchObject({ name: 'AbortError' });
+        expect(onRetry).not.toHaveBeenCalled();
+    });
+
+    it('throws second-attempt error when retry also fails', async () => {
+        global.fetch = vi.fn()
+            .mockResolvedValueOnce(errResponse(502, 'gateway one'))
+            .mockResolvedValueOnce(errResponse(503, 'gateway two'));
+        const onRetry = vi.fn();
+        agent.onRetry = onRetry;
+
+        await expect(agent.callLLM('https://x/v1', { api_key: 'k' }, [], []))
+            .rejects.toMatchObject({ status: 503 });
+        expect(global.fetch).toHaveBeenCalledTimes(2);
+        expect(onRetry).toHaveBeenCalledOnce();
+    });
+});

--- a/test/map-tools.test.js
+++ b/test/map-tools.test.js
@@ -1,0 +1,170 @@
+import { describe, it, expect, vi } from 'vitest';
+import { extractJsonArray, createMapTools } from '../app/map-tools.js';
+
+describe('extractJsonArray', () => {
+    it('parses to_json(array_agg(...)) output', () => {
+        expect(extractJsonArray('[1,2,3]')).toEqual([1, 2, 3]);
+    });
+
+    it('parses array wrapped in markdown table cell', () => {
+        const text = '| ids |\n|-----|\n| [10,20,30] |';
+        expect(extractJsonArray(text)).toEqual([10, 20, 30]);
+    });
+
+    it('parses string IDs', () => {
+        expect(extractJsonArray('["a","b","c"]')).toEqual(['a', 'b', 'c']);
+    });
+
+    it('handles empty array', () => {
+        expect(extractJsonArray('[]')).toEqual([]);
+    });
+
+    // Pin down the bug fixed by #180: DuckDB's native array display format
+    // (space-separated, no commas) is not valid JSON. The fix wraps SQL in
+    // to_json(); this test ensures the parser correctly rejects the raw form
+    // so a future regression in the SQL wrapping layer surfaces here.
+    it('returns null on DuckDB native array display (space-separated, no commas)', () => {
+        expect(extractJsonArray('[ 1  2  3]')).toBeNull();
+    });
+
+    it('returns null when no brackets present', () => {
+        expect(extractJsonArray('no array here')).toBeNull();
+    });
+
+    it('returns null on malformed JSON between brackets', () => {
+        expect(extractJsonArray('[1, 2, ]')).toBeNull();
+    });
+});
+
+describe('filter_by_query', () => {
+    const stubMapManager = () => {
+        const setFilterCalls = [];
+        return {
+            setFilter: vi.fn((layerId, filter) => {
+                setFilterCalls.push({ layerId, filter });
+                return { success: true, featuresInView: 42 };
+            }),
+            getLayerSummaries: () => [
+                { id: 'parcels', displayName: 'Parcels', type: 'vector' },
+            ],
+            _setFilterCalls: setFilterCalls,
+        };
+    };
+
+    const stubCatalog = () => ({
+        records: new Map(),
+    });
+
+    const getFilterTool = (mapManager, mcpClient) => {
+        const tools = createMapTools(mapManager, stubCatalog(), mcpClient);
+        return tools.find(t => t.name === 'filter_by_query');
+    };
+
+    it('returns success with idCount: 0 and does not call setFilter when query returns null', async () => {
+        const mapManager = stubMapManager();
+        const mcpClient = { callTool: vi.fn(async () => '| ids |\n|------|\n| NULL |') };
+        const tool = getFilterTool(mapManager, mcpClient);
+
+        const raw = await tool.execute({ layer_id: 'parcels', sql: 'SELECT id FROM x', id_property: 'id' });
+        const result = JSON.parse(raw);
+
+        expect(result.success).toBe(true);
+        expect(result.idCount).toBe(0);
+        expect(mapManager.setFilter).not.toHaveBeenCalled();
+    });
+
+    it('calls setFilter with [in, [get, col], [literal, ids]] on valid JSON array result', async () => {
+        const mapManager = stubMapManager();
+        const mcpClient = { callTool: vi.fn(async () => '[100,200,300]') };
+        const tool = getFilterTool(mapManager, mcpClient);
+
+        const raw = await tool.execute({ layer_id: 'parcels', sql: 'SELECT id FROM x', id_property: 'OBJECTID' });
+        const result = JSON.parse(raw);
+
+        expect(result.success).toBe(true);
+        expect(result.idCount).toBe(3);
+        expect(mapManager.setFilter).toHaveBeenCalledOnce();
+        const [layerId, filter] = mapManager.setFilter.mock.calls[0];
+        expect(layerId).toBe('parcels');
+        expect(filter).toEqual(['in', ['get', 'OBJECTID'], ['literal', [100, 200, 300]]]);
+    });
+
+    it('returns success with idCount: 0 when query returns empty array', async () => {
+        const mapManager = stubMapManager();
+        const mcpClient = { callTool: vi.fn(async () => '[]') };
+        const tool = getFilterTool(mapManager, mcpClient);
+
+        const raw = await tool.execute({ layer_id: 'parcels', sql: 'SELECT id FROM x', id_property: 'id' });
+        const result = JSON.parse(raw);
+
+        expect(result.success).toBe(true);
+        expect(result.idCount).toBe(0);
+        expect(mapManager.setFilter).not.toHaveBeenCalled();
+    });
+
+    it('returns {success: false, error} when MCP throws', async () => {
+        const mapManager = stubMapManager();
+        const mcpClient = { callTool: vi.fn(async () => { throw new Error('MCP timeout'); }) };
+        const tool = getFilterTool(mapManager, mcpClient);
+
+        const raw = await tool.execute({ layer_id: 'parcels', sql: 'SELECT id FROM x', id_property: 'id' });
+        const result = JSON.parse(raw);
+
+        expect(result.success).toBe(false);
+        expect(result.error).toContain('MCP timeout');
+        expect(mapManager.setFilter).not.toHaveBeenCalled();
+    });
+
+    it('returns parse error when raw result is unparseable (e.g., wrong column name)', async () => {
+        const mapManager = stubMapManager();
+        const mcpClient = { callTool: vi.fn(async () => '[ 1  2  3]') }; // DuckDB native format
+        const tool = getFilterTool(mapManager, mcpClient);
+
+        const raw = await tool.execute({ layer_id: 'parcels', sql: 'SELECT id FROM x', id_property: 'BAD_COL' });
+        const result = JSON.parse(raw);
+
+        expect(result.success).toBe(false);
+        expect(result.error).toContain('Could not parse ID list');
+        expect(mapManager.setFilter).not.toHaveBeenCalled();
+    });
+});
+
+describe('createMapTools smoke test', () => {
+    const stubMapManager = {
+        getLayerSummaries: () => [],
+        setFilter: () => ({ success: true }),
+    };
+    const stubCatalog = { records: new Map() };
+
+    it('returns expected tool names without mcpClient', () => {
+        const tools = createMapTools(stubMapManager, stubCatalog);
+        const names = tools.map(t => t.name).sort();
+        expect(names).toEqual([
+            'clear_filter',
+            'fly_to',
+            'get_map_state',
+            'get_schema',
+            'hide_layer',
+            'list_datasets',
+            'reset_filter',
+            'reset_style',
+            'set_filter',
+            'set_projection',
+            'set_style',
+            'show_layer',
+        ]);
+    });
+
+    it('adds filter_by_query when mcpClient is provided', () => {
+        const tools = createMapTools(stubMapManager, stubCatalog, { callTool: () => null });
+        const names = tools.map(t => t.name);
+        expect(names).toContain('filter_by_query');
+    });
+
+    it('every tool has an execute function', () => {
+        const tools = createMapTools(stubMapManager, stubCatalog, { callTool: () => null });
+        for (const tool of tools) {
+            expect(typeof tool.execute).toBe('function');
+        }
+    });
+});


### PR DESCRIPTION
Closes #194 (auto-retry) and #181 (test suite).

## Summary

**Retry logic (`app/agent.js`, `app/chat-ui.js`)**
- Auto-retry the LLM call once on transient failures: HTTP 5xx, network errors (TypeError), and the client-side 5-min timeout. Skip retry on user-pressed Stop and HTTP 4xx.
- Retry uses a tight **90s** timeout so a still-dead model fails fast (~6s offline + 90s cap ≈ 1.5 min total) rather than another full 5-minute wait.
- New `onRetry` callback surfaces a short "retrying..." system message in chat so the user knows what's happening and can press Stop.

`callLLM` is split into `_attemptLLMCall` (single attempt with internal per-attempt AbortController) plus an outer retry wrapper that classifies errors via `_isTransientLLMError`. The timeout no longer aborts the turn-level `this.abortController` — that controller's signal is captured by the outer loop's `abortPromise` and used by `withAbort` for tool execution / proposal approval, so it must stay valid if a retry succeeds. User-pressed Stop is forwarded from `this.abortController.signal` to the per-attempt internal controller via `addEventListener`.

**Test infra (`vitest`, GitHub Actions, `test/`)**
- Adds `vitest` as a devDependency, `npm test` script, CI workflow (`.github/workflows/test.yml`).
- 40 tests, runs in ~1.5s.

**Test coverage**

`test/agent-retry.test.js` — covers the new retry logic:
- `_isTransientLLMError` classification across 5xx, 4xx, AbortError, TypeError, timedOut
- `_attemptLLMCall` returns on success, throws timeout error after `timeoutMs` (fake timers), throws AbortError on user-Stop, attaches `.status` to HTTP errors, **does not abort the turn-level controller when timeout fires** (the load-bearing invariant)
- `callLLM` retries on 503/TypeError, surfaces `onRetry`, does not retry on 401 or user-Stop, throws second-attempt error on double-fail

`test/map-tools.test.js` — seed tests from #181:
- `extractJsonArray` parses `to_json(array_agg(...))` output, markdown-wrapped cells, string IDs, empty arrays; **returns null on DuckDB's native space-separated array format** (pins down why the #180 fix matters)
- `filter_by_query.execute` with mocked mcpClient + stub mapManager: null result → no `setFilter`, valid array → `['in', ['get', col], ['literal', ids]]`, MCP throws → error response, parse fail → error response
- `createMapTools` smoke: returns expected tool names; adds `filter_by_query` only with mcpClient

## Scope decisions

- Retry tests landed with the retry change (not as a follow-up) so the AbortController/timeout invariants are pinned down by the same PR that introduces them.
- #181's seed tests bundled into the same vitest setup since the infra is the larger commitment.
- Required `extractJsonArray` to be exported (was a module-local function) — only change to its surface.
- Did not add tests for `chat-ui.js` (DOM, out of #181 scope).

## Test plan

- [x] `npm test` — 40/40 pass locally
- [ ] CI runs green on this PR
- [ ] Manual: trigger a 503 (e.g. by editing endpoint to a known-down model) and confirm the "retrying..." message appears
- [ ] Manual: press Stop during the retry and confirm "Query cancelled." appears with no error
