### PR TITLE
test: expand coverage to 31.75% + add docs and CI coverage comment

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write  # for the coverage report comment on PRs
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -15,4 +18,7 @@ jobs:
           node-version: '20'
           cache: 'npm'
       - run: npm ci
-      - run: npm test
+      - run: npx vitest run --coverage --coverage.include='app/**' --coverage.reporter=json-summary --coverage.reporter=json --coverage.reporter=text
+      - name: Coverage report comment
+        if: github.event_name == 'pull_request'
+        uses: davelosert/vitest-coverage-report-action@v2

--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,4 @@ docs/superpowers/
 
 # Git worktrees
 .worktrees/
+coverage/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,3 +115,26 @@ All downstream apps serve a static HTML file that loads app code from jsDelivr, 
 - Create a local `app/config.json` with LLM model configs for development
 - `config.json` is in `.gitignore` — never committed (contains API keys)
 
+## Testing
+
+- `npm test` runs the suite; `npm run test:coverage` prints a per-module coverage table.
+- Tests live in `test/`; CI runs them on every PR (`.github/workflows/test.yml`).
+- The test runner is [vitest](https://vitest.dev/). Browser-bound modules are not in jsdom — they're left to manual verification in deployed apps.
+
+### Module coverage status
+
+When a PR touches a covered module, expect tests to change too. When it touches an uncovered one, verify by hand on a representative downstream app.
+
+| Module | Coverage | What changes here should be tested |
+|---|---:|---|
+| `app/transcriber.js` | 100% | `test/transcriber.test.js` — endpoint resolution, error paths, abort signal |
+| `app/mcp-client.js` | 99% | `test/mcp-client.test.js` — connect / reconnect / callTool retry / resources / prompts |
+| `app/tool-registry.js` | 98% | `test/tool-registry.test.js` — registration, dispatch, argsRewriter, schema cleaning |
+| `app/map-tools.js` | 98% | `test/map-tools.test.js` — local-tool execute paths, get_schema MCP delegate |
+| `app/dataset-catalog.js` | 89% | `test/dataset-catalog.test.js` — STAC parsing, layer config shape, prompt rendering |
+| `app/agent.js` | 48% | `test/agent-retry.test.js` — retry / abort / timeout. The conversation loop is uncovered (tested manually). |
+| `app/main.js` | 0% | Bootstrap — verify by loading the app locally. |
+| `app/chat-ui.js`, `app/map-manager.js`, `app/layout-manager.js`, `app/map-draw.js`, `app/h3geo.js`, `app/animation-manager.js`, `app/voice-input.js` | 0% | Browser-bound (DOM, MapLibre, MediaRecorder). Verify visually in a deployed app — no harness yet. |
+
+Overall line coverage is reported on each PR via the coverage workflow.
+

--- a/test/dataset-catalog.test.js
+++ b/test/dataset-catalog.test.js
@@ -391,6 +391,62 @@ describe('DatasetCatalog.extractMapLayers', () => {
         ]);
         expect(layers).toEqual([]);
     });
+
+    it('extracts a GeoJSON asset (by content type) as a vector layer with sourceType=geojson', () => {
+        const layers = cat.extractMapLayers(collectionWithAssets({
+            tracks: { type: 'application/geo+json', href: 'https://x/tracks.geojson' },
+        }), {}, [{ key: 'tracks', assetId: 'tracks', config: {} }]);
+        expect(layers[0].layerType).toBe('vector');
+        expect(layers[0].sourceType).toBe('geojson');
+        expect(layers[0].url).toBe('https://x/tracks.geojson');
+    });
+
+    it('extracts a GeoJSON asset (by .geojson href fallback) when type is missing', () => {
+        const layers = cat.extractMapLayers(collectionWithAssets({
+            tracks: { href: 'https://x/tracks.geojson' },
+        }), {}, [{ key: 'tracks', assetId: 'tracks', config: {} }]);
+        expect(layers[0].sourceType).toBe('geojson');
+    });
+
+    it('versioned config supports raster versions with classification:classes', () => {
+        const layers = cat.extractMapLayers(collectionWithAssets({
+            v2020: {
+                type: 'image/tiff; application=geotiff',
+                href: 'https://x/2020.tif',
+                'raster:bands': [{ 'classification:classes': [{ value: 1 }] }],
+            },
+            v2021: {
+                type: 'image/tiff; application=geotiff',
+                href: 'https://x/2021.tif',
+                'raster:bands': [{ nodata: 0 }],
+            },
+        }), {}, [{
+            key: 'lc',
+            assetId: 'lc',
+            config: {
+                versions: [
+                    { label: '2020', asset_id: 'v2020' },
+                    { label: '2021', asset_id: 'v2021' },
+                ],
+            },
+        }]);
+        expect(layers).toHaveLength(1);
+        expect(layers[0].versions[0].layerType).toBe('raster');
+        expect(layers[0].versions[0].legendClasses).toEqual([{ value: 1 }]);
+        expect(layers[0].versions[1].nodata).toBe(0);
+    });
+
+    it('versioned config supports geojson versions', () => {
+        const layers = cat.extractMapLayers(collectionWithAssets({
+            v1: { type: 'application/geo+json', href: 'https://x/v1.geojson' },
+        }), {}, [{
+            key: 'tracks',
+            assetId: 'tracks',
+            config: { versions: [{ label: 'v1', asset_id: 'v1' }] },
+        }]);
+        expect(layers[0].versions[0].sourceType).toBe('geojson');
+        expect(layers[0].versions[0].layerType).toBe('vector');
+    });
 });
 
 describe('DatasetCatalog.getMapLayerConfigs', () => {
@@ -445,6 +501,56 @@ describe('DatasetCatalog.getMapLayerConfigs', () => {
         expect(tile).toContain('https://titiler.example/cog/tiles');
         expect(tile).toContain('colormap_name=viridis');
         expect(tile).toContain('rescale=0,100');
+    });
+
+    it('flattens a vector geojson layer into a geojson source (no pmtiles:// prefix)', () => {
+        cat.datasets.set('demo', {
+            id: 'demo', title: 'Demo', columns: [],
+            mapLayers: [{
+                assetId: 'tracks', layerType: 'vector', sourceType: 'geojson',
+                title: 'Tracks', url: 'https://x/t.geojson',
+            }],
+        });
+        const [c] = cat.getMapLayerConfigs();
+        expect(c.source).toEqual({ type: 'geojson', data: 'https://x/t.geojson' });
+        expect(c.tracksUrl).toBe('https://x/t.geojson');
+    });
+
+    it('emits per-version configs for a versioned vector layer (one entry, versions[] populated)', () => {
+        cat.datasets.set('vd', {
+            id: 'vd', title: 'V', columns: [],
+            mapLayers: [{
+                assetId: 'basins', layerType: 'vector', title: 'Watersheds',
+                versions: [
+                    { label: 'L3', assetId: 'l3', layerType: 'vector', url: 'https://x/l3.pmtiles', sourceLayer: 'l3' },
+                    { label: 'L4', assetId: 'l4', layerType: 'vector', url: 'https://x/l4.pmtiles', sourceLayer: 'l4' },
+                ],
+                defaultVersionIndex: 1,
+            }],
+        });
+        const [c] = cat.getMapLayerConfigs();
+        expect(c.versions).toHaveLength(2);
+        expect(c.versions[0]).toMatchObject({ label: 'L3', type: 'vector' });
+        expect(c.versions[0].source.url).toBe('pmtiles://https://x/l3.pmtiles');
+        expect(c.defaultVersionIndex).toBe(1);
+    });
+
+    it('emits per-version configs for a versioned raster layer with TiTiler URLs', () => {
+        cat.titilerUrl = 'https://titiler.example';
+        cat.datasets.set('vr', {
+            id: 'vr', title: 'V', columns: [],
+            mapLayers: [{
+                assetId: 'lc', layerType: 'raster', title: 'Landcover',
+                colormap: 'viridis',
+                versions: [
+                    { label: '2020', assetId: 'v2020', layerType: 'raster', cogUrl: 'https://x/2020.tif' },
+                ],
+                defaultVersionIndex: 0,
+            }],
+        });
+        const [c] = cat.getMapLayerConfigs();
+        expect(c.versions[0].type).toBe('raster');
+        expect(c.versions[0].source.tiles[0]).toContain('colormap_name=viridis');
     });
 
     it('emits an inline colormap JSON for categorical raster layers from classification:classes', () => {

--- a/test/map-tools.test.js
+++ b/test/map-tools.test.js
@@ -129,6 +129,90 @@ describe('filter_by_query', () => {
     });
 });
 
+describe('list_datasets', () => {
+    it('returns the catalog ids and titles', () => {
+        const stubMapManager = { getLayerSummaries: () => [], setFilter: () => ({}) };
+        const stubCatalog = {
+            records: new Map(),
+            getAll: () => [
+                { id: 'a', title: 'Alpha' },
+                { id: 'b', title: 'Bravo' },
+            ],
+        };
+        const tools = createMapTools(stubMapManager, stubCatalog);
+        const tool = tools.find(t => t.name === 'list_datasets');
+        const result = JSON.parse(tool.execute());
+        expect(result.success).toBe(true);
+        expect(result.datasets).toEqual([
+            { id: 'a', title: 'Alpha' },
+            { id: 'b', title: 'Bravo' },
+        ]);
+    });
+});
+
+describe('set_projection', () => {
+    it('forwards the requested type to mapManager.setProjection', () => {
+        const calls = [];
+        const stubMapManager = {
+            getLayerSummaries: () => [], setFilter: () => ({}),
+            setProjection: (t) => { calls.push(t); },
+        };
+        const tools = createMapTools(stubMapManager, { records: new Map() });
+        const tool = tools.find(t => t.name === 'set_projection');
+        const result = JSON.parse(tool.execute({ type: 'globe' }));
+        expect(calls).toEqual(['globe']);
+        expect(result.projection).toBe('globe');
+    });
+});
+
+describe('get_schema MCP delegate', () => {
+    const stubMap = { getLayerSummaries: () => [], setFilter: () => ({}) };
+
+    const stubCatalog = (rawStac) => ({
+        records: new Map(),
+        get: (id) => (id === 'demo' ? { id: 'demo' } : null),
+        getIds: () => ['demo'],
+        toStacDict: (id) => (id === 'demo' ? rawStac : null),
+    });
+
+    it('forwards { dataset_id, collection } inline to MCP and returns the result', async () => {
+        const inline = { id: 'demo', stac_version: '1.0.0' };
+        const callTool = vi.fn(async () => 'schema-text');
+        const tools = createMapTools(stubMap, stubCatalog(inline), { callTool });
+        const tool = tools.find(t => t.name === 'get_schema');
+
+        const out = await tool.execute({ dataset_id: 'demo' });
+
+        expect(out).toBe('schema-text');
+        expect(callTool).toHaveBeenCalledWith('get_stac_details', { dataset_id: 'demo', collection: inline });
+    });
+
+    it('returns a structured error when the dataset is not in the catalog', async () => {
+        const tools = createMapTools(stubMap, stubCatalog({}), { callTool: vi.fn() });
+        const tool = tools.find(t => t.name === 'get_schema');
+        const result = JSON.parse(await tool.execute({ dataset_id: 'absent' }));
+        expect(result.success).toBe(false);
+        expect(result.error).toMatch(/not found/i);
+    });
+
+    it('returns a structured error when MCP throws', async () => {
+        const callTool = vi.fn(async () => { throw new Error('mcp down'); });
+        const tools = createMapTools(stubMap, stubCatalog({ id: 'demo' }), { callTool });
+        const tool = tools.find(t => t.name === 'get_schema');
+        const result = JSON.parse(await tool.execute({ dataset_id: 'demo' }));
+        expect(result.success).toBe(false);
+        expect(result.error).toMatch(/mcp down/);
+    });
+
+    it('returns a structured error when no MCP client is configured', async () => {
+        const tools = createMapTools(stubMap, stubCatalog({ id: 'demo' }));
+        const tool = tools.find(t => t.name === 'get_schema');
+        const result = JSON.parse(await tool.execute({ dataset_id: 'demo' }));
+        expect(result.success).toBe(false);
+        expect(result.error).toMatch(/unavailable/i);
+    });
+});
+
 describe('createMapTools smoke test', () => {
     const stubMapManager = {
         getLayerSummaries: () => [],

--- a/test/mcp-client.test.js
+++ b/test/mcp-client.test.js
@@ -1,0 +1,222 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const clientInstances = [];
+
+const buildClientInstance = () => ({
+    connect: vi.fn(async () => {}),
+    close: vi.fn(async () => {}),
+    listTools: vi.fn(async () => ({ tools: [{ name: 'query' }] })),
+    callTool: vi.fn(async () => ({ content: [{ text: 'ok' }] })),
+    readResource: vi.fn(async () => ({ contents: [{ text: 'res-text' }] })),
+    listResources: vi.fn(async () => ({ resources: [{ uri: 'r1' }] })),
+    listPrompts: vi.fn(async () => ({ prompts: [{ name: 'p1' }] })),
+    getPrompt: vi.fn(async () => ({ messages: [{ content: { text: 'hi' } }, { content: { text: 'there' } }] })),
+});
+
+vi.mock('@modelcontextprotocol/sdk/client/index.js', () => ({
+    Client: vi.fn(),
+}));
+
+vi.mock('@modelcontextprotocol/sdk/client/streamableHttp.js', () => ({
+    StreamableHTTPClientTransport: vi.fn(),
+}));
+
+const { MCPClient } = await import('../app/mcp-client.js');
+const { Client } = await import('@modelcontextprotocol/sdk/client/index.js');
+
+const lastClient = () => clientInstances[clientInstances.length - 1];
+
+// Quiet stdout — `[MCP] ...` console.log spam from each connect makes scrolling logs painful.
+let consoleSpies;
+
+beforeEach(() => {
+    clientInstances.length = 0;
+    Client.mockReset();
+    Client.mockImplementation(() => {
+        const instance = buildClientInstance();
+        clientInstances.push(instance);
+        return instance;
+    });
+    consoleSpies = [
+        vi.spyOn(console, 'log').mockImplementation(() => {}),
+        vi.spyOn(console, 'warn').mockImplementation(() => {}),
+        vi.spyOn(console, 'error').mockImplementation(() => {}),
+    ];
+});
+afterEach(() => {
+    consoleSpies.forEach(s => s.mockRestore());
+});
+
+describe('MCPClient connect', () => {
+    it('connects, caches tools, and is idempotent', async () => {
+        const c = new MCPClient('https://mcp.example/mcp');
+        await c.connect();
+        expect(c.isConnected).toBe(true);
+        expect(c.getTools()).toEqual([{ name: 'query' }]);
+
+        const before = clientInstances.length;
+        await c.connect();
+        expect(clientInstances.length).toBe(before);
+    });
+
+    it('deduplicates parallel connect calls', async () => {
+        const c = new MCPClient('https://mcp.example/mcp');
+        await Promise.all([c.connect(), c.connect(), c.connect()]);
+        expect(clientInstances.length).toBe(1);
+    });
+
+    it('on connect failure, marks disconnected and rethrows', async () => {
+        Client.mockImplementationOnce(() => {
+            const instance = buildClientInstance();
+            instance.connect = vi.fn().mockRejectedValueOnce(new Error('boom'));
+            clientInstances.push(instance);
+            return instance;
+        });
+        const c = new MCPClient('https://mcp.example/mcp');
+        await expect(c.connect()).rejects.toThrow('boom');
+        expect(c.isConnected).toBe(false);
+        expect(c.client).toBeNull();
+    });
+});
+
+describe('MCPClient ensureConnected and reconnect', () => {
+    it('listTools health check passes when connection is alive — no reconnect', async () => {
+        const c = new MCPClient('https://mcp/');
+        await c.connect();
+        const before = clientInstances.length;
+        await c.ensureConnected();
+        expect(clientInstances.length).toBe(before);
+    });
+
+    it('on stale connection (listTools throws), reconnects', async () => {
+        vi.useFakeTimers();
+        try {
+            const c = new MCPClient('https://mcp/');
+            await c.connect();
+            lastClient().listTools.mockRejectedValueOnce(new Error('stale'));
+
+            const promise = c.ensureConnected();
+            await vi.advanceTimersByTimeAsync(1000);
+            await promise;
+
+            expect(clientInstances.length).toBe(2);
+            expect(c.isConnected).toBe(true);
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
+    it('throws after maxReconnectAttempts', async () => {
+        const c = new MCPClient('https://mcp/');
+        c.reconnectAttempts = c.maxReconnectAttempts;
+        await expect(c.reconnect()).rejects.toThrow(/unreachable after multiple attempts/i);
+    });
+});
+
+describe('MCPClient callTool', () => {
+    it('returns the text content of the first content part', async () => {
+        const c = new MCPClient('https://mcp/');
+        await c.connect();
+        const out = await c.callTool('query', { sql_query: 'SELECT 1' });
+        expect(out).toBe('ok');
+    });
+
+    it('returns a placeholder string when content text is empty/whitespace', async () => {
+        const c = new MCPClient('https://mcp/');
+        await c.connect();
+        lastClient().callTool.mockResolvedValueOnce({ content: [{ text: '   ' }] });
+        const out = await c.callTool('query', { sql_query: 'X' });
+        expect(out).toMatch(/no data/i);
+    });
+
+    it('throws when result has no content', async () => {
+        const c = new MCPClient('https://mcp/');
+        await c.connect();
+        lastClient().callTool.mockResolvedValueOnce({ content: [] });
+        await expect(c.callTool('q', {})).rejects.toThrow(/no content/i);
+    });
+
+    it('retries once on a network/fetch error and returns the retry result', async () => {
+        vi.useFakeTimers();
+        try {
+            const c = new MCPClient('https://mcp/');
+            await c.connect();
+            // First call on the original client throws a connection error.
+            // The retry path sets connected=false → ensureConnected → reconnect
+            // → builds a fresh Client, whose callTool returns 'after-retry'.
+            lastClient().callTool.mockRejectedValueOnce(new TypeError('fetch failed'));
+            Client.mockImplementationOnce(() => {
+                const instance = buildClientInstance();
+                instance.callTool = vi.fn(async () => ({ content: [{ text: 'after-retry' }] }));
+                clientInstances.push(instance);
+                return instance;
+            });
+
+            const promise = c.callTool('q', {});
+            await vi.advanceTimersByTimeAsync(2000);  // backoff delay
+            const out = await promise;
+            expect(out).toBe('after-retry');
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
+    it('rethrows non-connection errors without retry', async () => {
+        const c = new MCPClient('https://mcp/');
+        await c.connect();
+        lastClient().callTool.mockRejectedValueOnce(new Error('SQL parse error'));
+        await expect(c.callTool('q', {})).rejects.toThrow('SQL parse error');
+    });
+});
+
+describe('MCPClient resources and prompts', () => {
+    it('readResource returns the first content text, empty string if absent', async () => {
+        const c = new MCPClient('https://mcp/');
+        await c.connect();
+        expect(await c.readResource('catalog://list')).toBe('res-text');
+
+        lastClient().readResource.mockResolvedValueOnce({ contents: [] });
+        expect(await c.readResource('catalog://empty')).toBe('');
+    });
+
+    it('listResources returns the resources array', async () => {
+        const c = new MCPClient('https://mcp/');
+        await c.connect();
+        expect(await c.listResources()).toEqual([{ uri: 'r1' }]);
+    });
+
+    it('listPrompts returns the prompts array', async () => {
+        const c = new MCPClient('https://mcp/');
+        await c.connect();
+        expect(await c.listPrompts()).toEqual([{ name: 'p1' }]);
+    });
+
+    it('getPrompt joins all message texts with two newlines', async () => {
+        const c = new MCPClient('https://mcp/');
+        await c.connect();
+        expect(await c.getPrompt('analyst')).toBe('hi\n\nthere');
+    });
+});
+
+describe('MCPClient disconnect and listTools refresh', () => {
+    it('disconnect closes the SDK client and clears state', async () => {
+        const c = new MCPClient('https://mcp/');
+        await c.connect();
+        const cl = lastClient();
+        await c.disconnect();
+        expect(cl.close).toHaveBeenCalled();
+        expect(c.isConnected).toBe(false);
+        expect(c.client).toBeNull();
+    });
+
+    it('listTools() refreshes the in-memory cache', async () => {
+        const c = new MCPClient('https://mcp/');
+        await c.connect();
+        // ensureConnected() consumes one listTools call as its health check;
+        // the second is the actual refresh, so override the default impl.
+        lastClient().listTools.mockResolvedValue({ tools: [{ name: 'fresh1' }, { name: 'fresh2' }] });
+        const out = await c.listTools();
+        expect(out.map(t => t.name)).toEqual(['fresh1', 'fresh2']);
+        expect(c.getTools().map(t => t.name)).toEqual(['fresh1', 'fresh2']);
+    });
+});

--- a/test/transcriber.test.js
+++ b/test/transcriber.test.js
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { Transcriber } from '../app/transcriber.js';
+
+const okResponse = (text) => ({
+    ok: true,
+    json: async () => ({ choices: [{ message: { content: text } }] }),
+});
+
+const errResponse = (status, body = 'oops') => ({
+    ok: false,
+    status,
+    text: async () => body,
+});
+
+describe('Transcriber constructor', () => {
+    it('throws when modelCfg is missing or has no value', () => {
+        expect(() => new Transcriber()).toThrow(/value/);
+        expect(() => new Transcriber({})).toThrow(/value/);
+        expect(() => new Transcriber({ value: '' })).toThrow(/value/);
+    });
+
+    it('accepts a modelCfg with at least a value field', () => {
+        expect(() => new Transcriber({ value: 'whisper-x' })).not.toThrow();
+    });
+});
+
+describe('Transcriber.transcribe', () => {
+    let originalFetch;
+    beforeEach(() => { originalFetch = global.fetch; });
+    afterEach(() => { global.fetch = originalFetch; });
+
+    it('POSTs to <endpoint>/chat/completions with the audio payload and returns trimmed text', async () => {
+        global.fetch = vi.fn(async () => okResponse('  hello there  '));
+        const t = new Transcriber({ value: 'gemma4', endpoint: 'https://llm/v1', api_key: 'k' });
+
+        const out = await t.transcribe({ data: 'BASE64', format: 'wav' });
+
+        expect(out).toBe('hello there');
+        expect(global.fetch).toHaveBeenCalledOnce();
+        const [url, opts] = global.fetch.mock.calls[0];
+        expect(url).toBe('https://llm/v1/chat/completions');
+        expect(opts.headers.Authorization).toBe('Bearer k');
+        const body = JSON.parse(opts.body);
+        expect(body.model).toBe('gemma4');
+        expect(body.messages[1].content[0]).toEqual({
+            type: 'input_audio',
+            input_audio: { data: 'BASE64', format: 'wav' },
+        });
+    });
+
+    it('appends /chat/completions when the configured endpoint omits it', async () => {
+        global.fetch = vi.fn(async () => okResponse('x'));
+        const t = new Transcriber({ value: 'm', endpoint: 'https://llm/v1/' });
+        await t.transcribe({ data: 'b', format: 'wav' });
+        expect(global.fetch.mock.calls[0][0]).toBe('https://llm/v1/chat/completions');
+    });
+
+    it('uses the default endpoint when none is configured', async () => {
+        global.fetch = vi.fn(async () => okResponse('x'));
+        const t = new Transcriber({ value: 'm' });
+        await t.transcribe({ data: 'b', format: 'wav' });
+        expect(global.fetch.mock.calls[0][0]).toBe('https://llm-proxy.nrp-nautilus.io/v1/chat/completions');
+    });
+
+    it('falls back to "EMPTY" Authorization when api_key is absent', async () => {
+        global.fetch = vi.fn(async () => okResponse('x'));
+        const t = new Transcriber({ value: 'm' });
+        await t.transcribe({ data: 'b', format: 'wav' });
+        expect(global.fetch.mock.calls[0][1].headers.Authorization).toBe('Bearer EMPTY');
+    });
+
+    it('throws an error including the HTTP status on a non-OK response', async () => {
+        global.fetch = vi.fn(async () => errResponse(500, 'server boom'));
+        const t = new Transcriber({ value: 'm' });
+        await expect(t.transcribe({ data: 'b', format: 'wav' }))
+            .rejects.toThrow(/500.*server boom/);
+    });
+
+    it('returns empty string when the response has no content', async () => {
+        global.fetch = vi.fn(async () => ({ ok: true, json: async () => ({ choices: [{ message: {} }] }) }));
+        const t = new Transcriber({ value: 'm' });
+        expect(await t.transcribe({ data: 'b', format: 'wav' })).toBe('');
+    });
+
+    it('forwards a user-supplied AbortSignal to fetch', async () => {
+        global.fetch = vi.fn(async () => okResponse('x'));
+        const t = new Transcriber({ value: 'm' });
+        const ctrl = new AbortController();
+        await t.transcribe({ data: 'b', format: 'wav' }, { signal: ctrl.signal });
+        expect(global.fetch.mock.calls[0][1].signal).toBe(ctrl.signal);
+    });
+});


### PR DESCRIPTION
## Summary

Builds on #200. Brings overall line coverage from 23.7% to **31.75%** (+34% relative). 131 tests passing (was 92).

| Module | Before | After |
|---|---:|---:|
| transcriber.js | 0% | **100%** |
| mcp-client.js | 0% | **99%** |
| map-tools.js | 89% | **98%** |
| dataset-catalog.js | 76% | **89%** |
| tool-registry.js | 98% | 98% |

## New test files

- **`test/mcp-client.test.js`** (17 tests). Mocks `@modelcontextprotocol/sdk` Client and StreamableHTTPClientTransport. Covers connect (idempotent, dedupes parallel calls, failure path), ensureConnected (health check, stale-detection → reconnect), maxReconnectAttempts limit, callTool (success, empty content, no content, connection-error retry, non-connection error rethrow), readResource / listResources / listPrompts / getPrompt, disconnect, listTools cache refresh.

- **`test/transcriber.test.js`** (9 tests). Constructor guard, endpoint resolution (with/without trailing `/chat/completions`, default), Bearer auth (with/without api_key), HTTP error mapping, empty content fallback, AbortSignal forwarding.

## Extended

- **`test/dataset-catalog.test.js`** (+7 tests): GeoJSON extraction by type and by .geojson href fallback, versioned raster + versioned geojson in `extractMapLayers`, vector-geojson source shape in `getMapLayerConfigs`, versioned per-layer configs (vector pmtiles + raster TiTiler).
- **`test/map-tools.test.js`** (+6 tests): `list_datasets`, `set_projection`, and the four `get_schema` delegate paths (success, dataset-not-found, MCP throw, no-MCP-client).

## Docs and CI

- **`AGENTS.md` "Testing" section**: per-module coverage table with the test file each module is covered by, plus a note on browser-bound modules that are 0% by design. Reviewers can see at a glance whether a file change should come with test changes.
- **CI**: the test workflow now also runs coverage and posts the table as a PR comment via `davelosert/vitest-coverage-report-action`. Zero maintenance — fires on every PR. No threshold gate (would be too noisy).

## What's still 0% by design

The browser-bound modules: `main.js` (bootstrap), `chat-ui.js` (DOM-heavy), `map-manager.js` / `map-draw.js` / `h3geo.js` / `animation-manager.js` (MapLibre + visual), `layout-manager.js` (DOM), `voice-input.js` (MediaRecorder). These are best verified visually in a downstream app.

## Test plan

- [ ] `npm test` → 131 passing
- [ ] `npm run test:coverage` → table matches numbers above
- [ ] CI green, coverage comment posted on this PR