### PR TITLE
feat: HTML chat-history export with reproducible SQL

### DIFF
--- a/app/chat-ui.js
+++ b/app/chat-ui.js
@@ -886,6 +886,175 @@ export class ChatUI {
     }
 
     /* ------------------------------------------------------------------ */
+    /*  HTML export                                                        */
+    /* ------------------------------------------------------------------ */
+
+    /**
+     * Build a self-contained HTML transcript of the current conversation
+     * and trigger a download. Faithful mirror of the live chat panel,
+     * with SQL rewritten for reproducibility and credential-shaped tokens
+     * scrubbed.
+     */
+    exportHtml() {
+        const clone = this.messagesEl.cloneNode(true);
+        this._sanitizeExportClone(clone);
+
+        const css = this._exportCss();
+        const title = this._exportTitle();
+        const appUrl = window.location.href;
+        const appTitle = document.title || 'Geo-Agent';
+        const exportedAt = new Date().toLocaleString();
+
+        const html =
+`<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>${this.escapeHtml(title)}</title>
+<style>${css}</style>
+</head>
+<body>
+<header class="export-header">
+  <h1>Geo-Agent chat transcript</h1>
+  <p>Exported ${this.escapeHtml(exportedAt)} — <a href="${this.escapeHtml(appUrl)}">${this.escapeHtml(appTitle)}</a></p>
+  <p class="export-note">SQL queries below have been rewritten to use the public S3 endpoint
+     (<code>https://s3-west.nrp-nautilus.io/</code>) so they can be re-run from any DuckDB
+     with the <code>httpfs</code> extension loaded.</p>
+</header>
+<main id="chat-messages">${clone.innerHTML}</main>
+</body>
+</html>`;
+
+        try {
+            const blob = new Blob([html], { type: 'text/html' });
+            const url = URL.createObjectURL(blob);
+            const a = document.createElement('a');
+            a.href = url;
+            a.download = this._exportFilename();
+            document.body.appendChild(a);
+            a.click();
+            a.remove();
+            URL.revokeObjectURL(url);
+        } catch (err) {
+            console.warn('[ChatUI] Export failed:', err);
+            this.addMessage('error',
+                "couldn't generate download — your browser may not support file downloads");
+        }
+    }
+
+    /**
+     * Walk a cloned messagesEl subtree applying export-time transforms:
+     * drop transient UI, rewrite SQL, scrub credentials.
+     */
+    _sanitizeExportClone(root) {
+        // Drop transient interactive UI.
+        root.querySelectorAll('.tool-approval-buttons, button, script')
+            .forEach(el => el.remove());
+
+        // Remove .running class from any rows still in-flight at click time.
+        root.querySelectorAll('.running').forEach(el => el.classList.remove('running'));
+
+        // SQL rewrite: only inside .language-sql code blocks.
+        root.querySelectorAll('code.language-sql').forEach(codeEl => {
+            const original = codeEl.textContent;
+            const rewritten = rewriteS3UrlsInSql(original);
+            // Replace text content; drop any prior syntax-highlight spans
+            // (they reference the original token offsets and become stale).
+            codeEl.className = 'language-sql';
+            codeEl.textContent = rewritten;
+        });
+
+        // Credential scrub: DOM-wide on text nodes only.
+        const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+        const toUpdate = [];
+        let node = walker.nextNode();
+        while (node) {
+            const scrubbed = scrubCredentials(node.nodeValue);
+            if (scrubbed !== node.nodeValue) toUpdate.push([node, scrubbed]);
+            node = walker.nextNode();
+        }
+        for (const [n, v] of toUpdate) n.nodeValue = v;
+    }
+
+    _exportFilename() {
+        const d = new Date();
+        const pad = (n) => String(n).padStart(2, '0');
+        const stamp = `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}` +
+                      `-${pad(d.getHours())}${pad(d.getMinutes())}`;
+        return `geo-agent-chat-${stamp}.html`;
+    }
+
+    _exportTitle() {
+        const d = new Date();
+        const pad = (n) => String(n).padStart(2, '0');
+        const stamp = `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ` +
+                      `${pad(d.getHours())}:${pad(d.getMinutes())}`;
+        return `Geo-Agent chat — ${stamp}`;
+    }
+
+    /**
+     * Inlined CSS subset for the export. Covers what's needed to render
+     * messages, turn rows, tool calls, SQL/result <details>, and code
+     * blocks. Excludes anything related to live input, layout, scrollbars,
+     * or interactive buttons.
+     */
+    _exportCss() {
+        return `
+body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+       max-width: 900px; margin: 1rem auto; padding: 0 1rem; color: #1a1a2e; line-height: 1.5; }
+.export-header { border-bottom: 1px solid #ddd; padding-bottom: 0.75rem; margin-bottom: 1rem; }
+.export-header h1 { margin: 0 0 0.25rem; font-size: 1.25rem; }
+.export-header p { margin: 0.25rem 0; color: #555; font-size: 13px; }
+.export-note { font-size: 12px; color: #6b7280; background: #f3f4f6;
+               padding: 6px 10px; border-radius: 4px; }
+.chat-message { padding: 8px 10px; margin: 6px 0; border-radius: 6px; font-size: 14px; }
+.chat-message.user { background: #e0f2fe; }
+.chat-message.assistant { background: #f9fafb; }
+.chat-message.system { background: #fff7ed; color: #92400e; font-size: 12px; font-style: italic; }
+.chat-message.error { background: #fef2f2; color: #991b1b; font-size: 12px; }
+.chat-message pre { background: #1e293b; color: #e2e8f0; padding: 8px; border-radius: 4px;
+                    overflow-x: auto; font-size: 12px; }
+.chat-message code { background: rgba(0,0,0,0.05); padding: 1px 4px; border-radius: 3px;
+                     font-size: 12px; }
+.chat-message pre code { background: transparent; padding: 0; color: inherit; }
+.chat-message table { border-collapse: collapse; margin: 6px 0; font-size: 12px; }
+.chat-message th, .chat-message td { border: 1px solid #ddd; padding: 4px 8px; }
+.chat-message th { background: #f3f4f6; }
+.agent-turn { margin: 8px 0; border: 1px solid #e5e7eb; border-radius: 6px;
+              padding: 4px 8px; }
+.agent-turn > summary { cursor: pointer; font-size: 12px; color: #2c5282;
+                        padding: 2px 4px; list-style: none; }
+.agent-turn > summary::-webkit-details-marker { display: none; }
+.agent-turn-row { font-size: 12px; margin: 2px 0; }
+.agent-turn-row-summary { padding: 2px 6px; cursor: pointer; list-style: none;
+                          display: flex; align-items: center; gap: 6px; color: #2c5282; }
+.agent-turn-row-summary::-webkit-details-marker { display: none; }
+.agent-turn-row-body { padding: 4px 10px 6px 24px; font-size: 12px; color: #1a1a2e; }
+.tool-call-item, .tool-result-item { margin: 4px 0; }
+.tool-call-item strong, .tool-result-item strong { font-weight: 600; color: #374151; }
+.row-status.done { color: #28a745; font-weight: 600; }
+.row-status.error { color: #dc3545; font-weight: 600; }
+.sql-detail summary { cursor: pointer; color: #2c5282; font-size: 11px;
+                      padding: 2px 0; list-style: none; }
+.sql-detail summary::-webkit-details-marker { display: none; }
+.sql-detail summary::before { content: '▸ '; }
+.sql-detail[open] summary::before { content: '▾ '; }
+.sql-detail pre { background: #1e293b; color: #e2e8f0; padding: 8px;
+                  border-radius: 4px; overflow-x: auto; font-size: 11px;
+                  white-space: pre-wrap; word-break: break-word; }
+.tool-output { background: #f9fafb; padding: 6px; border-radius: 3px;
+               font-size: 11px; white-space: pre-wrap; word-break: break-word;
+               max-height: 400px; overflow-y: auto; }
+.tool-tag { font-size: 10px; padding: 1px 5px; border-radius: 3px;
+            background: #e5e7eb; color: #374151; margin-left: 4px; }
+.tool-tag.remote { background: #dbeafe; color: #1e40af; }
+.welcome-message { background: #f9fafb; padding: 8px 10px; border-radius: 6px;
+                   font-size: 13px; color: #6b7280; }
+.welcome-examples { display: none; }
+`;
+    }
+
+    /* ------------------------------------------------------------------ */
     /*  Message rendering                                                  */
     /* ------------------------------------------------------------------ */
 

--- a/app/chat-ui.js
+++ b/app/chat-ui.js
@@ -902,6 +902,7 @@ export class ChatUI {
         const css = this._exportCss();
         const title = this._exportTitle();
         const appUrl = window.location.href;
+        const appUrlAttr = this.escapeHtml(appUrl).replace(/"/g, '&quot;');
         const appTitle = document.title || 'Geo-Agent';
         const exportedAt = new Date().toLocaleString();
 
@@ -916,7 +917,7 @@ export class ChatUI {
 <body>
 <header class="export-header">
   <h1>Geo-Agent chat transcript</h1>
-  <p>Exported ${this.escapeHtml(exportedAt)} — <a href="${this.escapeHtml(appUrl)}">${this.escapeHtml(appTitle)}</a></p>
+  <p>Exported ${this.escapeHtml(exportedAt)} — <a href="${appUrlAttr}">${this.escapeHtml(appTitle)}</a></p>
   <p class="export-note">SQL queries below have been rewritten to use the public S3 endpoint
      (<code>https://s3-west.nrp-nautilus.io/</code>) so they can be re-run from any DuckDB
      with the <code>httpfs</code> extension loaded.</p>
@@ -936,7 +937,7 @@ export class ChatUI {
             a.remove();
             URL.revokeObjectURL(url);
         } catch (err) {
-            console.warn('[ChatUI] Export failed:', err);
+            console.error('[ChatUI] Export failed:', err);
             this.addMessage('error',
                 "couldn't generate download — your browser may not support file downloads");
         }

--- a/app/chat-ui.js
+++ b/app/chat-ui.js
@@ -150,6 +150,9 @@ export class ChatUI {
         // Auto-approve toggle (always shown)
         this.initAutoApproveToggle();
 
+        // Export-to-HTML button (always shown)
+        this.initExportButton();
+
         // Optional header/footer links (github, docs, carbon)
         this.initLinks();
 
@@ -500,6 +503,41 @@ export class ChatUI {
         });
 
         footer.prepend(btn);
+    }
+
+    /* ------------------------------------------------------------------ */
+    /*  Export-to-HTML button                                              */
+    /* ------------------------------------------------------------------ */
+
+    initExportButton() {
+        const footer = this.footerRightEl;
+        if (!footer) return;
+
+        const btn = document.createElement('button');
+        btn.id = 'export-btn';
+        btn.title = 'Download this conversation as a self-contained HTML file.';
+        btn.textContent = '⬇';
+        btn.disabled = true;
+
+        btn.addEventListener('click', () => {
+            if (btn.disabled) return;
+            this.exportHtml();
+        });
+
+        footer.prepend(btn);
+        this._exportBtn = btn;
+
+        // Observe messagesEl for the first real turn appearing; enable once
+        // we see a .chat-message.user or an .agent-turn child.
+        const refresh = () => {
+            const hasTurn = !!this.messagesEl.querySelector(
+                '.chat-message.user, .agent-turn'
+            );
+            btn.disabled = !hasTurn;
+        };
+        refresh();
+        const observer = new MutationObserver(refresh);
+        observer.observe(this.messagesEl, { childList: true, subtree: true });
     }
 
     /*  Send handler                                                       */

--- a/app/chat-ui.js
+++ b/app/chat-ui.js
@@ -5,6 +5,23 @@
  * Renders collapsible tool-call blocks (VSCode Copilot-inspired).
  */
 
+/**
+ * Rewrite `s3://bucket/path` URLs to the public HTTPS endpoint so that the
+ * SQL is re-runnable from any DuckDB with httpfs loaded, outside the
+ * cluster. Mirrors (in reverse) the conversion in
+ * dataset-catalog.js:460-461.
+ *
+ * @param {string} sql
+ * @returns {string}
+ */
+export function rewriteS3UrlsInSql(sql) {
+    if (!sql) return sql;
+    return sql.replace(
+        /\bs3:\/\/([A-Za-z0-9._-]+)(\/[^\s'"]*)?/g,
+        (_m, bucket, path) => `https://s3-west.nrp-nautilus.io/${bucket}${path || ''}`
+    );
+}
+
 export class ChatUI {
     /**
      * @param {import('./agent.js').Agent} agent

--- a/app/chat-ui.js
+++ b/app/chat-ui.js
@@ -515,8 +515,8 @@ export class ChatUI {
 
         const btn = document.createElement('button');
         btn.id = 'export-btn';
-        btn.title = 'Download this conversation as a self-contained HTML file.';
-        btn.textContent = '⬇';
+        btn.title = 'Save this conversation as a self-contained HTML document you can share or print.';
+        btn.textContent = '💾';
         btn.disabled = true;
 
         btn.addEventListener('click', () => {

--- a/app/chat-ui.js
+++ b/app/chat-ui.js
@@ -55,6 +55,7 @@ export function scrubCredentials(text) {
     // Pre-signed URL signature/credential
     out = out.replace(/X-Amz-Signature=[^&\s'"]+/gi, 'X-Amz-Signature=[REDACTED]');
     out = out.replace(/X-Amz-Credential=[^&\s'"]+/gi, 'X-Amz-Credential=[REDACTED]');
+    out = out.replace(/X-Amz-Security-Token=[^&\s'"]+/gi, 'X-Amz-Security-Token=[REDACTED]');
 
     return out;
 }

--- a/app/chat-ui.js
+++ b/app/chat-ui.js
@@ -22,6 +22,43 @@ export function rewriteS3UrlsInSql(sql) {
     );
 }
 
+/**
+ * Defense-in-depth credential scrub. Replaces credential-shaped tokens with
+ * `[REDACTED]`. Each pattern requires a quoted value or structured
+ * delimiter, so false positives in prose are unlikely.
+ *
+ * @param {string} text
+ * @returns {string}
+ */
+export function scrubCredentials(text) {
+    if (text === '' || text == null) return text;
+
+    let out = text;
+
+    // DuckDB CREATE SECRET — KEY_ID 'value' / SECRET 'value'
+    out = out.replace(/(KEY_ID)\s+'[^']*'/gi, '$1 [REDACTED]');
+    out = out.replace(/(\bSECRET)\s+'[^']*'/gi, '$1 [REDACTED]');
+
+    // json/yaml/python access key assignments
+    out = out.replace(
+        /((?:aws_)?access_key(?:_id)?)["']?\s*([:=])\s*(['"])[^'"]+\3/gi,
+        '$1$2 [REDACTED]'
+    );
+    out = out.replace(
+        /((?:aws_)?secret(?:_access)?_key)["']?\s*([:=])\s*(['"])[^'"]+\3/gi,
+        '$1$2 [REDACTED]'
+    );
+
+    // Bearer tokens
+    out = out.replace(/(Authorization:)\s*Bearer\s+\S+/gi, '$1 [REDACTED]');
+
+    // Pre-signed URL signature/credential
+    out = out.replace(/X-Amz-Signature=[^&\s'"]+/gi, 'X-Amz-Signature=[REDACTED]');
+    out = out.replace(/X-Amz-Credential=[^&\s'"]+/gi, 'X-Amz-Credential=[REDACTED]');
+
+    return out;
+}
+
 export class ChatUI {
     /**
      * @param {import('./agent.js').Agent} agent

--- a/app/chat-ui.js
+++ b/app/chat-ui.js
@@ -60,6 +60,13 @@ export function scrubCredentials(text) {
     return out;
 }
 
+/**
+ * Tool-call argument keys whose values are credentials and must never be
+ * rendered to the chat or to any export. Used by both `renderToolCallArgs`
+ * (live chat) and `exportHtml` (download).
+ */
+export const REDACTED_KEYS = ['s3_key', 's3_secret', 's3_endpoint', 's3_scope', 'catalog_token'];
+
 export class ChatUI {
     /**
      * @param {import('./agent.js').Agent} agent
@@ -815,7 +822,6 @@ export class ChatUI {
             const sqlKey = args.sql_query !== undefined ? 'sql_query' : args.query !== undefined ? 'query' : 'sql';
             if (sqlText) {
                 argDisplay += `<details class="sql-detail"><summary>SQL</summary><pre><code class="language-sql">${this.escapeHtml(sqlText)}</code></pre></details>`;
-                const REDACTED_KEYS = ['s3_key', 's3_secret', 's3_endpoint', 's3_scope', 'catalog_token'];
                 const otherArgs = Object.fromEntries(
                     Object.entries(args).filter(([k]) => k !== sqlKey && !REDACTED_KEYS.includes(k))
                 );

--- a/app/chat.css
+++ b/app/chat.css
@@ -849,6 +849,27 @@ details[open]>.query-summary-btn::before {
     color: #d97706;
 }
 
+#export-btn {
+    background: transparent;
+    border: 1px solid #cbd5e1;
+    border-radius: 4px;
+    padding: 2px 8px;
+    font-size: 14px;
+    color: #475569;
+    cursor: pointer;
+    line-height: 1;
+}
+
+#export-btn:hover:not(:disabled) {
+    background: #f1f5f9;
+    color: #1e293b;
+}
+
+#export-btn:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+}
+
 /* ── Settings panel (user-provided API key mode) ────────── */
 
 #settings-btn {

--- a/app/chat.css
+++ b/app/chat.css
@@ -850,19 +850,20 @@ details[open]>.query-summary-btn::before {
 }
 
 #export-btn {
-    background: transparent;
-    border: 1px solid #cbd5e1;
+    background: none;
+    border: none;
     border-radius: 4px;
-    padding: 2px 8px;
+    padding: 2px 6px;
     font-size: 14px;
-    color: #475569;
+    color: rgba(0, 0, 0, 0.4);
     cursor: pointer;
     line-height: 1;
+    opacity: 0.5;
+    transition: opacity 0.15s, color 0.15s;
 }
 
 #export-btn:hover:not(:disabled) {
-    background: #f1f5f9;
-    color: #1e293b;
+    opacity: 0.9;
 }
 
 #export-btn:disabled {

--- a/docs/guide/agent-loop.md
+++ b/docs/guide/agent-loop.md
@@ -67,7 +67,7 @@ A toggle in the chat UI lets users switch remote tools to auto-approve mode, ski
 
 Tool call arguments displayed in the UI are filtered to strip S3 credentials, API tokens, and similar secrets before rendering. This applies to both the collapsed "Running: …" blocks and the expanded Details view, so sensitive values injected into SQL or tool parameters are never shown to the user.
 
-The same redaction extends to the HTML chat export (the ⬇ button in the chat footer): the same key list is re-applied to the cloned DOM as an invariant, and a defense-in-depth regex pass scrubs credential-shaped tokens (AWS access keys, `CREATE SECRET` values, `Authorization: Bearer …` tokens, pre-signed-URL signature/credential/session-token parameters) that might have reached the rendered DOM through other paths. See [Chat export](/guide/configuration#chat-export) for the user-facing description.
+The same redaction extends to the HTML chat export (the 💾 save button in the chat footer): the same key list is re-applied to the cloned DOM as an invariant, and a defense-in-depth regex pass scrubs credential-shaped tokens (AWS access keys, `CREATE SECRET` values, `Authorization: Bearer …` tokens, pre-signed-URL signature/credential/session-token parameters) that might have reached the rendered DOM through other paths. See [Chat export](/guide/configuration#chat-export) for the user-facing description.
 
 ## Pre-call explanation: how it works
 

--- a/docs/guide/agent-loop.md
+++ b/docs/guide/agent-loop.md
@@ -67,6 +67,8 @@ A toggle in the chat UI lets users switch remote tools to auto-approve mode, ski
 
 Tool call arguments displayed in the UI are filtered to strip S3 credentials, API tokens, and similar secrets before rendering. This applies to both the collapsed "Running: …" blocks and the expanded Details view, so sensitive values injected into SQL or tool parameters are never shown to the user.
 
+The same redaction extends to the HTML chat export (the ⬇ button in the chat footer): the same key list is re-applied to the cloned DOM as an invariant, and a defense-in-depth regex pass scrubs credential-shaped tokens (AWS access keys, `CREATE SECRET` values, `Authorization: Bearer …` tokens, pre-signed-URL signature/credential/session-token parameters) that might have reached the rendered DOM through other paths. See [Chat export](/guide/configuration#chat-export) for the user-facing description.
+
 ## Pre-call explanation: how it works
 
 When the LLM returns a response with tool calls, it often (but not always) includes a `message.content` alongside the `tool_calls`. This text is the model's reasoning — its natural-language explanation of what it's about to do.

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -424,6 +424,17 @@ Set `auto_approve: false` to require a **Run** / **Cancel** confirmation before 
 
 A ⚡ toggle button in the chat footer lets users switch auto-approve on or off at runtime. The toggle affects only the current session — every page load resets to the `auto_approve` value from config.
 
+## Chat export
+
+A ⬇ button in the chat footer downloads the current conversation as a self-contained HTML file. The button is disabled until the first user message and enables automatically after. No configuration — it's always present.
+
+The downloaded file mirrors what the user sees in the live chat: user prompts, assistant prose, and tool-call rows with collapsible SQL and result blocks. Everything is in a single `.html` with inlined CSS — no external assets, no JavaScript required to view it.
+
+Two guarantees apply to the export:
+
+- **Reproducible SQL.** Every `s3://bucket/...` URL inside a SQL block is rewritten to `https://s3-west.nrp-nautilus.io/bucket/...`. Pasting the SQL into any DuckDB with `INSTALL httpfs; LOAD httpfs;` will run it against the public endpoint without secret configuration (public buckets only).
+- **Credential scrubbing.** On top of the live-chat redaction described in the agent-loop docs, the export pass replaces credential-shaped tokens with `[REDACTED]` — DuckDB `CREATE SECRET` key/value pairs, AWS access keys (`aws_access_key_id`, `aws_secret_access_key`), `Authorization: Bearer …` tokens, and pre-signed-URL `X-Amz-Signature` / `X-Amz-Credential` / `X-Amz-Security-Token` query parameters.
+
 ## Finding STAC asset IDs
 
 Browse the catalog in STAC Browser:

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -426,9 +426,9 @@ A ⚡ toggle button in the chat footer lets users switch auto-approve on or off 
 
 ## Chat export
 
-A ⬇ button in the chat footer downloads the current conversation as a self-contained HTML file. The button is disabled until the first user message and enables automatically after. No configuration — it's always present.
+A 💾 save button in the chat footer saves the current conversation as a self-contained HTML document you can share or print. The button is disabled until the first user message and enables automatically after. No configuration — it's always present.
 
-The downloaded file mirrors what the user sees in the live chat: user prompts, assistant prose, and tool-call rows with collapsible SQL and result blocks. Everything is in a single `.html` with inlined CSS — no external assets, no JavaScript required to view it.
+The saved file mirrors what the user sees in the live chat: user prompts, assistant prose, and tool-call rows with collapsible SQL and result blocks. Everything is in a single `.html` with inlined CSS — no external assets, no JavaScript required to view it.
 
 Two guarantees apply to the export:
 

--- a/test/chat-export.test.js
+++ b/test/chat-export.test.js
@@ -41,3 +41,66 @@ describe('rewriteS3UrlsInSql', () => {
         expect(rewriteS3UrlsInSql('')).toBe('');
     });
 });
+
+import { scrubCredentials } from '../app/chat-ui.js';
+
+describe('scrubCredentials', () => {
+    it('redacts DuckDB CREATE SECRET KEY_ID and SECRET values', () => {
+        const sql =
+            "CREATE SECRET my_secret (TYPE S3, KEY_ID 'AKIAIOSFODNN7EXAMPLE', " +
+            "SECRET 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY');";
+        const out = scrubCredentials(sql);
+        expect(out).not.toContain('AKIAIOSFODNN7EXAMPLE');
+        expect(out).not.toContain('wJalrXUtnFEMI');
+        expect(out).toMatch(/KEY_ID\s+\[REDACTED\]/);
+        expect(out).toMatch(/SECRET\s+\[REDACTED\]/);
+        expect(out).toContain('CREATE SECRET my_secret');
+    });
+
+    it('redacts case-insensitive key_id and secret', () => {
+        const sql = "key_id 'AKIA…' secret 'xyz'";
+        const out = scrubCredentials(sql);
+        expect(out).not.toContain('AKIA');
+        expect(out).not.toContain('xyz');
+    });
+
+    it('redacts aws_access_key_id assignments (json/yaml/python)', () => {
+        const json = '"aws_access_key_id": "AKIAEXAMPLE"';
+        const py = "aws_access_key_id = 'AKIAEXAMPLE'";
+        expect(scrubCredentials(json)).not.toContain('AKIAEXAMPLE');
+        expect(scrubCredentials(py)).not.toContain('AKIAEXAMPLE');
+    });
+
+    it('redacts aws_secret_access_key assignments', () => {
+        const text = '"aws_secret_access_key": "wJalrXUtnFEMI/K7MDENG"';
+        expect(scrubCredentials(text)).not.toContain('wJalrXUtnFEMI');
+    });
+
+    it('redacts Authorization Bearer tokens', () => {
+        const text = 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.abc.def';
+        const out = scrubCredentials(text);
+        expect(out).not.toContain('eyJhbGciOiJIUzI1NiJ9');
+        expect(out).toMatch(/Authorization:\s*\[REDACTED\]/);
+    });
+
+    it('redacts X-Amz-Signature values inside URLs', () => {
+        const url =
+            'https://s3-west.nrp-nautilus.io/b/x.parquet?' +
+            'X-Amz-Signature=abc123def456&X-Amz-Credential=AKIA/20260101/us-east-1';
+        const out = scrubCredentials(url);
+        expect(out).not.toContain('abc123def456');
+        expect(out).not.toContain('AKIA/20260101');
+        expect(out).toContain('s3-west.nrp-nautilus.io/b/x.parquet');
+    });
+
+    it('leaves plain prose mentioning KEY_ID alone (no quoted value follows)', () => {
+        const prose = 'You must provide your KEY_ID before running this query.';
+        expect(scrubCredentials(prose)).toBe(prose);
+    });
+
+    it('returns empty input unchanged', () => {
+        expect(scrubCredentials('')).toBe('');
+        expect(scrubCredentials(undefined)).toBe(undefined);
+        expect(scrubCredentials(null)).toBe(null);
+    });
+});

--- a/test/chat-export.test.js
+++ b/test/chat-export.test.js
@@ -93,6 +93,17 @@ describe('scrubCredentials', () => {
         expect(out).toContain('s3-west.nrp-nautilus.io/b/x.parquet');
     });
 
+    it('redacts X-Amz-Security-Token values inside URLs (STS session tokens)', () => {
+        const url =
+            'https://s3-west.nrp-nautilus.io/b/x.parquet?' +
+            'X-Amz-Security-Token=FQoGZ.eXampleToken/abc123&X-Amz-Signature=def456';
+        const out = scrubCredentials(url);
+        expect(out).not.toContain('FQoGZ.eXampleToken');
+        expect(out).not.toContain('def456');
+        expect(out).toContain('s3-west.nrp-nautilus.io/b/x.parquet');
+        expect(out).toMatch(/X-Amz-Security-Token=\[REDACTED\]/);
+    });
+
     it('leaves plain prose mentioning KEY_ID alone (no quoted value follows)', () => {
         const prose = 'You must provide your KEY_ID before running this query.';
         expect(scrubCredentials(prose)).toBe(prose);

--- a/test/chat-export.test.js
+++ b/test/chat-export.test.js
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { rewriteS3UrlsInSql } from '../app/chat-ui.js';
+
+describe('rewriteS3UrlsInSql', () => {
+    it('rewrites a single s3:// URL inside read_parquet', () => {
+        const sql = "SELECT * FROM read_parquet('s3://public-data/foo.parquet') LIMIT 5";
+        expect(rewriteS3UrlsInSql(sql)).toBe(
+            "SELECT * FROM read_parquet('https://s3-west.nrp-nautilus.io/public-data/foo.parquet') LIMIT 5"
+        );
+    });
+
+    it('rewrites multiple s3:// URLs in one string (join)', () => {
+        const sql =
+            "SELECT a.* FROM read_parquet('s3://b1/a.parquet') a " +
+            "JOIN read_parquet('s3://b2/b.parquet') b ON a.id = b.id";
+        const out = rewriteS3UrlsInSql(sql);
+        expect(out).toContain("'https://s3-west.nrp-nautilus.io/b1/a.parquet'");
+        expect(out).toContain("'https://s3-west.nrp-nautilus.io/b2/b.parquet'");
+        expect(out).not.toContain('s3://');
+    });
+
+    it('handles bare s3://bucket with no trailing slash', () => {
+        expect(rewriteS3UrlsInSql('s3://my-bucket')).toBe(
+            'https://s3-west.nrp-nautilus.io/my-bucket'
+        );
+    });
+
+    it('preserves dotted and hyphenated bucket names', () => {
+        const sql = "FROM read_parquet('s3://my.bucket-name/x.parquet')";
+        expect(rewriteS3UrlsInSql(sql)).toBe(
+            "FROM read_parquet('https://s3-west.nrp-nautilus.io/my.bucket-name/x.parquet')"
+        );
+    });
+
+    it('leaves non-s3 schemes alone', () => {
+        const sql = "FROM read_parquet('gs://bucket/x.parquet')";
+        expect(rewriteS3UrlsInSql(sql)).toBe(sql);
+    });
+
+    it('returns empty string for empty input', () => {
+        expect(rewriteS3UrlsInSql('')).toBe('');
+    });
+});


### PR DESCRIPTION
## Summary
- Adds a ⬇ Export button to the chat footer that downloads the current conversation as a self-contained HTML file.
- SQL inside the export is rewritten from `s3://bucket/...` to `https://s3-west.nrp-nautilus.io/bucket/...` so users can re-run queries from any DuckDB with `httpfs` loaded.
- Defense-in-depth credential scrub (DuckDB `CREATE SECRET` values, AWS access keys, `Authorization: Bearer` tokens, pre-signed-URL `X-Amz-Signature`/`X-Amz-Credential`/`X-Amz-Security-Token`) layered on top of the existing live-chat redaction.
- Two new pure helpers (`rewriteS3UrlsInSql`, `scrubCredentials`) covered by 15 new unit tests in `test/chat-export.test.js`.

Addresses part of #62 (chat export). Map export and report generation remain open; this PR does not close the issue.

## Implementation notes
- `app/chat-ui.js`: new `exportHtml()` method on `ChatUI` clones `messagesEl`, sanitizes the clone (drops approval buttons, in-flight spinners, scripts; rewrites SQL inside `code.language-sql`; runs the credential scrub over text nodes), assembles a self-contained HTML document with inlined CSS, and triggers a Blob download.
- `REDACTED_KEYS` was promoted from a function-local to a module-level export so the export pass can re-apply it as an invariant.
- `app/chat.css`: minimal `#export-btn` rule, mirroring `#auto-approve-btn` styling.
- No new modules. No changes to `agent.js`, `map-manager.js`, `layout-manager.js`, or any other file.

## Test plan
- [x] `npm test` — 527/527 pass (15 new tests for the two helpers, 512 pre-existing)
- [ ] Local app: ⬇ button is disabled before the first user message, enabled after
- [ ] Local app: clicking ⬇ downloads `geo-agent-chat-YYYY-MM-DD-HHMM.html`
- [ ] Open the downloaded file in a clean tab: page is self-contained (zero network requests in DevTools), collapsible SQL/result `<details>` work without JS
- [ ] Copy a SQL block from the export and run it in `duckdb -c "INSTALL httpfs; LOAD httpfs; <SQL>"` — same rows
- [ ] Search the export source for `s3_key`, `KEY_ID '`, `Bearer ` followed by an actual token, `X-Amz-Signature=` followed by a value — none found

## Merge note
Per `feedback_no_squash_merge.md`, this should be merged with a regular merge commit (not squashed), since downstream apps pin to SHAs.