### PR TITLE
docs: drop @main pin pattern

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ Core library for map-based applications with LLM-powered data analysis. Interact
 - **Data**: STAC catalog → unified dataset records with visual + parquet assets
 - **Analytics**: SQL queries via MCP (Model Context Protocol) to DuckDB on H3-indexed parquet
 - **LLM**: OpenAI-compatible Chat Completions API (multiple models via proxy)
-- **Deployment**: App JS/CSS is loaded from jsDelivr CDN (`@main` or a pinned tag). Downstream apps only need a static HTML file — see the [geo-agent-template](https://github.com/boettiger-lab/geo-agent-template) repo.
+- **Deployment**: App JS/CSS is loaded from jsDelivr CDN. **Every downstream app pins a version tag or commit SHA** — `@main` is no longer used in production or demos. Downstream apps only need a static HTML file — see the [geo-agent-template](https://github.com/boettiger-lab/geo-agent-template) repo.
 
 ## Architecture (app/ modules)
 - `main.js` — Bootstrap: loads config, initializes catalog → map → tools → agent → UI
@@ -97,18 +97,19 @@ The `main` branch is protected: **direct pushes are rejected**. All changes must
 
 ## Deployment
 
-Changes merged to `main` are picked up automatically by downstream apps via jsDelivr CDN — no restarts needed. jsDelivr caches `@main` aggressively; to force immediate refresh, purge the affected files:
+Downstream apps pin a specific jsDelivr ref — either a release tag (`@vX.Y.Z`, preferred) or a commit SHA. `@main` is **not** used by any deployed app; merging a PR here does *not* propagate to downstream apps until those apps bump their pin. Coordinating that bump across the fleet is the job of the private [geo-agent-ops](https://github.com/boettiger-lab/geo-agent-ops) repo.
 
-```
-https://purge.jsdelivr.net/gh/boettiger-lab/geo-agent@main/app/main.js
-https://purge.jsdelivr.net/gh/boettiger-lab/geo-agent@main/app/chat-ui.js
-https://purge.jsdelivr.net/gh/boettiger-lab/geo-agent@main/app/chat.css
-```
+**Release flow:**
+1. Merge feature PRs to `main` here.
+2. Cut a release with `gh release create vX.Y.Z --target main --generate-notes` (or edit notes for migration-relevant changes).
+3. geo-agent-ops opens PRs against each downstream app to bump its pin.
+
+Because every consumer is pinned, `jsdelivr.net` cache purges are normally unnecessary; the only situation that needs them is a SHA-pinned demo where a force-push rewrote the SHA's content (don't do this).
 
 **Live deployments:**
-- [boettiger-lab/geo-agent-template](https://github.com/boettiger-lab/geo-agent-template) → canonical starting point for new apps; deployed to GitHub Pages as live demo
+- [boettiger-lab/geo-agent-template](https://github.com/boettiger-lab/geo-agent-template) → canonical starting point for new apps; deployed to GitHub Pages as live demo (pinned to a tag).
 
-All downstream apps serve a static HTML file that loads app code from jsDelivr, so a `kubectl rollout restart` is not required after merging changes here.
+All downstream apps serve a static HTML file that loads app code from jsDelivr, so a `kubectl rollout restart` is not required when a downstream app bumps its pin.
 
 ## Development
 - Local: `cd app && python -m http.server 8000`

--- a/docs/guide/deployment.md
+++ b/docs/guide/deployment.md
@@ -43,30 +43,15 @@ kubectl rollout restart deployment/my-app
 
 ## CDN versioning
 
-All deployment options load the core library from jsDelivr. Pin to a tagged release for production stability:
+All deployment options load the core library from jsDelivr. **Always pin to a release tag** — `@main` is not supported for deployed apps because changes can land between page loads and break tooling/MCP-server contracts that the app depends on.
 
 ```html
-<!-- Pinned — immutable, recommended for production -->
+<!-- Pinned to a release tag — required for any deployed app -->
 <script type="module"
-  src="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@v3.2.0/app/main.js">
-</script>
-
-<!-- Latest main — use for staging/development -->
-<script type="module"
-  src="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@main/app/main.js">
+  src="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@v3.6.0/app/main.js">
 </script>
 ```
 
-To release a new version: create a GitHub release via `gh release create vX.Y.Z --target main`. Production apps upgrade by changing their tag in `index.html`.
+For short-lived demos previewing an in-flight feature branch, pin to a commit SHA (`@<40-char-sha>`); never use a branch name, since jsDelivr's branch-ref resolution is non-deterministic.
 
-::: tip jsDelivr cache
-jsDelivr caches `@main` aggressively. After merging to `main`, force a refresh by hitting the purge URLs:
-```
-https://purge.jsdelivr.net/gh/boettiger-lab/geo-agent@main/app/main.js
-https://purge.jsdelivr.net/gh/boettiger-lab/geo-agent@main/app/chat-ui.js
-https://purge.jsdelivr.net/gh/boettiger-lab/geo-agent@main/app/style.css
-https://purge.jsdelivr.net/gh/boettiger-lab/geo-agent@main/app/chat.css
-https://purge.jsdelivr.net/gh/boettiger-lab/geo-agent@main/app/sidebar.css
-https://purge.jsdelivr.net/gh/boettiger-lab/geo-agent@main/app/layout-manager.js
-```
-:::
+To release a new version: create a GitHub release via `gh release create vX.Y.Z --target main --generate-notes`. Apps upgrade by changing their tag in `index.html` (coordinated through the geo-agent-ops repo for in-house apps).

--- a/docs/guide/quickstart.md
+++ b/docs/guide/quickstart.md
@@ -35,15 +35,15 @@ The HTML shell loads core JS/CSS from the CDN. The `<body>` only needs two place
 <head>
   <meta charset="utf-8">
   <title>My Map App</title>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@v3.2.0/app/style.css">
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@v3.2.0/app/chat.css">
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@v3.2.0/app/sidebar.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@v3.6.0/app/style.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@v3.6.0/app/chat.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@v3.6.0/app/sidebar.css">
 </head>
 <body>
   <div id="map"></div>
   <div id="menu"></div>
   <script type="module"
-    src="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@v3.2.0/app/main.js">
+    src="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@v3.6.0/app/main.js">
   </script>
 </body>
 </html>
@@ -55,8 +55,10 @@ The HTML shell loads core JS/CSS from the CDN. The `<body>` only needs two place
 
 | CDN reference | When to use |
 |---|---|
-| `@v3.2.0` | Production — pinned, immutable |
-| `@main` | Staging/dev — always latest |
+| `@vX.Y.Z` (e.g. `@v3.6.0`) | Every deployed app — pinned, immutable |
+| `@<40-char-commit-sha>` | Short-lived demo of an in-flight feature branch |
+
+`@main` is **not** used by deployed apps: a merge to `main` can change behavior under a running page, and tooling/MCP contracts evolve between releases. Bump the pin deliberately, never implicitly.
 
 ## layers-input.json
 


### PR DESCRIPTION
## Summary
- AGENTS.md: explicit "every downstream app pins a tag or SHA; `@main` is not used anywhere"; rewrote the Deployment section to describe the geo-agent-ops bump flow.
- docs/guide/deployment.md: removed the `@main` example and the jsDelivr purge tip; updated the pinned-version sample to `@v3.6.0`.
- docs/guide/quickstart.md: replaced the `@main` row in the CDN-reference table with a short paragraph forbidding branch refs; bumped sample to `@v3.6.0`.

Companion to the v3.6.0 release that adds the hex tile tools — apps must bump their pin to pick up new behavior.

## Test plan
- [x] `grep -rn '@main' AGENTS.md app/ docs/guide/` returns no tracked references.
- [ ] VitePress site builds (verify post-merge via CI / preview).