### PR TITLE
fix(hex): drop stale finest_res advice in add_hex_tile_layer description

### DIFF
--- a/app/map-tools.js
+++ b/app/map-tools.js
@@ -261,7 +261,7 @@ Pass the following fields straight through from the register_hex_tiles return va
   - bounds                ← bounds
   - layer_name            ← layer_name (when present; defaults to "layer" otherwise)
 
-Hexes get finer as the user zooms in: the tile server's pyramid serves the appropriate H3 resolution for each zoom level automatically. If the user wants a coarser overall view, re-run \`register_hex_tiles\` with a smaller \`finest_res\`.
+Hexes get finer as the user zooms in: the tile server's pyramid serves the appropriate H3 resolution for each zoom level automatically. If the user wants a coarser overall view, re-run \`register_hex_tiles\` with the SQL projected to a coarser resolution by wrapping the first column in \`h3_cell_to_parent(<h3_col>, <target_res>)\` — the server auto-detects the H3 resolution from that column.
 
 IMPORTANT: The tile_url must be the exact tile_url_template returned by register_hex_tiles — the tool rejects other URLs.
 


### PR DESCRIPTION
## Summary

- `app/map-tools.js:264` told the LLM to "re-run `register_hex_tiles` with a smaller `finest_res`" for a coarser view, but mcp-data-server PR [#126](https://github.com/boettiger-lab/mcp-data-server/pull/126) hid `finest_res` from the MCP schema. The agent would either hallucinate the parameter or give the user invalid advice.
- Rewrote the sentence to point at the supported approach: project upstream in SQL via `h3_cell_to_parent(<h3_col>, <target_res>)`. The server auto-detects the H3 resolution from the first column.

Closes #203.

## Test plan

- [ ] Manually verify with a downstream app: ask the agent for a "coarser overall view" of a hex layer and confirm it now reaches for a SQL projection rather than a `finest_res` argument.