### PR TITLE
tool-registry: inline cached STAC for direct LLM calls (closes #193)

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -193,10 +193,25 @@ async function main() {
         });
     }
 
+    // Inline cached STAC content on LLM-issued direct calls to in-app data,
+    // mirroring what the local get_schema delegate does (see #192). Skips an
+    // upstream fetch on the MCP side. Foreign-catalog calls pass through.
+    const injectInlineStac = (toolName, args) => {
+        if (!args) return args;
+        if (args.catalog_url && args.catalog_url !== catalog.catalogUrl) return args;
+        let id = null;
+        if (toolName === 'get_stac_details') id = args.dataset_id;
+        else if (toolName === 'get_collection') id = args.collection_id;
+        if (!id) return args;
+        const collection = catalog.toStacDict(id);
+        if (!collection) return args;
+        return { ...args, collection };
+    };
+
     // Register remote MCP tools (lazy – tries to list, falls back silently)
     try {
         const mcpTools = await mcp.listTools();
-        toolRegistry.registerRemote(mcpTools, mcp);
+        toolRegistry.registerRemote(mcpTools, mcp, injectInlineStac);
         console.log(`[main] ${mcpTools.length} MCP tools registered`);
     } catch (err) {
         console.warn('[main] Could not list MCP tools (will retry on first use):', err.message);
@@ -214,7 +229,7 @@ async function main() {
                 },
                 required: ['sql_query']
             }
-        }], mcp);
+        }], mcp, injectInlineStac);
     }
 
     /* ── 6. Build system prompt ────────────────────────────────────────── */

--- a/app/tool-registry.js
+++ b/app/tool-registry.js
@@ -39,11 +39,14 @@ export class ToolRegistry {
 
     /**
      * Register remote MCP tools.
-     * 
+     *
      * @param {Array} mcpTools - Tool definitions from MCPClient.getTools()
      * @param {MCPClient} mcpClient - Client instance for execution
+     * @param {Function} [argsRewriter] - Optional (toolName, args) => args hook
+     *   applied before forwarding to MCP. Used to inject cached STAC content
+     *   inline for in-app calls (skips an upstream fetch).
      */
-    registerRemote(mcpTools, mcpClient) {
+    registerRemote(mcpTools, mcpClient, argsRewriter = null) {
         for (const tool of mcpTools) {
             this.tools.set(tool.name, {
                 name: tool.name,
@@ -55,6 +58,7 @@ export class ToolRegistry {
                 },
                 source: 'remote',
                 mcpClient,
+                argsRewriter,
             });
         }
         console.log(`[Tools] Registered ${mcpTools.length} remote tools`);
@@ -141,7 +145,8 @@ export class ToolRegistry {
                 };
             } else {
                 // Remote MCP tool
-                const result = await tool.mcpClient.callTool(tool.name, args);
+                const finalArgs = tool.argsRewriter ? tool.argsRewriter(tool.name, args) : args;
+                const result = await tool.mcpClient.callTool(tool.name, finalArgs);
                 return {
                     success: true,
                     name,

--- a/test/tool-registry.test.js
+++ b/test/tool-registry.test.js
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi } from 'vitest';
+import { ToolRegistry } from '../app/tool-registry.js';
+
+const stubMcpTool = (name = 'get_stac_details') => ({
+    name,
+    description: 'stub',
+    inputSchema: { type: 'object', properties: {}, required: [] },
+});
+
+describe('ToolRegistry argsRewriter', () => {
+    it('forwards original args when no rewriter is registered', async () => {
+        const callTool = vi.fn(async () => 'ok');
+        const reg = new ToolRegistry();
+        reg.registerRemote([stubMcpTool()], { callTool });
+
+        await reg.execute('get_stac_details', { dataset_id: 'foo' });
+
+        expect(callTool).toHaveBeenCalledWith('get_stac_details', { dataset_id: 'foo' });
+    });
+
+    it('passes (toolName, args) to the rewriter and forwards its return value', async () => {
+        const callTool = vi.fn(async () => 'ok');
+        const rewriter = vi.fn((name, args) => ({ ...args, collection: { id: args.dataset_id } }));
+        const reg = new ToolRegistry();
+        reg.registerRemote([stubMcpTool()], { callTool }, rewriter);
+
+        await reg.execute('get_stac_details', { dataset_id: 'foo' });
+
+        expect(rewriter).toHaveBeenCalledWith('get_stac_details', { dataset_id: 'foo' });
+        expect(callTool).toHaveBeenCalledWith('get_stac_details', {
+            dataset_id: 'foo',
+            collection: { id: 'foo' },
+        });
+    });
+
+    it('rewriter return value of original args (no-op) leaves the call untouched', async () => {
+        const callTool = vi.fn(async () => 'ok');
+        const rewriter = vi.fn((name, args) => args);
+        const reg = new ToolRegistry();
+        reg.registerRemote([stubMcpTool()], { callTool }, rewriter);
+
+        await reg.execute('get_stac_details', { dataset_id: 'foo', catalog_url: 'https://other' });
+
+        expect(callTool).toHaveBeenCalledWith('get_stac_details', {
+            dataset_id: 'foo',
+            catalog_url: 'https://other',
+        });
+    });
+
+    it('does not invoke the rewriter for local tools', async () => {
+        const rewriter = vi.fn((name, args) => args);
+        const reg = new ToolRegistry();
+        reg.registerLocal({
+            name: 'local_tool',
+            description: 'local',
+            inputSchema: { type: 'object', properties: {} },
+            execute: async () => 'done',
+        });
+        reg.registerRemote([stubMcpTool()], { callTool: vi.fn() }, rewriter);
+
+        await reg.execute('local_tool', { x: 1 });
+
+        expect(rewriter).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
## Summary

Adds an optional `argsRewriter` hook on `ToolRegistry.registerRemote()`. `main.js` installs a rewriter that, on LLM-issued `get_stac_details` / `get_collection` calls whose `dataset_id` / `collection_id` matches an in-app dataset, injects `catalog.toStacDict(id)` as the `collection` argument before the MCP call.

Mirrors the inline-forwarding pattern #192 added for the local `get_schema` delegate — same upstream-fetch skip, same staleness profile — but applies to direct calls the LLM still makes despite the `get_schema` nudge.

## Why now

Pre-merge log scan (proxy logs, post-#192, 2026-04-30 → 2026-05-08, 9-day window):

- **36 direct STAC calls** (`get_stac_details` + `get_collection` + `browse_stac_catalog`)
- Of those, ~15 had an in-app `dataset_id` / `collection_id` — exactly what this PR intercepts
- Models: minimax-m2 and qwen3 are the main offenders
- Apps: ca-wolves, padus, wetlands, tpl-ca

Latency saving per call is small (hundreds of ms), but the asymmetry with `get_schema` was confusing.

## Foreign-catalog handling

- `args.catalog_url` present and != app catalog → pass through unchanged
- `args.catalog_url` missing or == app catalog, but `dataset_id` not in catalog → pass through (toStacDict returns null)
- Both match → inject `args.collection`

## Out of scope

- **`browse_stac_catalog`**: 11 of the 36 measured calls. Requires retaining `_rawCatalog` on `DatasetCatalog` (not stored today) plus an aggressive-vs-conservative policy for no-arg calls. Worth its own PR; most measured calls are no-arg `{}` which the conservative policy wouldn't catch.

## Test plan

- [ ] Local boot against ca-wolves config; observe `[Tools] Registered N remote tools` log
- [ ] LLM call to `get_stac_details({"dataset_id": "ca-wolves"})` — verify MCP request payload contains inline `collection` and no upstream fetch in mcp-data-server logs
- [ ] LLM call to `get_stac_details({"dataset_id": "ca-wolves", "catalog_url": "https://other.example/catalog.json"})` — verify pass-through (no inline injection)
- [ ] LLM call to `get_stac_details({"dataset_id": "unknown-id"})` — verify pass-through, MCP returns its normal not-found error
- [ ] Chat UI displays the LLM's original args (rewriting is invisible to the user)

Closes #193