### PR TITLE
fix(mcp): bump callTool timeout to 10 min for large hex tile builds

### DIFF
--- a/app/mcp-client.js
+++ b/app/mcp-client.js
@@ -156,7 +156,7 @@ export class MCPClient {
         await this.ensureConnected();
 
         try {
-            const result = await this.client.callTool({ name, arguments: args }, undefined, { timeout: 300000 });
+            const result = await this.client.callTool({ name, arguments: args }, undefined, { timeout: 600000 });
             this.reconnectAttempts = 0;
 
             if (result.content && result.content.length > 0) {
@@ -181,7 +181,7 @@ export class MCPClient {
                 this.connected = false;
                 await this.ensureConnected();
                 // Retry once
-                const result = await this.client.callTool({ name, arguments: args }, undefined, { timeout: 300000 });
+                const result = await this.client.callTool({ name, arguments: args }, undefined, { timeout: 600000 });
                 if (result.content?.[0]?.text) return result.content[0].text;
                 throw new Error('No content in MCP response after retry');
             }


### PR DESCRIPTION
## Summary
- Bump the MCP `callTool` timeout from 300s → 600s in both the primary call and the post-reconnect retry path (`app/mcp-client.js`).
- Aligns the client-side MCP cap with the upstream LLM request budget so big builds like `register_hex_tiles` on h8 global datasets stop hitting an artificial 5-min cliff while the server-side build is still progressing.

## Test plan
- [x] `npm test` (166 tests pass)
- [ ] In the padus app, ask the agent to `regenerate the carbon hex tiles` and confirm:
  - [ ] Tool call latency runs past 5 min without an MCP timeout error
  - [ ] `metadata.json` appears at `s3://public-output/hex/<new-hash>/` once the build finishes
  - [ ] The returned tile URL renders on the map

Closes #205