### PR TITLE
fix(chat-ui): sanitize marked output with DOMPurify

### DIFF
--- a/app/chat-ui.js
+++ b/app/chat-ui.js
@@ -558,7 +558,8 @@ export class ChatUI {
                 ? reasoningText.trim()
                 : this.describeToolCalls(calls);
             if (desc) {
-                const descHtml = typeof marked !== 'undefined' ? marked.parse(desc) : this.escapeHtml(desc);
+                const rawDesc = typeof marked !== 'undefined' ? marked.parse(desc) : this.escapeHtml(desc);
+                const descHtml = typeof DOMPurify !== 'undefined' ? DOMPurify.sanitize(rawDesc) : rawDesc;
                 html += `<div class="tool-reasoning">${descHtml}</div>`;
             }
         }
@@ -690,7 +691,8 @@ export class ChatUI {
     addMarkdown(role, md) {
         const el = document.createElement('div');
         el.className = `chat-message ${role}`;
-        el.innerHTML = typeof marked !== 'undefined' ? marked.parse(md) : md;
+        const rawHtml = typeof marked !== 'undefined' ? marked.parse(md) : md;
+        el.innerHTML = typeof DOMPurify !== 'undefined' ? DOMPurify.sanitize(rawHtml) : rawHtml;
         this.messagesEl.appendChild(el);
 
         // Highlight code blocks


### PR DESCRIPTION
## Summary

- Wraps `marked.parse()` output through `DOMPurify.sanitize()` at the two `innerHTML` paths in **app/chat-ui.js** that render untrusted content:
  - `addMarkdown` (line 693) — all assistant messages
  - `showToolProposal` (line 561) — tool-reasoning description
- Follows the existing graceful-degradation pattern (`typeof DOMPurify !== 'undefined'`) — if DOMPurify is not loaded, behavior is unchanged
- Downstream apps opt in by adding one `<script>` tag alongside `marked` and `highlight.js`:
  ```html
  <script src="https://cdn.jsdelivr.net/npm/dompurify@3/dist/purify.min.js"></script>
  ```

## Root cause

The rendering pipeline trusts LLM output structurally — `marked.parse()` feeds directly to `innerHTML` with no sanitization layer. This holds when the model provider is trusted, but geo-agent's architecture (configurable MCP servers, pluggable LLM providers) extends the trust perimeter beyond the operator's control. Behavioral controls (prompt design, model selection) don't protect against injection through tool responses or adversarial providers. The fix adds a structural enforcement point that holds regardless of content source.

## Related

- Extends `chat-ui-review-notes.md` item 4, which flags the tool-reasoning path — `addMarkdown` has the same pattern and is the larger attack surface

## Test plan

- [x] `npm test` — 166 tests pass, no regressions
- [ ] Verify in a deployed app: assistant markdown renders correctly with DOMPurify loaded
- [ ] Verify graceful fallback: app works identically without DOMPurify loaded