### PR TITLE
feat(chat): per-turn agent timeline + surface model reasoning

### DIFF
--- a/app/agent.js
+++ b/app/agent.js
@@ -31,6 +31,7 @@ export class Agent {
         // Event callbacks (set by chat-ui.js)
         this.onThinkingStart = () => { };
         this.onThinkingEnd = () => { };
+        this.onReasoning = () => { };
         this.onToolProposal = async () => ({ approved: true }); // auto-approve by default
         this.onToolExecuting = () => { };
         this.onToolResults = () => { };
@@ -131,6 +132,11 @@ export class Agent {
             } finally {
                 this.onThinkingEnd();
             }
+            // Surface reasoning before pushing back into the loop. Strips
+            // <think> blocks from content and drops reasoning_content from
+            // the message so it isn't re-sent on subsequent turns.
+            const reasoning = this.extractReasoning(message);
+            if (reasoning) this.onReasoning(reasoning, iterations);
             turnMessages.push(message);
 
             // Check for tool calls
@@ -332,6 +338,36 @@ export class Agent {
         if (error.name === 'TypeError') return true;
         if (typeof error.status === 'number' && error.status >= 500 && error.status < 600) return true;
         return false;
+    }
+
+    /**
+     * Extract reasoning from a model message (mutates: strips reasoning_content
+     * and inline <think> blocks so they don't get re-sent on the next turn).
+     * Returns the combined reasoning text, or null if none was present.
+     *
+     * Handles two shapes:
+     *   1. `reasoning_content` field (vLLM/qwen3/DeepSeek thinking-mode template)
+     *   2. Inline <think>...</think> blocks in `content` (qwen3 default, others)
+     */
+    extractReasoning(message) {
+        const parts = [];
+
+        if (typeof message.reasoning_content === 'string' && message.reasoning_content.trim()) {
+            parts.push(message.reasoning_content.trim());
+        }
+        delete message.reasoning_content;
+
+        if (typeof message.content === 'string' && message.content.includes('<think>')) {
+            const pattern = /<think>([\s\S]*?)<\/think>/gi;
+            let m;
+            while ((m = pattern.exec(message.content)) !== null) {
+                const text = m[1].trim();
+                if (text) parts.push(text);
+            }
+            message.content = message.content.replace(/<think>[\s\S]*?<\/think>/gi, '').trim();
+        }
+
+        return parts.length > 0 ? parts.join('\n\n') : null;
     }
 
     /**

--- a/app/chat-ui.js
+++ b/app/chat-ui.js
@@ -93,6 +93,7 @@ export class ChatUI {
         // Wire agent callbacks
         this.agent.onThinkingStart = () => this.showThinking();
         this.agent.onThinkingEnd = () => this.hideThinking();
+        this.agent.onReasoning = (text, iter) => this.showReasoning(text, iter);
         this.agent.onToolProposal = (calls, text, iter, autoApproved) =>
             this.showToolProposal(calls, text, iter, autoApproved);
         this.agent.onToolExecuting = (calls) => this.showToolExecuting(calls);
@@ -463,17 +464,23 @@ export class ChatUI {
         document.addEventListener('keydown', escHandler);
 
         this.addMessage('user', text);
+        this.startTurn();
 
         try {
             const { response, cancelled } = await this.agent.processMessage(text);
 
             if (cancelled) {
+                this.endTurn('cancelled');
                 this.addMessage('system', 'Query cancelled.');
             } else if (response) {
+                this.endTurn('done');
                 this.addMarkdown('assistant', response);
+            } else {
+                this.endTurn('done');
             }
         } catch (err) {
             console.error('[ChatUI] Error:', err);
+            this.endTurn('error');
             const msg = err.message || String(err);
             const isNetworkOrTimeout =
                 msg.toLowerCase().includes('fetch') ||
@@ -493,10 +500,92 @@ export class ChatUI {
     }
 
     /* ------------------------------------------------------------------ */
-    /*  Thinking indicator                                                 */
+    /*  Per-turn timeline                                                  */
+    /* ------------------------------------------------------------------ */
+
+    /**
+     * Open a new agent-turn container. All subsequent agent events
+     * (reasoning, tool proposals, tool results) route into it as compact
+     * rows, and the whole container collapses to a one-liner when the
+     * assistant's final answer arrives.
+     */
+    startTurn() {
+        const container = document.createElement('details');
+        container.className = 'agent-turn running';
+        container.open = true;
+
+        const summary = document.createElement('summary');
+        summary.className = 'agent-turn-summary';
+        summary.innerHTML = '<span class="agent-turn-label">Working</span><span class="loading-dots"></span>';
+
+        const body = document.createElement('div');
+        body.className = 'agent-turn-body';
+
+        container.appendChild(summary);
+        container.appendChild(body);
+        this.messagesEl.appendChild(container);
+
+        this.currentTurn = {
+            container,
+            summary,
+            body,
+            startedAt: Date.now(),
+            rowsByIter: new Map(),
+            stepCount: 0,
+        };
+        this.scrollToBottom();
+    }
+
+    /**
+     * Close the current agent-turn container and rewrite its summary to a
+     * one-liner: "▸ N steps · 12.3s ✓". Status may be 'done', 'error',
+     * 'cancelled'.
+     */
+    endTurn(status = 'done') {
+        if (!this.currentTurn) return;
+        this.removeThinkingRow();
+
+        const { container, summary, body, startedAt, stepCount } = this.currentTurn;
+        const elapsed = ((Date.now() - startedAt) / 1000).toFixed(1);
+
+        const icon = status === 'done' ? '✓' : '✕';
+        const stepsLabel = stepCount === 0 ? '0 steps' :
+                           stepCount === 1 ? '1 step' :
+                           `${stepCount} steps`;
+
+        summary.innerHTML =
+            `<span class="agent-turn-icon ${status}">${icon}</span>` +
+            `<span class="agent-turn-label">${stepsLabel} · ${elapsed}s</span>`;
+
+        container.classList.remove('running');
+        container.classList.add(status);
+
+        // Empty turns (direct answer, no tools/reasoning) are noise — drop them.
+        if (stepCount === 0 && status === 'done') {
+            container.remove();
+        } else {
+            container.open = false;
+        }
+
+        this.currentTurn = null;
+    }
+
+    /* ------------------------------------------------------------------ */
+    /*  Thinking row (transient, inside the current turn)                  */
     /* ------------------------------------------------------------------ */
 
     showThinking() {
+        if (this.currentTurn) {
+            this.removeThinkingRow();
+            const row = document.createElement('div');
+            row.className = 'agent-turn-row thinking';
+            row.id = 'turn-thinking-row';
+            row.innerHTML = '<span class="row-icon">·</span><span class="row-label">Thinking</span><span class="loading-dots"></span>';
+            this.currentTurn.body.appendChild(row);
+            this.scrollToBottom();
+            return;
+        }
+        // Fallback for cases where no turn is active (shouldn't happen in normal flow).
         this.removeThinking();
         const el = document.createElement('div');
         el.className = 'chat-message assistant-thinking';
@@ -507,6 +596,7 @@ export class ChatUI {
     }
 
     hideThinking() {
+        this.removeThinkingRow();
         this.removeThinking();
     }
 
@@ -514,165 +604,215 @@ export class ChatUI {
         document.getElementById('thinking-indicator')?.remove();
     }
 
-    showToolExecuting(calls) {
-        this.removeToolExecuting();
-        const hasSql = calls.some(tc => {
-            try {
-                const args = JSON.parse(tc.function.arguments);
-                return !!(args.sql_query || args.query || args.sql);
-            } catch { return false; }
-        });
-        const label = hasSql ? 'Running query' : 'Running';
-        const el = document.createElement('div');
-        el.className = 'chat-message assistant-thinking';
-        el.id = 'tool-executing-indicator';
-        el.innerHTML = `${label}<span class="loading-dots"></span>`;
-        this.messagesEl.appendChild(el);
+    removeThinkingRow() {
+        document.getElementById('turn-thinking-row')?.remove();
+    }
+
+    /* ------------------------------------------------------------------ */
+    /*  Tool execution indicator (no-op now: state lives on the row)       */
+    /* ------------------------------------------------------------------ */
+
+    showToolExecuting(_calls) {
+        // The tool row already shows a running spinner from showToolProposal
+        // onward; no separate indicator needed in the timeline layout.
+    }
+
+    /* ------------------------------------------------------------------ */
+    /*  Reasoning row                                                      */
+    /* ------------------------------------------------------------------ */
+
+    showReasoning(text, _iter) {
+        if (!this.currentTurn) return;
+        this.removeThinkingRow();
+
+        const row = document.createElement('details');
+        row.className = 'agent-turn-row reasoning';
+
+        const summary = document.createElement('summary');
+        summary.className = 'agent-turn-row-summary';
+        summary.innerHTML = '<span class="row-icon">💭</span><span class="row-label">Reasoning</span>';
+
+        const body = document.createElement('div');
+        body.className = 'agent-turn-row-body';
+        body.innerHTML = typeof marked !== 'undefined'
+            ? marked.parse(text)
+            : `<pre>${this.escapeHtml(text)}</pre>`;
+
+        row.appendChild(summary);
+        row.appendChild(body);
+        this.currentTurn.body.appendChild(row);
+        this.currentTurn.stepCount++;
         this.scrollToBottom();
     }
 
-    removeToolExecuting() {
-        document.getElementById('tool-executing-indicator')?.remove();
-    }
-
     /* ------------------------------------------------------------------ */
-    /*  Tool proposal & results (collapsible blocks)                       */
+    /*  Tool proposal & results (merged into one mutable row per iter)     */
     /* ------------------------------------------------------------------ */
 
     /**
-     * Show a tool proposal — collapsible block listing tool calls.
-     * If autoApproved is true, it's just informational.
-     * Otherwise returns a promise that resolves with { approved }.
+     * Create a tool row in 'running' state. If autoApproved is true the
+     * call proceeds immediately; otherwise approval buttons are shown
+     * inside the row body and the returned promise resolves when the user
+     * decides.
      */
     showToolProposal(calls, reasoningText, iteration, autoApproved = false) {
-        this.removeThinking();
+        if (!this.currentTurn) return Promise.resolve({ approved: true });
+        this.removeThinkingRow();
 
-        const block = document.createElement('div');
-        block.className = 'chat-message tool-block';
+        // Group repeated tool names for a compact label: "query ×3"
+        const counts = new Map();
+        for (const c of calls) {
+            counts.set(c.function.name, (counts.get(c.function.name) || 0) + 1);
+        }
+        const namesLabel = [...counts.entries()]
+            .map(([n, c]) => c > 1 ? `${n} ×${c}` : n)
+            .join(', ');
 
-        // Show plain-english description above the fold for proposals requiring approval.
-        // Use model-provided reasoning if available, otherwise derive from tool args.
-        let html = '';
+        const row = document.createElement('details');
+        row.className = 'agent-turn-row tool running';
+        row.dataset.iter = String(iteration);
+
+        const summary = document.createElement('summary');
+        summary.className = 'agent-turn-row-summary';
+        summary.innerHTML =
+            '<span class="row-icon">⚙</span>' +
+            `<span class="row-label">${this.escapeHtml(namesLabel)}</span>` +
+            '<span class="row-status running"><span class="loading-dots"></span></span>';
+
+        const body = document.createElement('div');
+        body.className = 'agent-turn-row-body';
+
+        // Optional plain-english description above the fold (shown for
+        // non-auto-approve proposals so the user can decide).
         if (!autoApproved) {
             const desc = (reasoningText && reasoningText.trim())
                 ? reasoningText.trim()
                 : this.describeToolCalls(calls);
             if (desc) {
                 const descHtml = typeof marked !== 'undefined' ? marked.parse(desc) : this.escapeHtml(desc);
-                html += `<div class="tool-reasoning">${descHtml}</div>`;
+                body.insertAdjacentHTML('beforeend', `<div class="tool-reasoning">${descHtml}</div>`);
             }
         }
-
-        // Build collapsible header
-        const names = calls.map(c => c.function.name).join(', ');
-        const label = autoApproved ? `Running: ${names}` : `Details: ${names}`;
-
-        html += `<details><summary class="query-summary-btn">${label}</summary><div class="tool-detail">`;
 
         for (const tc of calls) {
-            let args;
-            try { args = JSON.parse(tc.function.arguments); } catch { args = tc.function.arguments; }
-
-            let argDisplay = '';
-            if (typeof args === 'object' && args !== null) {
-                // Extract SQL query field and display it highlighted with real newlines
-                const sqlText = args.sql_query || args.query || args.sql || null;
-                const sqlKey = args.sql_query !== undefined ? 'sql_query' : args.query !== undefined ? 'query' : 'sql';
-                if (sqlText) {
-                    argDisplay += `<details class="sql-detail"><summary>SQL</summary><pre><code class="language-sql">${this.escapeHtml(sqlText)}</code></pre></details>`;
-                    const REDACTED_KEYS = ['s3_key', 's3_secret', 's3_endpoint', 's3_scope', 'catalog_token'];
-                    const otherArgs = Object.fromEntries(
-                        Object.entries(args).filter(([k]) => k !== sqlKey && !REDACTED_KEYS.includes(k))
-                    );
-                    if (Object.keys(otherArgs).length > 0) {
-                        argDisplay += `<pre><code>${this.escapeHtml(JSON.stringify(otherArgs, null, 2))}</code></pre>`;
-                    }
-                } else {
-                    argDisplay = `<pre><code>${this.escapeHtml(JSON.stringify(args, null, 2))}</code></pre>`;
-                }
-            } else {
-                argDisplay = `<pre><code>${this.escapeHtml(String(args))}</code></pre>`;
-            }
-
-            html += `<div class="tool-call-item"><strong>${tc.function.name}</strong>${argDisplay}</div>`;
+            body.insertAdjacentHTML('beforeend', this.renderToolCallArgs(tc));
         }
 
-        html += '</div></details>';
+        row.appendChild(summary);
+        row.appendChild(body);
+        this.currentTurn.body.appendChild(row);
+        this.currentTurn.rowsByIter.set(iteration, row);
+        this.currentTurn.stepCount++;
 
-        if (!autoApproved) {
-            html += '<div class="tool-approval-buttons"><button class="approve-btn approve-yes">▶ Run</button><button class="approve-btn approve-no" style="background:#dc3545">✕ Cancel</button></div>';
-        }
-        block.innerHTML = html;
-        this.messagesEl.appendChild(block);
-
-        // Highlight any SQL blocks in the proposal
-        block.querySelectorAll('code.language-sql').forEach(el => {
+        row.querySelectorAll('code.language-sql').forEach(el => {
             if (typeof hljs !== 'undefined') hljs.highlightElement(el);
         });
 
         this.scrollToBottom();
 
-        if (autoApproved) {
-            return Promise.resolve({ approved: true });
-        }
+        if (autoApproved) return Promise.resolve({ approved: true });
 
-        // Wait for user to click approve/cancel
+        // Open the row so the user can see what's being proposed.
+        row.open = true;
+        body.insertAdjacentHTML('beforeend',
+            '<div class="tool-approval-buttons">' +
+            '<button class="approve-btn approve-yes">▶ Run</button>' +
+            '<button class="approve-btn approve-no" style="background:#dc3545">✕ Cancel</button>' +
+            '</div>'
+        );
+
         return new Promise(resolve => {
-            const yesBtn = block.querySelector('.approve-yes');
-            const noBtn = block.querySelector('.approve-no');
+            const yesBtn = row.querySelector('.approve-yes');
+            const noBtn = row.querySelector('.approve-no');
+            const cleanup = () => row.querySelector('.tool-approval-buttons')?.remove();
 
             yesBtn.addEventListener('click', () => {
-                yesBtn.disabled = true;
-                noBtn.disabled = true;
-                yesBtn.textContent = '✓ Approved';
+                cleanup();
                 resolve({ approved: true });
             });
-
             noBtn.addEventListener('click', () => {
-                yesBtn.disabled = true;
-                noBtn.disabled = true;
-                noBtn.textContent = '✕ Cancelled';
+                cleanup();
                 resolve({ approved: false });
             });
         });
     }
 
     /**
-     * Show tool results as a collapsible block.
+     * Render the body block for one tool call (args, with SQL pretty-print
+     * and redaction of credential-like keys).
      */
-    showToolResults(results, iteration) {
-        this.removeToolExecuting();
-        const block = document.createElement('div');
-        block.className = 'chat-message tool-block';
+    renderToolCallArgs(tc) {
+        let args;
+        try { args = JSON.parse(tc.function.arguments); } catch { args = tc.function.arguments; }
 
-        const count = results.length;
-        const label = `✅ ${count} tool result${count > 1 ? 's' : ''}`;
-
-        let html = `<details><summary class="query-summary-btn">${label}</summary><div class="tool-detail">`;
-
-        for (const r of results) {
-            const icon = r.success ? '✓' : '✗';
-            const sourceTag = r.source === 'remote' ? ' <span class="tool-tag remote">MCP</span>' : '';
-            const truncated = this.truncateResult(r.result, 2000);
-            html += `<div class="tool-result-item"><strong>${icon} ${r.name}</strong>${sourceTag}`;
-
-            // If it's a SQL query, show it specially
-            if (r.sqlQuery) {
-                html += `<details class="sql-detail"><summary>SQL</summary><pre><code class="language-sql">${this.escapeHtml(r.sqlQuery)}</code></pre></details>`;
+        let argDisplay = '';
+        if (typeof args === 'object' && args !== null) {
+            const sqlText = args.sql_query || args.query || args.sql || null;
+            const sqlKey = args.sql_query !== undefined ? 'sql_query' : args.query !== undefined ? 'query' : 'sql';
+            if (sqlText) {
+                argDisplay += `<details class="sql-detail"><summary>SQL</summary><pre><code class="language-sql">${this.escapeHtml(sqlText)}</code></pre></details>`;
+                const REDACTED_KEYS = ['s3_key', 's3_secret', 's3_endpoint', 's3_scope', 'catalog_token'];
+                const otherArgs = Object.fromEntries(
+                    Object.entries(args).filter(([k]) => k !== sqlKey && !REDACTED_KEYS.includes(k))
+                );
+                if (Object.keys(otherArgs).length > 0) {
+                    argDisplay += `<pre><code>${this.escapeHtml(JSON.stringify(otherArgs, null, 2))}</code></pre>`;
+                }
+            } else {
+                argDisplay = `<pre><code>${this.escapeHtml(JSON.stringify(args, null, 2))}</code></pre>`;
             }
-
-            html += `<pre class="tool-output"><code>${this.escapeHtml(truncated)}</code></pre></div>`;
+        } else {
+            argDisplay = `<pre><code>${this.escapeHtml(String(args))}</code></pre>`;
         }
 
-        html += '</div></details>';
-        block.innerHTML = html;
-        this.messagesEl.appendChild(block);
-        this.scrollToBottom();
+        return `<div class="tool-call-item"><strong>${tc.function.name}</strong>${argDisplay}</div>`;
+    }
 
-        // Highlight SQL if available
-        block.querySelectorAll('code.language-sql').forEach(el => {
+    /**
+     * Mutate the tool row created in showToolProposal: change its status
+     * icon and append the result panels to the body.
+     */
+    showToolResults(results, iteration) {
+        if (!this.currentTurn) return;
+        const row = this.currentTurn.rowsByIter.get(iteration);
+        if (!row) return;
+
+        const anyError = results.some(r => !r.success);
+        const status = anyError ? 'error' : 'done';
+        const icon = anyError ? '✗' : '✓';
+
+        row.classList.remove('running');
+        row.classList.add(status);
+
+        const statusEl = row.querySelector('.row-status');
+        if (statusEl) {
+            statusEl.className = `row-status ${status}`;
+            statusEl.textContent = icon;
+        }
+
+        const body = row.querySelector('.agent-turn-row-body');
+        if (!body) return;
+
+        let resultsHtml = '<div class="tool-results-list">';
+        for (const r of results) {
+            const itemIcon = r.success ? '✓' : '✗';
+            const sourceTag = r.source === 'remote' ? ' <span class="tool-tag remote">MCP</span>' : '';
+            const truncated = this.truncateResult(r.result, 2000);
+            resultsHtml += `<div class="tool-result-item"><strong>${itemIcon} ${r.name}</strong>${sourceTag}`;
+            if (r.sqlQuery) {
+                resultsHtml += `<details class="sql-detail"><summary>SQL</summary><pre><code class="language-sql">${this.escapeHtml(r.sqlQuery)}</code></pre></details>`;
+            }
+            resultsHtml += `<pre class="tool-output"><code>${this.escapeHtml(truncated)}</code></pre></div>`;
+        }
+        resultsHtml += '</div>';
+        body.insertAdjacentHTML('beforeend', resultsHtml);
+
+        // Highlight any new SQL blocks in the appended results
+        body.querySelectorAll('code.language-sql:not(.hljs)').forEach(el => {
             if (typeof hljs !== 'undefined') hljs.highlightElement(el);
         });
+
+        this.scrollToBottom();
     }
 
     /* ------------------------------------------------------------------ */

--- a/app/chat.css
+++ b/app/chat.css
@@ -477,6 +477,192 @@
     background: rgba(255, 255, 255, 0.75);
 }
 
+/* ── Per-turn agent timeline ────────────────────────────── */
+
+.agent-turn {
+    align-self: stretch;
+    margin: 4px 0;
+    padding: 0;
+    background: transparent;
+    border-left: 2px solid rgba(0, 122, 255, 0.25);
+    border-radius: 0;
+}
+
+.agent-turn.done {
+    border-left-color: rgba(40, 167, 69, 0.4);
+}
+
+.agent-turn.error {
+    border-left-color: rgba(220, 53, 69, 0.5);
+}
+
+.agent-turn.cancelled {
+    border-left-color: rgba(108, 117, 125, 0.4);
+}
+
+.agent-turn > .agent-turn-summary {
+    padding: 4px 10px;
+    margin: 0;
+    cursor: pointer;
+    list-style: none;
+    font-size: 12px;
+    color: #4a5568;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    line-height: 1.4;
+    user-select: none;
+}
+
+.agent-turn > .agent-turn-summary::-webkit-details-marker {
+    display: none;
+}
+
+.agent-turn > .agent-turn-summary::before {
+    content: '';
+    flex-shrink: 0;
+    border-left: 4px solid currentColor;
+    border-top: 3px solid transparent;
+    border-bottom: 3px solid transparent;
+    transition: transform 0.15s ease;
+}
+
+.agent-turn[open] > .agent-turn-summary::before {
+    transform: rotate(90deg);
+}
+
+.agent-turn-icon.done {
+    color: #28a745;
+}
+.agent-turn-icon.error,
+.agent-turn-icon.cancelled {
+    color: #dc3545;
+}
+
+.agent-turn-body {
+    padding: 2px 0 4px 12px;
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+}
+
+/* Rows inside the timeline */
+.agent-turn-row {
+    margin: 0;
+    padding: 0;
+    background: transparent;
+    border: none;
+    font-size: 12px;
+    line-height: 1.4;
+}
+
+.agent-turn-row.thinking {
+    padding: 2px 6px;
+    color: #6b7280;
+    font-style: italic;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.agent-turn-row-summary {
+    padding: 2px 6px;
+    cursor: pointer;
+    list-style: none;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    color: #2c5282;
+    border-radius: 3px;
+    transition: background 0.1s ease;
+    user-select: none;
+}
+
+.agent-turn-row-summary::-webkit-details-marker {
+    display: none;
+}
+
+.agent-turn-row-summary::before {
+    content: '';
+    flex-shrink: 0;
+    border-left: 4px solid currentColor;
+    border-top: 3px solid transparent;
+    border-bottom: 3px solid transparent;
+    opacity: 0.5;
+    transition: transform 0.15s ease;
+}
+
+details.agent-turn-row[open] > .agent-turn-row-summary::before {
+    transform: rotate(90deg);
+}
+
+.agent-turn-row-summary:hover {
+    background: rgba(0, 122, 255, 0.06);
+}
+
+.agent-turn-row .row-icon {
+    flex-shrink: 0;
+    font-size: 11px;
+    width: 14px;
+    text-align: center;
+}
+
+.agent-turn-row .row-label {
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-weight: 500;
+}
+
+.agent-turn-row .row-status {
+    flex-shrink: 0;
+    font-size: 11px;
+    color: #6b7280;
+}
+
+.agent-turn-row .row-status.done {
+    color: #28a745;
+    font-weight: 600;
+}
+
+.agent-turn-row .row-status.error {
+    color: #dc3545;
+    font-weight: 600;
+}
+
+.agent-turn-row.reasoning > .agent-turn-row-summary {
+    color: #6b7280;
+    font-style: italic;
+}
+
+.agent-turn-row-body {
+    padding: 4px 10px 6px 24px;
+    font-size: 12px;
+    line-height: 1.5;
+    color: #1a1a2e;
+}
+
+.agent-turn-row-body .tool-call-item,
+.agent-turn-row-body .tool-result-item {
+    margin: 4px 0;
+    padding: 0;
+    border: none;
+}
+
+.agent-turn-row-body .tool-results-list {
+    margin-top: 6px;
+    padding-top: 6px;
+    border-top: 1px solid rgba(0, 0, 0, 0.06);
+}
+
+.agent-turn-row-body p:first-child {
+    margin-top: 0;
+}
+.agent-turn-row-body p:last-child {
+    margin-bottom: 0;
+}
+
 /* ── Tool blocks (collapsible) ──────────────────────────── */
 
 .tool-reasoning {

--- a/test/agent-reasoning.test.js
+++ b/test/agent-reasoning.test.js
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { Agent } from '../app/agent.js';
+
+const stubToolRegistry = {
+    getToolsForLLM: () => [],
+    isLocal: () => true,
+    execute: async () => ({ result: '' }),
+    has: () => false,
+};
+
+const makeAgent = () => {
+    const agent = new Agent(
+        { llm_models: [{ value: 'm', endpoint: 'https://x/v1', api_key: 'k' }] },
+        stubToolRegistry,
+    );
+    return agent;
+};
+
+const okResponse = (message) => ({
+    ok: true,
+    json: async () => ({ choices: [{ message }] }),
+});
+
+describe('Agent reasoning extraction', () => {
+    let originalFetch;
+
+    beforeEach(() => {
+        originalFetch = global.fetch;
+    });
+
+    afterEach(() => {
+        global.fetch = originalFetch;
+        vi.restoreAllMocks();
+    });
+
+    it('emits onReasoning when reasoning_content is present on the message', async () => {
+        const agent = makeAgent();
+        const events = [];
+        agent.onReasoning = (text, iter) => events.push({ text, iter });
+
+        global.fetch = vi.fn().mockResolvedValueOnce(okResponse({
+            role: 'assistant',
+            content: 'Here you go.',
+            reasoning_content: 'I considered options A and B and chose B.',
+        }));
+
+        await agent.processMessage('hi');
+
+        expect(events).toHaveLength(1);
+        expect(events[0].text).toBe('I considered options A and B and chose B.');
+    });
+
+    it('emits onReasoning for inline <think> blocks and strips them from displayed content', async () => {
+        const agent = makeAgent();
+        const events = [];
+        agent.onReasoning = (text) => events.push(text);
+
+        global.fetch = vi.fn().mockResolvedValueOnce(okResponse({
+            role: 'assistant',
+            content: '<think>step 1\nstep 2</think>\nFinal answer here.',
+        }));
+
+        const { response } = await agent.processMessage('hi');
+
+        expect(events).toHaveLength(1);
+        expect(events[0]).toContain('step 1');
+        expect(events[0]).toContain('step 2');
+        // The displayed response should not contain the <think> block
+        expect(response).not.toContain('<think>');
+        expect(response).toContain('Final answer here.');
+    });
+
+    it('handles multiple <think> blocks in one message', async () => {
+        const agent = makeAgent();
+        const events = [];
+        agent.onReasoning = (text) => events.push(text);
+
+        global.fetch = vi.fn().mockResolvedValueOnce(okResponse({
+            role: 'assistant',
+            content: '<think>first</think>middle<think>second</think>end',
+        }));
+
+        const { response } = await agent.processMessage('hi');
+
+        // Both think blocks captured (joined)
+        expect(events).toHaveLength(1);
+        expect(events[0]).toContain('first');
+        expect(events[0]).toContain('second');
+        // Visible content has both blocks stripped
+        expect(response).not.toContain('<think>');
+        expect(response).toContain('middle');
+        expect(response).toContain('end');
+    });
+
+    it('does not emit onReasoning when neither reasoning_content nor <think> is present', async () => {
+        const agent = makeAgent();
+        const events = [];
+        agent.onReasoning = (text) => events.push(text);
+
+        global.fetch = vi.fn().mockResolvedValueOnce(okResponse({
+            role: 'assistant',
+            content: 'Plain answer.',
+        }));
+
+        await agent.processMessage('hi');
+
+        expect(events).toHaveLength(0);
+    });
+
+    it('strips reasoning_content from the assistant message stored in history', async () => {
+        const agent = makeAgent();
+        agent.onReasoning = () => {};
+
+        global.fetch = vi.fn().mockResolvedValueOnce(okResponse({
+            role: 'assistant',
+            content: 'Answer.',
+            reasoning_content: 'Big chain of thought that should not be re-sent.',
+        }));
+
+        await agent.processMessage('hi');
+
+        const lastAssistant = agent.messages.at(-1);
+        expect(lastAssistant.role).toBe('assistant');
+        expect(lastAssistant.reasoning_content).toBeUndefined();
+        expect(lastAssistant.content).toBe('Answer.');
+    });
+});


### PR DESCRIPTION
## Summary

- Collapses the per-event card stack in the chat panel into a single per-turn timeline. Each agent iteration is now one mutable row (`running` → `done` / `error`) inside a parent `.agent-turn` container, instead of two separate cards. Consecutive calls to the same tool collapse to `tool ×N`.
- When the assistant's final answer renders, the whole timeline auto-collapses to a one-line summary (`8 steps · 12.3s`) so the chat panel stays readable across multi-step queries. Empty turns (model answers directly) drop their container entirely.
- Surfaces model reasoning where models emit it: `reasoning_content` (vLLM / qwen3 / DeepSeek shape) and inline `<think>…</think>` blocks. Reasoning is rendered as a row inside the turn (collapsed by default, markdown when expanded) and stripped from the assistant message before it's re-fed to the LLM, so it doesn't inflate the context window on subsequent turns.

Closes #186. Partially addresses #195 by making `reasoning_content` visible in the cases where it was previously dropped on the floor.

## Before / after

**Before** (today's `nature.nrp-nautilus.io` for a multi-step query): 13 vertical cards stacked, paired `Running:` + `tool results` boxes, no relationship between them, answer pushed off-screen.

**After**: one collapsible `.agent-turn` container. Expanded shows reasoning + iteration rows in chronological order; collapsed shows `▸ 8 steps · 12.3s ✓`. Reasoning rows use 💭, tool rows use ⚙.

## What changed

- `app/agent.js`: new `extractReasoning(message)` helper + `onReasoning` callback wired into the agent loop. Mutates the message to strip `reasoning_content` and inline `<think>` blocks before they're pushed back into `turnMessages`.
- `app/chat-ui.js`: new `startTurn` / `endTurn` lifecycle. `showToolProposal` / `showToolResults` now mutate one merged row per iteration (tracked via `rowsByIter`). New `showReasoning` handler. `showThinking` lives inside the turn body now. `showToolExecuting` is a no-op (the row already shows the running state). Falls back gracefully to old behavior when no turn is active.
- `app/chat.css`: new `.agent-turn` / `.agent-turn-row` styles. Compact spacing, status colors on the left border.
- `test/agent-reasoning.test.js`: 5 new tests covering `reasoning_content`, inline `<think>` (single and multiple), no-reasoning, and the strip-from-history invariant.

## Test plan

- [x] `npx vitest run` — 512 / 512 pass.
- [x] `node --check` on `agent.js` and `chat-ui.js`.
- [x] Dev server boots; `index.html`, `chat-ui.js`, `agent.js`, `chat.css` all serve 200.
- [ ] Manual: drive a multi-step query (e.g. "Which european countries are closest to 30x30 goals?") through a deployed app. Confirm rows compact during execution, container auto-collapses on final answer, expanding re-shows the original details, and reasoning rows appear for models that emit it (qwen3 family).
- [ ] Manual: non-auto-approve mode — confirm approval buttons still appear inside the row and the row mutates correctly after approve / cancel.
- [ ] Manual: cancel / error mid-turn — confirm the summary reads `✕ N steps · Xs` and the answer area shows the cancel/error banner below.

## Notes

- Reasoning display is phase 1 of #186 — display only, no toggle. The toggle (and per-model reasoning-on/off) is deferred until #195 produces enough data to classify which query classes benefit.