### PR TITLE
fix(map-tools): document set_style paint props and surface partial failures

### DIFF
--- a/app/map-manager.js
+++ b/app/map-manager.js
@@ -742,7 +742,17 @@ export class MapManager {
             }
         }
 
-        return { success: true, layer: layerId, displayName: state.displayName, updates: results };
+        const failed = results.filter(r => !r.success).map(r => r.property);
+        const layerType = this.map.getLayer?.(state.mapLayerId)?.type;
+        return {
+            success: failed.length === 0,
+            layer: layerId,
+            displayName: state.displayName,
+            updates: results,
+            ...(failed.length > 0 && {
+                error: `${failed.length}/${results.length} property update(s) failed: ${failed.join(', ')}. Layer type is "${layerType}" — use ${layerType}-prefixed paint properties (see set_style tool description for the supported set).`,
+            }),
+        };
     }
 
     /**

--- a/app/map-tools.js
+++ b/app/map-tools.js
@@ -210,9 +210,15 @@ ${formatLayerList(vectorLayers())}`,
 
         {
             name: 'set_style',
-            description: `Update a layer's paint/style properties. Provide MapLibre paint properties.
+            description: `Update a layer's paint/style properties. Provide MapLibre paint properties — every property name carries a layer-type prefix (\`fill-\`, \`line-\`, \`circle-\`, \`raster-\`).
 
 IMPORTANT: For categorical coloring (e.g., a "match" expression), never guess or assume valid values. Check the dataset catalog in your system prompt for documented coded values, or call get_stac_details for full column details. Only fall back to SELECT DISTINCT via SQL if the metadata doesn't cover it.
+
+Supported paint properties by MapLibre layer type:
+  fill (polygons):   fill-color, fill-opacity, fill-outline-color, fill-pattern
+  line (lines, polygon outlines): line-color, line-width, line-opacity, line-blur, line-dasharray
+  circle (points):   circle-color, circle-radius, circle-opacity, circle-stroke-color, circle-stroke-width
+  raster:            raster-opacity, raster-brightness-min, raster-brightness-max, raster-contrast, raster-saturation, raster-hue-rotate
 
 Examples:
   Simple: { "fill-color": "red", "fill-opacity": 0.5 }

--- a/test/map-manager.style.test.js
+++ b/test/map-manager.style.test.js
@@ -1,0 +1,61 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { MapManager } from '../app/map-manager.js';
+
+/**
+ * Bare MapManager mock — exposes only the surface setStyle touches.
+ * The setPaintProperty stub fails for any property that doesn't start with
+ * the recorded layer type, mirroring MapLibre's behaviour where e.g.
+ * `stroke-color` on a fill layer throws.
+ */
+function createManager(layerType = 'fill') {
+    const sources = new Map();
+    const layers = new Map([[ 'layer-A', { id: 'layer-A', type: layerType } ]]);
+    const map = {
+        addSource: (id, s) => sources.set(id, s),
+        getSource: (id) => sources.get(id) || null,
+        addLayer: (l) => layers.set(l.id, l),
+        getLayer: (id) => layers.get(id) || null,
+        setPaintProperty(id, prop) {
+            const t = layers.get(id)?.type;
+            if (!t || !prop.startsWith(`${t}-`)) {
+                throw new Error(`layer "${id}" doesn't support "${prop}"`);
+            }
+        },
+        on() {}, off() {},
+    };
+    const mm = Object.create(MapManager.prototype);
+    mm.map = map;
+    mm.layers = new Map([[
+        'A',
+        { mapLayerId: 'layer-A', displayName: 'A', defaultPaint: {} },
+    ]]);
+    return mm;
+}
+
+describe('MapManager.setStyle', () => {
+    let mm;
+    beforeEach(() => { mm = createManager('fill'); });
+
+    it('returns success=true when every property applies', () => {
+        const r = mm.setStyle('A', { 'fill-color': 'red', 'fill-opacity': 0.5 });
+        expect(r.success).toBe(true);
+        expect(r.updates).toHaveLength(2);
+        expect(r.updates.every(u => u.success)).toBe(true);
+        expect(r.error).toBeUndefined();
+    });
+
+    it('returns success=false when any property fails and names the offenders', () => {
+        const r = mm.setStyle('A', { 'fill-color': 'red', 'stroke-color': 'blue', 'stroke-width': 2 });
+        expect(r.success).toBe(false);
+        expect(r.error).toMatch(/stroke-color.*stroke-width/);
+        expect(r.error).toMatch(/Layer type is "fill"/);
+        expect(r.updates.find(u => u.property === 'fill-color').success).toBe(true);
+        expect(r.updates.find(u => u.property === 'stroke-color').success).toBe(false);
+    });
+
+    it('returns success=false with an unknown-layer error when the id is missing', () => {
+        const r = mm.setStyle('missing', { 'fill-color': 'red' });
+        expect(r.success).toBe(false);
+        expect(r.error).toMatch(/Unknown layer/);
+    });
+});


### PR DESCRIPTION
## Summary
The agent was calling `set_style` with SVG-style property names like `stroke-color` / `stroke-width` — which MapLibre rejects because every paint property carries a layer-type prefix (`fill-*`, `line-*`, `circle-*`, `raster-*`). Two failure modes compounded:
1. The `set_style` tool description didn't enumerate the supported property set, so the model guessed plausible-sounding names from general MapLibre/CSS knowledge.
2. `MapManager.setStyle` returned `success: true` at the top level even when every per-property `setPaintProperty` call had thrown, so the agent never noticed and never retried.

This PR fixes both halves:
- **Tool description (`app/map-tools.js`):** add a per-layer-type list of supported paint properties (fill / line / circle / raster) so the model has the right names to reach for.
- **Top-level success (`app/map-manager.js`):** `setStyle` now flips `success` to reflect whether any update failed, and surfaces a top-level `error` that names the offending properties plus the layer's actual MapLibre type — giving the agent enough to self-correct.

## Test plan
- [x] `npm test` — 169/169 pass (3 new tests in `test/map-manager.style.test.js` cover all-pass, partial-fail, and unknown-layer paths)
- [ ] Manual check in a downstream app (e.g. padus): ask the agent to "style this layer with a red stroke" and confirm
  - [ ] Either it picks a correctly-prefixed property (`fill-outline-color`, `line-color`, `circle-stroke-color`) on the first attempt, or
  - [ ] If it still guesses wrong, the returned error names the bad property + layer type and the model self-corrects on the next call

Closes #161