### PR TITLE
fix(sidebar): layers-collapse, footer link contrast, region buffer

### DIFF
--- a/app/sidebar.css
+++ b/app/sidebar.css
@@ -97,8 +97,23 @@ body.sidebar-mode #sidebar-layers-pane {
     flex: 0 0 auto;
     max-height: 40%;
     overflow-y: auto;
-    padding: 8px 12px;
+    padding: 8px 12px 16px;
     border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+}
+
+/* Collapse behavior — mirror the floating-mode #menu rules in style.css
+ * (#menu only matches in floating mode, so sidebar needs its own copies). */
+body.sidebar-mode #sidebar-layers-pane.collapsed #menu-body {
+    display: none;
+}
+
+body.sidebar-mode #sidebar-layers-pane:not(.collapsed) .menu-header .section-title {
+    display: none;
+}
+
+body.sidebar-mode #sidebar-layers-pane:not(.collapsed) .menu-header {
+    justify-content: flex-end;
+    margin-bottom: 4px;
 }
 
 /* ----- Chat region — override a few chat.css rules that assume a
@@ -107,7 +122,7 @@ body.sidebar-mode #sidebar-layers-pane {
 body.sidebar-mode #chat-messages {
     flex: 1 1 auto;
     overflow-y: auto;
-    padding: 10px 12px;
+    padding: 18px 12px 10px;
 }
 
 body.sidebar-mode #chat-input-container {
@@ -147,14 +162,19 @@ body.sidebar-mode #sidebar-footer .footer-link {
     align-items: center;
     padding: 2px 6px;
     margin-right: 4px;
-    color: rgba(255, 255, 255, 0.75);
+    color: rgba(0, 0, 0, 0.55);
     text-decoration: none;
     border-radius: 3px;
 }
 
 body.sidebar-mode #sidebar-footer .footer-link:hover {
-    color: rgba(255, 255, 255, 1);
-    background: rgba(255, 255, 255, 0.08);
+    color: rgba(0, 0, 0, 0.85);
+    background: rgba(0, 0, 0, 0.06);
+}
+
+body.sidebar-mode #sidebar-footer .footer-link.carbon-link,
+body.sidebar-mode #sidebar-footer .footer-link.carbon-link:hover {
+    color: #2e7d32;
 }
 
 /* ----- Collapse / show toggle ------------------------------------------- */


### PR DESCRIPTION
Three small sidebar-mode polish fixes spotted in #184 evaluation work.

## Issues

1. **LAYERS minimize button did nothing.** Clicking the `−` swapped to `+` but didn't collapse the body. Root cause: `app/map-manager.js:891` toggles \`.collapsed\` on its container, but the hide rule at \`app/style.css:127\` only matches \`#menu\`. In sidebar mode the container is \`#sidebar-layers-pane\`, so the class flipped with nothing to react to it. Same for the \"hide title when expanded\" rule.
2. **\"About\" and carbon-tracker links were white-on-white in the sidebar footer.** \`sidebar.css\` copy-pasted \`color: rgba(255,255,255,0.75)\` from \`chat.css\`, which only made sense on the floating chat's dark translucent background. Sidebar background is \`#f8f9fa\`, so the links became invisible. The green carbon-link override in \`chat.css\` was scoped to \`#chat-footer\`, so it didn't reach \`#sidebar-footer\` either.
3. **Greeting text sat right against the layers pane.** Visually unclear that the two regions were distinct.

## Fix

CSS-only changes in \`app/sidebar.css\`:

- Add three parallel selectors against \`#sidebar-layers-pane\` so the collapse/expand behavior mirrors floating mode exactly.
- Swap footer-link color to dark ink with a matching hover, and re-apply the carbon-link green via a sidebar-scoped selector.
- Bump padding on the layers pane bottom (8 → 16px) and chat-messages top (10 → 18px) for clearer region separation.

Floating mode is untouched — every change is scoped under \`body.sidebar-mode\`.

## Test plan

- [ ] Sidebar mode, click the LAYERS \`−\`: body collapses, button becomes \`+\`, title \"Layers\" remains visible (now hidden when expanded, shown when collapsed — matches floating).
- [ ] Sidebar footer: \"About\" link visible in dark ink, carbon-tracker link in green.
- [ ] Visible gap between layers pane border and the greeting text.
- [ ] Floating mode: visually unchanged.
- [ ] \`npm test\` passes (CSS-only — confirmed locally, 512/512).