### PR TITLE
fix(chat-ui): wrap long input queries in an auto-growing textarea

### DIFF
--- a/app/chat-ui.js
+++ b/app/chat-ui.js
@@ -58,6 +58,7 @@ export class ChatUI {
                 this.handleSend();
             }
         });
+        this.inputEl.addEventListener('input', () => this._autoResizeInput());
 
         // Wire collapse toggle
         this.toggleBtn?.addEventListener('click', () => {
@@ -195,6 +196,7 @@ export class ChatUI {
                     this.inputEl.value = existing
                         ? `${existing} ${transcript}`.trim()
                         : transcript;
+                    this._autoResizeInput();
                 } finally {
                     this.inputEl.placeholder = prevPlaceholder;
                     this.inputEl.disabled = false;
@@ -239,6 +241,7 @@ export class ChatUI {
         el.querySelectorAll('.welcome-example-btn').forEach(btn => {
             btn.addEventListener('click', () => {
                 this.inputEl.value = btn.textContent;
+                this._autoResizeInput();
                 this.inputEl.focus();
             });
         });
@@ -439,6 +442,11 @@ export class ChatUI {
     /*  Send handler                                                       */
     /* ------------------------------------------------------------------ */
 
+    _autoResizeInput() {
+        this.inputEl.style.height = 'auto';
+        this.inputEl.style.height = this.inputEl.scrollHeight + 'px';
+    }
+
     async handleSend() {
         const text = this.inputEl.value.trim();
         if (!text) return;
@@ -455,6 +463,7 @@ export class ChatUI {
         this.sendBtn.textContent = '■';
         this.sendBtn.title = 'Stop';
         this.inputEl.value = '';
+        this._autoResizeInput();
 
         // Esc anywhere on the page while busy → stop.
         const escHandler = (e) => {

--- a/app/chat.css
+++ b/app/chat.css
@@ -146,6 +146,7 @@
     border-top: 1px solid rgba(255, 255, 255, 0.15);
     display: flex;
     gap: 8px;
+    align-items: flex-end;
 }
 
 #chat-input {
@@ -156,6 +157,11 @@
     background: rgba(255, 255, 255, 0.45);
     color: #333;
     font-size: 14px;
+    font-family: inherit;
+    line-height: 1.4;
+    resize: none;
+    max-height: 8em;
+    overflow-y: auto;
 }
 
 #chat-input:focus {

--- a/app/layout-manager.js
+++ b/app/layout-manager.js
@@ -55,10 +55,10 @@ function buildFloatingLayout(_appConfig, title) {
     const messages = el('div', { id: 'chat-messages' });
 
     const inputContainer = el('div', { id: 'chat-input-container' });
-    const input = el('input', {
+    const input = el('textarea', {
         id: 'chat-input',
-        type: 'text',
         placeholder: 'Ask about the data\u2026',
+        rows: '1',
         autocomplete: 'off',
     });
     const mic = el('button', {
@@ -126,10 +126,10 @@ function buildSidebarLayout(appConfig, title) {
 
     // Input row
     const inputContainer = el('div', { id: 'chat-input-container' });
-    const input = el('input', {
+    const input = el('textarea', {
         id: 'chat-input',
-        type: 'text',
         placeholder: 'Ask about the data…',
+        rows: '1',
         autocomplete: 'off',
     });
     const mic = el('button', {

--- a/app/sidebar.css
+++ b/app/sidebar.css
@@ -113,6 +113,7 @@ body.sidebar-mode #chat-messages {
 body.sidebar-mode #chat-input-container {
     flex: 0 0 auto;
     display: flex;
+    align-items: flex-end;
     gap: 6px;
     padding: 8px 12px;
     border-top: 1px solid rgba(0, 0, 0, 0.1);


### PR DESCRIPTION
## Summary
- Swap the chat input from `<input type="text">` to `<textarea rows="1">` in both the floating and sidebar layouts so long user queries wrap instead of scrolling horizontally.
- Add a small `_autoResizeInput()` helper in `chat-ui.js` that grows the textarea with content (scrollHeight-based) and is invoked from the user `input` event plus the three programmatic value-set sites (send-clear, voice transcript, welcome prompt-button).
- Cap growth at `max-height: 8em` with vertical scrolling beyond that; `align-items: flex-end` on the input container keeps the send/mic buttons anchored at the bottom as the textarea grows. Enter still sends — `Shift+Enter` now inserts a newline naturally via the existing keydown handler (which already early-returned on `shiftKey`).

## Test plan
- [x] `npm test` — 166/166 pass (no regressions in covered modules)
- [ ] Manual browser verification (chat-ui is uncovered per AGENTS.md):
  - [ ] Floating mode: type a long single-line query, confirm it wraps and the textarea grows up to ~8em then scrolls
  - [ ] Sidebar mode: same check
  - [ ] Send-clear resets the textarea height
  - [ ] Welcome prompt-button click sizes the textarea to fit the prompt
  - [ ] Voice transcript append (if a transcription model is configured) sizes correctly
  - [ ] Enter sends, Shift+Enter inserts a newline

Closes #149