### PR TITLE
fix(agent): raise tool-result truncation cap from 4K to 16K

### DIFF
--- a/app/agent.js
+++ b/app/agent.js
@@ -187,10 +187,12 @@ export class Agent {
                     // Track SQL queries
                     if (execResult.sqlQuery) sqlQueries.push(execResult.sqlQuery);
 
-                    // Add to conversation — cap at 4K chars to prevent SQL results
-                    // from consuming the remaining context budget mid-turn
-                    const resultContent = execResult.result?.length > 4000
-                        ? execResult.result.substring(0, 4000) + '\n... (truncated)'
+                    // Add to conversation — cap to prevent SQL results from consuming
+                    // the remaining context budget mid-turn. 16K fits current STAC
+                    // schema-discovery payloads (~8–10 KB at largest) with headroom.
+                    const TOOL_RESULT_CAP = 16000;
+                    const resultContent = execResult.result?.length > TOOL_RESULT_CAP
+                        ? execResult.result.substring(0, TOOL_RESULT_CAP) + '\n... (truncated)'
                         : execResult.result;
                     turnMessages.push({
                         role: 'tool',


### PR DESCRIPTION
Closes #218.

## Summary
- Bumps the per-tool-result truncation cap in `app/agent.js` from 4000 to 16000 chars, extracted to a `TOOL_RESULT_CAP` constant with an explanatory comment.
- Restores complete `get_schema` payloads (~7 KB for `calenviroscreen-5-0`) so the model no longer falls back to `DESCRIBE` / `SELECT *` to recover columns past the old cutoff.

## Why
The 4K cap was originally there to prevent large SQL result payloads from eating context mid-turn, but it doubled as a cap on schema-discovery tool output where the *complete* column inventory is the entire point. See #218 for proxy-log evidence.

16K fits every STAC collection in the catalog today (largest ~8–10 KB) with headroom and remains well below per-turn context budgets for the models in use.

## Test plan
- [x] `npm test` — 512 tests pass (no test currently covers this branch; the cap is a constant inside the agent loop)
- [ ] Manual: redeploy on `calenviroscreen.nrp-nautilus.io` and confirm the verification scenario from #218 (no `DESCRIBE SELECT *` after the initial `get_schema`)