### PR TITLE
fix(mcp): retry listTools at startup and refresh registry on reconnect

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -208,14 +208,40 @@ async function main() {
         return { ...args, collection };
     };
 
-    // Register remote MCP tools (lazy – tries to list, falls back silently)
+    // Register remote MCP tools. The initial listTools() can time out when
+    // the MCP pod is cold-starting; retry a few times before falling back to
+    // a minimal hardcoded `query` tool. If the fallback fires, the
+    // onReconnect hook below will refresh the registry once the transport
+    // finally connects.
+    const listMcpToolsWithRetry = async (attempts = 3) => {
+        let lastErr;
+        for (let i = 0; i < attempts; i++) {
+            try {
+                return await mcp.listTools();
+            } catch (err) {
+                lastErr = err;
+                const delay = Math.min(2000 * Math.pow(2, i), 8000);
+                console.warn(`[main] listTools attempt ${i + 1}/${attempts} failed: ${err.message}`);
+                if (i < attempts - 1) await new Promise(r => setTimeout(r, delay));
+            }
+        }
+        throw lastErr;
+    };
+
+    mcp.setOnReconnect((tools) => {
+        toolRegistry.clearRemote();
+        toolRegistry.registerRemote(tools, mcp, injectInlineStac);
+        console.log(`[main] Refreshed MCP tools after reconnect: ${tools.length} tools`);
+    });
+
     try {
-        const mcpTools = await mcp.listTools();
+        const mcpTools = await listMcpToolsWithRetry();
         toolRegistry.registerRemote(mcpTools, mcp, injectInlineStac);
         console.log(`[main] ${mcpTools.length} MCP tools registered`);
     } catch (err) {
-        console.warn('[main] Could not list MCP tools (will retry on first use):', err.message);
-        // Manually register query tool with known schema so LLM always has it
+        console.warn('[main] Could not list MCP tools after retries (will refresh on reconnect):', err.message);
+        // Hardcoded fallback so the LLM always has at least the query tool.
+        // The onReconnect hook replaces this entry once the transport connects.
         toolRegistry.registerRemote([{
             name: 'query',
             description: 'Execute a read-only SQL query against a DuckDB database that is pre-loaded with H3 geospatial extensions, spatial functions, and httpfs for accessing remote parquet data. The database supports partitioned hive-style parquet files on S3.',

--- a/app/mcp-client.js
+++ b/app/mcp-client.js
@@ -20,6 +20,18 @@ export class MCPClient {
         this.reconnectAttempts = 0;
         this.maxReconnectAttempts = 3;
         this._connectPromise = null;
+        this._onReconnect = null;
+    }
+
+    /**
+     * Register a callback that fires after a successful reconnect (not on
+     * initial connect). Receives the freshly-listed tools array so the
+     * consumer can refresh its registry.
+     *
+     * @param {(tools: Array) => void | Promise<void>} cb
+     */
+    setOnReconnect(cb) {
+        this._onReconnect = cb;
     }
 
     /**
@@ -102,6 +114,14 @@ export class MCPClient {
 
         await new Promise(r => setTimeout(r, delay));
         await this.connect();
+
+        if (this._onReconnect) {
+            try {
+                await this._onReconnect(this.tools);
+            } catch (err) {
+                console.warn('[MCP] onReconnect callback threw:', err.message);
+            }
+        }
     }
 
     /**

--- a/app/tool-registry.js
+++ b/app/tool-registry.js
@@ -65,6 +65,17 @@ export class ToolRegistry {
     }
 
     /**
+     * Drop every remote tool from the registry. Use before re-registering
+     * after a reconnect to avoid leaving stale entries when the server's
+     * tool list has changed.
+     */
+    clearRemote() {
+        for (const [name, tool] of this.tools) {
+            if (tool.source === 'remote') this.tools.delete(name);
+        }
+    }
+
+    /**
      * Get all tools formatted for the OpenAI Chat Completions API.
      * @returns {Array} tools[] array
      */

--- a/test/mcp-client.test.js
+++ b/test/mcp-client.test.js
@@ -198,6 +198,64 @@ describe('MCPClient resources and prompts', () => {
     });
 });
 
+describe('MCPClient onReconnect', () => {
+    it('fires after a successful reconnect with the freshly-listed tools', async () => {
+        vi.useFakeTimers();
+        try {
+            const c = new MCPClient('https://mcp/');
+            await c.connect();
+
+            const cb = vi.fn();
+            c.setOnReconnect(cb);
+
+            // Health check throws → forces reconnect → fresh client returns 2 tools
+            lastClient().listTools.mockRejectedValueOnce(new Error('stale'));
+            Client.mockImplementationOnce(() => {
+                const instance = buildClientInstance();
+                instance.listTools = vi.fn(async () => ({
+                    tools: [{ name: 'browse_stac_catalog' }, { name: 'query' }],
+                }));
+                clientInstances.push(instance);
+                return instance;
+            });
+
+            const promise = c.ensureConnected();
+            await vi.advanceTimersByTimeAsync(1000);
+            await promise;
+
+            expect(cb).toHaveBeenCalledTimes(1);
+            expect(cb.mock.calls[0][0].map(t => t.name)).toEqual(['browse_stac_catalog', 'query']);
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
+    it('does NOT fire on the initial connect', async () => {
+        const c = new MCPClient('https://mcp/');
+        const cb = vi.fn();
+        c.setOnReconnect(cb);
+        await c.connect();
+        expect(cb).not.toHaveBeenCalled();
+    });
+
+    it('swallows callback errors so reconnect still succeeds', async () => {
+        vi.useFakeTimers();
+        try {
+            const c = new MCPClient('https://mcp/');
+            await c.connect();
+            c.setOnReconnect(() => { throw new Error('registry boom'); });
+            lastClient().listTools.mockRejectedValueOnce(new Error('stale'));
+
+            const promise = c.ensureConnected();
+            await vi.advanceTimersByTimeAsync(1000);
+            await expect(promise).resolves.toBeUndefined();
+            expect(c.isConnected).toBe(true);
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+});
+
 describe('MCPClient disconnect and listTools refresh', () => {
     it('disconnect closes the SDK client and clears state', async () => {
         const c = new MCPClient('https://mcp/');

--- a/test/tool-registry.test.js
+++ b/test/tool-registry.test.js
@@ -243,6 +243,47 @@ describe('ToolRegistry executeAll', () => {
     });
 });
 
+describe('ToolRegistry clearRemote', () => {
+    it('drops only remote tools and leaves local tools intact', () => {
+        const reg = new ToolRegistry();
+        reg.registerLocal({
+            name: 'local_a',
+            description: '', inputSchema: { type: 'object', properties: {} },
+            execute: () => 'ok',
+        });
+        reg.registerRemote([
+            { name: 'remote_a', description: '', inputSchema: { type: 'object', properties: {} } },
+            { name: 'remote_b', description: '', inputSchema: { type: 'object', properties: {} } },
+        ], { callTool: vi.fn() });
+
+        expect(reg.getNames().sort()).toEqual(['local_a', 'remote_a', 'remote_b']);
+        reg.clearRemote();
+        expect(reg.getNames()).toEqual(['local_a']);
+    });
+
+    it('is a no-op when no remote tools are registered', () => {
+        const reg = new ToolRegistry();
+        reg.registerLocal({
+            name: 'l',
+            description: '', inputSchema: { type: 'object', properties: {} },
+            execute: () => 'ok',
+        });
+        reg.clearRemote();
+        expect(reg.getNames()).toEqual(['l']);
+    });
+
+    it('lets a subsequent registerRemote install a fresh tool set', () => {
+        const reg = new ToolRegistry();
+        reg.registerRemote([{ name: 'old_only', description: '', inputSchema: { type: 'object', properties: {} } }], { callTool: vi.fn() });
+        reg.clearRemote();
+        reg.registerRemote([
+            { name: 'new_a', description: '', inputSchema: { type: 'object', properties: {} } },
+            { name: 'new_b', description: '', inputSchema: { type: 'object', properties: {} } },
+        ], { callTool: vi.fn() });
+        expect(reg.getNames().sort()).toEqual(['new_a', 'new_b']);
+    });
+});
+
 describe('ToolRegistry registerLocal duplicate handling', () => {
     it('warns on overwrite but accepts the new tool', () => {
         const reg = new ToolRegistry();


### PR DESCRIPTION
## Summary

Fixes #206. When the initial `mcp.listTools()` at app startup timed out, the `ToolRegistry` was permanently frozen with only the hardcoded `query` tool for the session — `register_hex_tiles`, `get_collection`, `browse_stac_catalog`, and `get_stac_details` were silently dropped even after the MCP transport reconnected.

Three layered changes:

- **`app/main.js`** — wrap the initial `listTools()` in a bounded retry (3 attempts, exponential backoff capped at 8s) before falling back. Catches the common cold-start case where the MCP pod is still warming up.
- **`app/mcp-client.js`** — add `setOnReconnect(cb)` hook. The callback fires after a successful `reconnect()` (not on the initial `connect()`) and receives the freshly-listed tools. Callback errors are caught and warned, never break the reconnect.
- **`app/tool-registry.js`** — add `clearRemote()` so refreshing remote tools doesn't accumulate stale entries if the server's tool list has changed.

`main.js` wires the onReconnect callback to `clearRemote()` + `registerRemote()`, so even if every initial retry fails, the registry self-heals on the next transport reconnect.

## Test plan

- [x] `npm test` — 166 tests pass, including new coverage for `clearRemote()`, `setOnReconnect()` fires on reconnect / not on initial connect, and callback errors don't break reconnect.
- [ ] Manual: load padus app while the MCP pod is cold; confirm console shows either successful initial registration, a successful retry, or `[main] Refreshed MCP tools after reconnect: 5 tools`.
- [ ] Manual: proxy logs show `tools_count: 20` (15 local + 5 MCP), not 16.
- [ ] Manual: agent can call `register_hex_tiles` without claiming it's missing.

## Related

- #205 — independent issue about per-call MCP timeout duration, not addressed here.