### PR TITLE
feat(catalog): warn on asset ID mismatches at startup (#177)

### DIFF
--- a/app/dataset-catalog.js
+++ b/app/dataset-catalog.js
@@ -248,7 +248,10 @@ export class DatasetCatalog {
                     const versions = [];
                     for (const v of config.versions) {
                         const vAsset = stacAssets[v.asset_id];
-                        if (!vAsset) continue;
+                        if (!vAsset) {
+                            console.warn(`[Catalog] ${collection.id}: versioned asset "${v.asset_id}" not found in STAC. Available keys: ${Object.keys(stacAssets).join(', ') || '(none)'}`);
+                            continue;
+                        }
                         const vType = vAsset.type || '';
                         if (vType.includes('pmtiles')) {
                             versions.push({
@@ -319,7 +322,10 @@ export class DatasetCatalog {
 
                 // ── Standard (non-versioned) asset ──
                 const asset = stacAssets[assetId];
-                if (!asset) continue;
+                if (!asset) {
+                    console.warn(`[Catalog] ${collection.id}: configured asset "${assetId}" not found in STAC. Available keys: ${Object.keys(stacAssets).join(', ') || '(none)'}`);
+                    continue;
+                }
 
                 const type = asset.type || '';
 

--- a/test/dataset-catalog.test.js
+++ b/test/dataset-catalog.test.js
@@ -362,13 +362,17 @@ describe('DatasetCatalog.extractMapLayers', () => {
         expect(layers[0].defaultVersionIndex).toBe(1);
     });
 
-    it('skips a versioned config whose asset_ids are all missing', () => {
+    it('skips a versioned config whose asset_ids are all missing (with warning)', () => {
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
         const layers = cat.extractMapLayers(collectionWithAssets({}), {}, [{
             key: 'basins',
             assetId: 'basins',
             config: { versions: [{ label: 'X', asset_id: 'absent' }] },
         }]);
         expect(layers).toHaveLength(0);
+        expect(warnSpy).toHaveBeenCalledOnce();
+        expect(warnSpy.mock.calls[0][0]).toContain('absent');
+        warnSpy.mockRestore();
     });
 
     it('respects alias — same STAC asset can produce multiple logical layers', () => {
@@ -385,11 +389,58 @@ describe('DatasetCatalog.extractMapLayers', () => {
         expect(layers[1].defaultFilter).toEqual(['==', 'kind', 'easement']);
     });
 
-    it('skips assets whose STAC entry is missing in filtered mode', () => {
+    it('skips assets whose STAC entry is missing in filtered mode (with warning)', () => {
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
         const layers = cat.extractMapLayers(collectionWithAssets({}), {}, [
             { key: 'ghost', assetId: 'ghost', config: {} },
         ]);
         expect(layers).toEqual([]);
+        expect(warnSpy).toHaveBeenCalledOnce();
+        expect(warnSpy.mock.calls[0][0]).toContain('ghost');
+        warnSpy.mockRestore();
+    });
+
+    it('warns when a configured asset ID is not found in STAC (#177)', () => {
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        cat.extractMapLayers(
+            collectionWithAssets({ real: { type: 'application/vnd.pmtiles', href: 'https://x/r.pmtiles' } }),
+            {},
+            [{ key: 'ghost', assetId: 'ghost', config: {} }],
+        );
+        expect(warnSpy).toHaveBeenCalledOnce();
+        expect(warnSpy.mock.calls[0][0]).toContain('ghost');
+        expect(warnSpy.mock.calls[0][0]).toContain('real');
+        warnSpy.mockRestore();
+    });
+
+    it('warns for each missing versioned asset ID (#177)', () => {
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        cat.extractMapLayers(
+            collectionWithAssets({ l3: { type: 'application/vnd.pmtiles', href: 'https://x/l3.pmtiles' } }),
+            {},
+            [{
+                key: 'basins', assetId: 'basins', config: {
+                    versions: [
+                        { label: 'L3', asset_id: 'l3' },
+                        { label: 'L4', asset_id: 'missing-l4' },
+                    ],
+                },
+            }],
+        );
+        expect(warnSpy).toHaveBeenCalledOnce();
+        expect(warnSpy.mock.calls[0][0]).toContain('missing-l4');
+        warnSpy.mockRestore();
+    });
+
+    it('does not warn when all configured asset IDs match STAC keys', () => {
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        cat.extractMapLayers(
+            collectionWithAssets({ tiles: { type: 'application/vnd.pmtiles', href: 'https://x/t.pmtiles' } }),
+            {},
+            [{ key: 'tiles', assetId: 'tiles', config: {} }],
+        );
+        expect(warnSpy).not.toHaveBeenCalled();
+        warnSpy.mockRestore();
     });
 
     it('extracts a GeoJSON asset (by content type) as a vector layer with sourceType=geojson', () => {


### PR DESCRIPTION
Fixes #177.

## Summary

- `extractMapLayers()` in **app/dataset-catalog.js** silently dropped configured assets whose IDs didn't match any STAC collection key — config drift surfaced as "wrong layer shown" or "tool says layer not found" downstream
- Now emits one `console.warn` per offending entry, naming the collection, the configured ID, and the available STAC keys
- Covers both standard and versioned (`versions[].asset_id`) asset forms
- Warn, not error — apps with forward-referenced assets still boot normally

## Root cause

Asset IDs in the catalog config are validated only at runtime, when a user requests the layer. Between deploy and use, STAC collections can change (renamed assets, updated versions), creating silent divergence between declared config and actual catalog state. The fix adds a boot-time integrity check — the system verifies its own assumptions on startup rather than failing silently downstream.

## Tests added

Three new tests in **test/dataset-catalog.test.js**:

- `warns when a configured asset ID is not found in STAC` — standard asset
- `warns for each missing versioned asset ID` — versioned asset
- `does not warn when all configured asset IDs match STAC keys` — no spurious warning

Two existing tests updated to assert warnings fire (previously leaked to stderr).

## Test plan

- [x] `npm test` — 169 tests pass (166 existing + 3 new, no regressions)
- [ ] Verify in a deployed app: boot with a deliberately wrong asset ID, confirm warning in dev console