### PR TITLE
fix(map-manager): propagate property failure to top-level success (#161)

### DIFF
--- a/app/map-manager.js
+++ b/app/map-manager.js
@@ -742,7 +742,12 @@ export class MapManager {
             }
         }
 
-        return { success: true, layer: layerId, displayName: state.displayName, updates: results };
+        const anySucceeded = results.length === 0 || results.some(r => r.success);
+        const result = { success: anySucceeded, layer: layerId, displayName: state.displayName, updates: results };
+        if (!anySucceeded) {
+            result.error = 'All property updates failed — see individual update results for details';
+        }
+        return result;
     }
 
     /**


### PR DESCRIPTION
## Summary

- `setStyle()` in **app/map-manager.js** returned `{ success: true }` even when every `setPaintProperty` call threw — the model saw top-level success and moved on
- Now `success` reflects whether at least one property was actually set
- When all properties fail, includes an `error` message directing the model to inspect individual `updates[]` results
- Addresses the success-masking bug only — stroke support and property documentation from #161 are left as a separate decision

## Root cause

`setStyle()` reports success based on reaching the end of its execution path, not on whether any property was actually set. The agent receives affirmative feedback from a failed action — it can't distinguish "all properties updated" from "all properties failed" and has no signal to retry or escalate. The fix aligns the reported outcome with the actual outcome so the agent can self-correct.

## Test plan

- [x] `npm test` — 166 tests pass, no regressions
- [ ] Verify in a deployed app: `set_style` with invalid property names returns `{ success: false }` and the model retries or reports the failure