### PR TITLE
feat(tooltip): add set_tooltip / reset_tooltip local tools

### DIFF
--- a/app/map-manager.js
+++ b/app/map-manager.js
@@ -230,9 +230,11 @@ export class MapManager {
                     }
                 }
 
-                // Tooltip
-                if (tooltipFields && tooltipFields.length > 0) {
-                    this._wireTooltip(vMapLayerId, tooltipFields);
+                // Wire tooltip on every vector version. The handler reads
+                // `tooltipFields` from the logical layer's state record each
+                // event, so set_tooltip can update fields at runtime.
+                if (v.type === 'vector') {
+                    this._wireTooltip(vMapLayerId, layerId);
                 }
 
                 return {
@@ -260,7 +262,8 @@ export class MapManager {
                 defaultFilter: defaultFilter || null,
                 columns: columns || [],
                 defaultPaint: { ...(paint || {}) },
-                tooltipFields: tooltipFields || null,
+                tooltipFields: tooltipFields ? [...tooltipFields] : null,
+                defaultTooltipFields: tooltipFields ? [...tooltipFields] : null,
                 colormap: colormap || null,
                 rescale: rescale || null,
                 legendLabel: legendLabel || null,
@@ -355,7 +358,8 @@ export class MapManager {
             defaultFilter: defaultFilter || null,
             columns: columns || [],
             defaultPaint: { ...(paint || {}) },
-            tooltipFields: tooltipFields || null,
+            tooltipFields: tooltipFields ? [...tooltipFields] : null,
+            defaultTooltipFields: tooltipFields ? [...tooltipFields] : null,
             colormap: colormap || null,
             rescale: rescale || null,
             legendLabel: legendLabel || null,
@@ -363,9 +367,11 @@ export class MapManager {
             legendClasses: legendClasses || null,
         });
 
-        // Wire hover tooltip if fields are declared
-        if (tooltipFields && tooltipFields.length > 0) {
-            this._wireTooltip(mapLayerId, tooltipFields);
+        // Wire tooltip handler on every vector layer (even those without
+        // declared fields) so set_tooltip can attach fields at runtime. The
+        // handler bails when the state record's tooltipFields is null/empty.
+        if (type === 'vector') {
+            this._wireTooltip(mapLayerId, layerId);
         }
     }
 
@@ -397,6 +403,7 @@ export class MapManager {
             columns: [],
             defaultPaint: { ...(paint || {}) },
             tooltipFields: null,
+            defaultTooltipFields: null,
             animation: null,   // filled in below
         };
         this.layers.set(layerId, state);
@@ -571,12 +578,15 @@ export class MapManager {
             defaultFilter: null,
             defaultPaint: { ...paint },
             tooltipFields: null,
+            defaultTooltipFields: null,
             colormap: null,
             rescale: null,
             legendLabel: null,
             legendType: null,
             legendClasses: null,
         });
+
+        this._wireTooltip(layerId, layerId);
 
         if (fitBounds && Array.isArray(bounds) && bounds.length === 4) {
             const [w, s, e, n] = bounds;
@@ -676,6 +686,38 @@ export class MapManager {
         const state = this.layers.get(layerId);
         if (!state) return { success: false, error: `Unknown layer: ${layerId}` };
         return this.setFilter(layerId, state.defaultFilter);
+    }
+
+    // ---- Tooltip ----
+
+    /**
+     * Set which feature properties appear in the hover tooltip for a vector
+     * layer. Pass an empty array to disable the tooltip.
+     */
+    setTooltip(layerId, fields) {
+        const state = this.layers.get(layerId);
+        if (!state) return { success: false, error: `Unknown layer: ${layerId}` };
+        if (state.type !== 'vector') {
+            return { success: false, error: `Tooltips only apply to vector layers; '${layerId}' is ${state.type}` };
+        }
+        if (!Array.isArray(fields) || !fields.every(f => typeof f === 'string')) {
+            return { success: false, error: `fields must be an array of strings` };
+        }
+        state.tooltipFields = fields.length > 0 ? [...fields] : null;
+        return { success: true, layer: layerId, displayName: state.displayName, tooltipFields: state.tooltipFields };
+    }
+
+    /**
+     * Reset tooltip fields to the layer's config default (or disable if no default).
+     */
+    resetTooltip(layerId) {
+        const state = this.layers.get(layerId);
+        if (!state) return { success: false, error: `Unknown layer: ${layerId}` };
+        if (state.type !== 'vector') {
+            return { success: false, error: `Tooltips only apply to vector layers; '${layerId}' is ${state.type}` };
+        }
+        state.tooltipFields = state.defaultTooltipFields ? [...state.defaultTooltipFields] : null;
+        return { success: true, layer: layerId, displayName: state.displayName, tooltipFields: state.tooltipFields };
     }
 
     // ---- Styling ----
@@ -1149,11 +1191,13 @@ export class MapManager {
 
     // ---- Utilities ----
 
-    _wireTooltip(mapLayerId, tooltipFields) {
+    _wireTooltip(mapLayerId, layerId) {
         this.map.on('mousemove', mapLayerId, (e) => {
+            const fields = this.layers.get(layerId)?.tooltipFields;
+            if (!fields || fields.length === 0) return;
             if (!e.features || e.features.length === 0) return;
             const props = e.features[0].properties;
-            const rows = tooltipFields
+            const rows = fields
                 .filter(f => props[f] !== undefined && props[f] !== null && props[f] !== '')
                 .map(f => `<tr><th>${f}</th><td>${this._formatTooltipValue(f, props[f])}</td></tr>`)
                 .join('');

--- a/app/map-tools.js
+++ b/app/map-tools.js
@@ -166,6 +166,49 @@ ${formatLayerList(vectorLayers())}`,
         },
 
         {
+            name: 'set_tooltip',
+            description: `Set which feature properties appear in the hover tooltip for a vector layer. Pass an array of property names; the tooltip displays them in order. Pass an empty array to disable the tooltip for that layer.
+
+Use when the user asks to "show X on hover", "include Y in the tooltip", or "stop showing the tooltip".
+
+Property names must exactly match the feature properties in the vector tiles. Call get_schema first if you need to see available property names — the agent's catalog may list them, but get_schema returns the live set. Unknown names render nothing (no error).
+
+${pickLayerNudge}
+
+Vector layers:
+${formatLayerList(vectorLayers())}`,
+            inputSchema: {
+                type: 'object',
+                properties: {
+                    layer_id: { type: 'string', description: 'Vector layer ID' },
+                    fields: {
+                        type: 'array',
+                        items: { type: 'string' },
+                        description: 'Property names to display, in order. Pass [] to disable the tooltip.'
+                    },
+                },
+                required: ['layer_id', 'fields'],
+            },
+            execute: (args) => JSON.stringify(mapManager.setTooltip(args.layer_id, args.fields)),
+        },
+
+        {
+            name: 'reset_tooltip',
+            description: `Reset a layer's tooltip fields to its config default (the fields it had when the app loaded). If the layer had no default tooltip, this disables the tooltip. Use when the user asks to "reset the tooltip", "restore the default hover", or "go back to how it was".
+
+Vector layers:
+${formatLayerList(vectorLayers())}`,
+            inputSchema: {
+                type: 'object',
+                properties: {
+                    layer_id: { type: 'string', description: 'Vector layer ID' },
+                },
+                required: ['layer_id'],
+            },
+            execute: (args) => JSON.stringify(mapManager.resetTooltip(args.layer_id)),
+        },
+
+        {
             name: 'set_style',
             description: `Update a layer's paint/style properties. Provide MapLibre paint properties.
 

--- a/test/map-manager.hex.test.js
+++ b/test/map-manager.hex.test.js
@@ -32,6 +32,8 @@ function createMockMap() {
         setFilter() {},
         setPaintProperty() {},
         queryRenderedFeatures() { return []; },
+        on() {},
+        off() {},
         fitBounds(bounds, options) { fitBoundsCalls.push({ bounds, options }); },
         // Introspection helpers (not real MapLibre API)
         _sources: sources,

--- a/test/map-tools.test.js
+++ b/test/map-tools.test.js
@@ -213,6 +213,50 @@ describe('get_schema MCP delegate', () => {
     });
 });
 
+describe('set_tooltip / reset_tooltip', () => {
+    const stubMapManager = () => ({
+        setTooltip: vi.fn((layerId, fields) => ({ success: true, layer: layerId, tooltipFields: fields })),
+        resetTooltip: vi.fn((layerId) => ({ success: true, layer: layerId, tooltipFields: ['name'] })),
+        getLayerSummaries: () => [
+            { id: 'parcels', displayName: 'Parcels', type: 'vector' },
+            { id: 'irrecoverable', displayName: 'Irrecoverable Carbon', type: 'raster' },
+        ],
+    });
+    const stubCatalog = { records: new Map() };
+
+    const getTool = (name) => {
+        const mapManager = stubMapManager();
+        const tools = createMapTools(mapManager, stubCatalog);
+        return { tool: tools.find(t => t.name === name), mapManager };
+    };
+
+    it('set_tooltip forwards (layer_id, fields) to mapManager.setTooltip', () => {
+        const { tool, mapManager } = getTool('set_tooltip');
+        const result = JSON.parse(tool.execute({ layer_id: 'parcels', fields: ['name', 'gap_code'] }));
+        expect(result.success).toBe(true);
+        expect(mapManager.setTooltip).toHaveBeenCalledWith('parcels', ['name', 'gap_code']);
+    });
+
+    it('set_tooltip with empty array disables the tooltip', () => {
+        const { tool, mapManager } = getTool('set_tooltip');
+        tool.execute({ layer_id: 'parcels', fields: [] });
+        expect(mapManager.setTooltip).toHaveBeenCalledWith('parcels', []);
+    });
+
+    it('reset_tooltip forwards layer_id to mapManager.resetTooltip', () => {
+        const { tool, mapManager } = getTool('reset_tooltip');
+        const result = JSON.parse(tool.execute({ layer_id: 'parcels' }));
+        expect(result.success).toBe(true);
+        expect(mapManager.resetTooltip).toHaveBeenCalledWith('parcels');
+    });
+
+    it('set_tooltip description lists vector layers only', () => {
+        const { tool } = getTool('set_tooltip');
+        expect(tool.description).toMatch(/Parcels/);
+        expect(tool.description).not.toMatch(/Irrecoverable Carbon/);
+    });
+});
+
 describe('createMapTools smoke test', () => {
     const stubMapManager = {
         getLayerSummaries: () => [],
@@ -234,9 +278,11 @@ describe('createMapTools smoke test', () => {
             'remove_hex_tile_layer',
             'reset_filter',
             'reset_style',
+            'reset_tooltip',
             'set_filter',
             'set_projection',
             'set_style',
+            'set_tooltip',
             'show_layer',
         ]);
     });


### PR DESCRIPTION
Closes #196.

## Summary
- Adds two local tools — `set_tooltip(layer_id, fields)` and `reset_tooltip(layer_id)` — so the agent can change a vector layer's hover-tooltip fields at runtime, mirroring `set_filter` / `reset_filter`.
- `set_tooltip(_, [])` disables the tooltip; `reset_tooltip` restores config defaults (or disables if none).
- Errors cleanly on raster / animation layers.

## Implementation
- `_wireTooltip` now takes `(mapLayerId, layerId)` and reads `tooltipFields` from the layer state record on each event (late binding), so `set_tooltip` only mutates state — no listener swap. This mirrors how `defaultFilter` and the live filter live alongside each other.
- Every vector layer gets a tooltip handler wired up-front (handler bails when `tooltipFields` is null/empty), so `set_tooltip` works on any vector layer — including dynamic hex tiles, which previously had no hover info.
- Each layer record now carries a `defaultTooltipFields` snapshot for `reset_tooltip`.

## Test plan
- [x] `npm test` — 160 passing (added 4 dispatch tests for the new tools)
- [x] `npm run test:coverage` — `map-tools.js` stays at ~96% (new execute paths are covered; the drop from 98% reflects file-size dilution, not lost coverage)
- [x] Manual verification on a deployed app:
  - [x] "Show the watershed name on hover" → tooltip updates immediately
  - [x] "Stop showing the tooltip" → tooltip disabled
  - [x] "Reset the tooltip" → defaults restored
  - [x] Calling on a raster layer returns a clear error