### PR TITLE
feat(sidebar): draggable splitter + chat-collapse toggle

### DIFF
--- a/app/layout-manager.js
+++ b/app/layout-manager.js
@@ -121,6 +121,21 @@ function buildSidebarLayout(appConfig, title) {
     // Layers pane — MapManager.generateMenu() will mount inside this element.
     const layersPane = el('div', { id: 'sidebar-layers-pane' });
 
+    // Splitter — draggable bar to resize the layers/chat split.
+    const splitter = el('div', { class: 'sidebar-splitter', title: 'Drag to resize' });
+
+    // Chat section header — mirrors the layers .menu-header pattern so the
+    // chat can be collapsed independently. Title only shows while collapsed.
+    const chatSectionHeader = el('div', { id: 'chat-section-header' });
+    const chatSectionTitle = el('label', { class: 'section-title' });
+    chatSectionTitle.textContent = 'Chat';
+    const chatToggle = el('button', {
+        id: 'chat-section-toggle',
+        title: 'Toggle chat',
+    });
+    chatToggle.textContent = '−';
+    chatSectionHeader.append(chatSectionTitle, chatToggle);
+
     // Chat message list
     const messages = el('div', { id: 'chat-messages' });
 
@@ -153,7 +168,16 @@ function buildSidebarLayout(appConfig, title) {
     footerRight.append(modelSelector);
     footer.append(footerRight);
 
-    sidebar.append(resizeHandle, header, layersPane, messages, inputContainer, footer);
+    sidebar.append(
+        resizeHandle,
+        header,
+        layersPane,
+        splitter,
+        chatSectionHeader,
+        messages,
+        inputContainer,
+        footer,
+    );
     document.body.appendChild(sidebar);
 
     // Floating "show" button pinned to the top-right of the map,
@@ -167,6 +191,8 @@ function buildSidebarLayout(appConfig, title) {
 
     initSidebarResize(resizeHandle, defaultWidth);
     initSidebarCollapse(sidebar, hideBtn, showBtn);
+    initLayersSplitter(splitter, sidebar);
+    initChatCollapse(chatToggle);
 
     return {
         chatMount: {
@@ -325,6 +351,105 @@ function initSidebarCollapse(sidebar, hideBtn, showBtn) {
     // that's what actually transitions.
     sidebar.addEventListener('transitionend', (e) => {
         if (e.propertyName !== 'transform') return;
+        sidebarHooks.onResizeEnd?.();
+    });
+}
+
+/* ----- Layers/chat splitter: drag → CSS var → localStorage --------------- */
+
+const LAYERS_PANE_HEIGHT_KEY = 'geo-agent-layers-pane-height';
+// Min content height for either side; also leaves the chat input visible.
+const SPLITTER_MIN = 80;
+
+function layersHeightBounds(sidebar) {
+    // Reserve room for sidebar-header + chat-section-header + input + footer
+    // plus a SPLITTER_MIN floor for the chat-messages region.
+    const reserved = Array.from(
+        sidebar.querySelectorAll(
+            '#sidebar-header, #chat-section-header, #chat-input-container, #sidebar-footer',
+        ),
+    ).reduce((sum, n) => sum + n.offsetHeight, 0);
+    const max = Math.max(SPLITTER_MIN, sidebar.clientHeight - reserved - SPLITTER_MIN);
+    return { min: SPLITTER_MIN, max };
+}
+
+function applyLayersPaneHeight(h) {
+    document.documentElement.style.setProperty('--layers-pane-height', h + 'px');
+    document.body.classList.add('layers-pane-resized');
+}
+
+function initLayersSplitter(handle, sidebar) {
+    // Restore persisted height on boot (sets the body class so CSS takes over).
+    const stored = Number(localStorage.getItem(LAYERS_PANE_HEIGHT_KEY));
+    if (Number.isFinite(stored) && stored >= SPLITTER_MIN) {
+        applyLayersPaneHeight(stored);
+    }
+
+    let dragging = false;
+    let startY = 0;
+    let startH = 0;
+    let pendingH = 0;
+    let rafPending = false;
+
+    const onMove = (e) => {
+        if (!dragging) return;
+        const { min, max } = layersHeightBounds(sidebar);
+        pendingH = Math.min(max, Math.max(min, startH + (e.clientY - startY)));
+        if (!rafPending) {
+            rafPending = true;
+            requestAnimationFrame(() => {
+                rafPending = false;
+                applyLayersPaneHeight(pendingH);
+            });
+        }
+    };
+
+    const onUp = () => {
+        if (!dragging) return;
+        dragging = false;
+        document.removeEventListener('mousemove', onMove);
+        document.removeEventListener('mouseup', onUp);
+        document.body.style.userSelect = '';
+        document.body.style.cursor = '';
+        applyLayersPaneHeight(pendingH);
+        localStorage.setItem(LAYERS_PANE_HEIGHT_KEY, String(pendingH));
+    };
+
+    handle.addEventListener('mousedown', (e) => {
+        if (getComputedStyle(handle).pointerEvents === 'none') return;
+        e.preventDefault();
+        dragging = true;
+        startY = e.clientY;
+        const layersPane = sidebar.querySelector('#sidebar-layers-pane');
+        startH = layersPane ? layersPane.offsetHeight : 200;
+        pendingH = startH;
+        document.body.style.userSelect = 'none';
+        document.body.style.cursor = 'row-resize';
+        document.addEventListener('mousemove', onMove);
+        document.addEventListener('mouseup', onUp);
+    });
+}
+
+/* ----- Chat collapse toggle --------------------------------------------- */
+
+const CHAT_COLLAPSED_KEY = 'geo-agent-chat-collapsed';
+
+function setChatCollapsed(collapsed, toggleBtn) {
+    document.body.classList.toggle('chat-collapsed', collapsed);
+    toggleBtn.textContent = collapsed ? '+' : '−';
+    localStorage.setItem(CHAT_COLLAPSED_KEY, collapsed ? '1' : '0');
+}
+
+function initChatCollapse(toggleBtn) {
+    // Restore persisted state.
+    const initial = localStorage.getItem(CHAT_COLLAPSED_KEY) === '1';
+    setChatCollapsed(initial, toggleBtn);
+
+    toggleBtn.addEventListener('click', () => {
+        const next = !document.body.classList.contains('chat-collapsed');
+        setChatCollapsed(next, toggleBtn);
+        // Map width hasn't changed, but trigger the same reflow hook used by
+        // sidebar resize in case downstream code wants to react.
         sidebarHooks.onResizeEnd?.();
     });
 }

--- a/app/sidebar.css
+++ b/app/sidebar.css
@@ -98,6 +98,27 @@ body.sidebar-mode #sidebar-layers-pane {
     max-height: 40%;
     overflow-y: auto;
     padding: 8px 12px 16px;
+    /* Divider line lives on .sidebar-splitter when the splitter is visible. */
+}
+
+/* Once the user drags the splitter, switch to fixed-pixel sizing.
+ * Skipped when either pane is collapsed (other rules below take over). */
+body.sidebar-mode.layers-pane-resized:not(.chat-collapsed)
+    #sidebar-layers-pane:not(.collapsed) {
+    flex: 0 0 var(--layers-pane-height, 200px);
+    max-height: none;
+}
+
+/* When chat is collapsed, layers pane fills the available height. */
+body.sidebar-mode.chat-collapsed #sidebar-layers-pane {
+    flex: 1 1 auto;
+    max-height: none;
+    border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+}
+
+/* Layers pane keeps a visible divider when its own splitter is hidden
+ * (which happens when the layers pane itself is collapsed). */
+body.sidebar-mode #sidebar-layers-pane.collapsed {
     border-bottom: 1px solid rgba(0, 0, 0, 0.1);
 }
 
@@ -114,6 +135,79 @@ body.sidebar-mode #sidebar-layers-pane:not(.collapsed) .menu-header .section-tit
 body.sidebar-mode #sidebar-layers-pane:not(.collapsed) .menu-header {
     justify-content: flex-end;
     margin-bottom: 4px;
+}
+
+/* ----- Splitter between layers pane and chat ---------------------------- */
+
+body.sidebar-mode .sidebar-splitter {
+    flex: 0 0 5px;
+    background: transparent;
+    border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+    cursor: row-resize;
+    transition: background 120ms ease, border-color 120ms ease;
+    z-index: 1;
+}
+
+body.sidebar-mode .sidebar-splitter:hover {
+    background: rgba(120, 170, 255, 0.12);
+    border-bottom-color: rgba(120, 170, 255, 0.8);
+}
+
+/* Hide the splitter when either side is fully collapsed — nothing to drag. */
+body.sidebar-mode.chat-collapsed .sidebar-splitter,
+body.sidebar-mode #sidebar-layers-pane.collapsed + .sidebar-splitter {
+    display: none;
+}
+
+/* ----- Chat section header (collapse toggle bar) ------------------------ */
+
+body.sidebar-mode #chat-section-header {
+    flex: 0 0 auto;
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    padding: 4px 8px;
+    font-size: 11px;
+    color: rgba(0, 0, 0, 0.55);
+    letter-spacing: 0.4px;
+    text-transform: uppercase;
+}
+
+body.sidebar-mode #chat-section-header .section-title {
+    margin: 0;
+    font-weight: 600;
+    /* Mirror layers menu-header: only show the title while collapsed. */
+    display: none;
+}
+
+body.sidebar-mode.chat-collapsed #chat-section-header {
+    justify-content: space-between;
+    border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+}
+
+body.sidebar-mode.chat-collapsed #chat-section-header .section-title {
+    display: inline;
+}
+
+body.sidebar-mode #chat-section-toggle {
+    background: transparent;
+    border: none;
+    color: inherit;
+    font-size: 14px;
+    line-height: 1;
+    cursor: pointer;
+    padding: 0 6px;
+    border-radius: 3px;
+}
+
+body.sidebar-mode #chat-section-toggle:hover {
+    background: rgba(0, 0, 0, 0.06);
+}
+
+/* Hide chat content when collapsed; layers pane fills the gap. */
+body.sidebar-mode.chat-collapsed #chat-messages,
+body.sidebar-mode.chat-collapsed #chat-input-container {
+    display: none;
 }
 
 /* ----- Chat region — override a few chat.css rules that assume a
@@ -228,7 +322,8 @@ body.sidebar-mode #h3-res-badge {
         width: var(--sidebar-width);
         box-shadow: -4px 0 10px rgba(0, 0, 0, 0.35);
     }
-    body.sidebar-mode .sidebar-resize-handle {
+    body.sidebar-mode .sidebar-resize-handle,
+    body.sidebar-mode .sidebar-splitter {
         /* Drag-resize disabled on narrow viewports. */
         pointer-events: none;
     }


### PR DESCRIPTION
## Summary

- Replaces the static border between the layers pane and the chat region with a draggable horizontal splitter — drag up to give more room to chat, drag down to give more room to layers.
- Adds a chat-section-header with a collapse toggle mirroring the existing layers-pane collapse, so the chat can be hidden entirely and the layers list can use the full sidebar height.
- Splitter position (`--layers-pane-height`) and chat-collapse state persist in `localStorage`. The splitter auto-hides while either pane is collapsed.
- All new behavior is scoped to `body.sidebar-mode`; floating mode is untouched.

Closes #228.

## Implementation notes

**`app/layout-manager.js`** — in `buildSidebarLayout`, inserts a `.sidebar-splitter` div and a `#chat-section-header` (label + toggle button) between the layers pane and `#chat-messages`. Two new init helpers:

- `initLayersSplitter` — `mousedown`/`mousemove`/`mouseup` drag loop with rAF-batched CSS-var updates, mirroring the pattern used by `initSidebarResize`. Adds `body.layers-pane-resized` once the user has explicitly resized, switching the layers pane from content-sized to fixed-pixel sizing.
- `initChatCollapse` — toggles `body.chat-collapsed`, persists the flag, and pings `sidebarHooks.onResizeEnd?.()` so any downstream reflow runs.

Clamps: layers-pane height is clamped to `[80px, sidebarHeight − (header + chat-header + input + footer + 80px)]` so the chat input always stays visible.

**`app/sidebar.css`** — moves the divider line off `#sidebar-layers-pane` and onto `.sidebar-splitter` (hover state mirrors the existing horizontal `.sidebar-resize-handle`). Adds `body.layers-pane-resized` override (fixed-pixel layers height) and `body.chat-collapsed` rules (hide chat content + splitter, let layers fill, restore a bottom border on the layers pane since the splitter is gone). Splitter is also `pointer-events: none` under the existing `max-width: 700px` mobile breakpoint.

## Edge cases covered

- **Layers pane collapsed** (existing toggle): adjacent splitter hides via `#sidebar-layers-pane.collapsed + .sidebar-splitter { display: none }`, layers-pane keeps a visible bottom border.
- **Chat collapsed** (new toggle): chat content + splitter hide, layers pane switches to `flex: 1 1 auto` to fill, keeps a bottom border.
- **Mobile / narrow viewport**: splitter drag disabled alongside the existing horizontal handle.
- **Sidebar hidden** (`.sidebar-collapsed`): the splitter and collapse toggle live inside the sidebar and slide off-screen with it — no-op while hidden.
- **Both panes collapsed**: degenerate but harmless — two thin headers stack, each with a "+" button to re-expand. Did not add auto-expand logic since the visual result is self-explanatory.

## Test plan

`layout-manager.js` is uncovered in the vitest suite (per the coverage table in `AGENTS.md`, browser-bound UI modules are verified manually). No Node.js is available in the sandbox where this change was authored, so `npm test` was not run here — please run it in CI / locally before merging.

Manual verification (recommended on the geo-agent-template downstream app once a tag exists, or on a local app with `sidebar.enabled: true`):

- [ ] Drag splitter up → chat grows, layers pane shrinks; reverse works too.
- [ ] Drop and reload → splitter position is restored from localStorage.
- [ ] Try to drag past the top/bottom limits → clamps at min (~80px) on either side; chat input stays visible.
- [ ] Click chat-section-toggle "−" → chat region (messages + input) hides; layers pane fills the sidebar; splitter disappears.
- [ ] Click chat-section-toggle "+" → previous split is restored.
- [ ] Collapse the layers pane via its existing toggle → splitter hides; chat fills.
- [ ] Resize the browser to under 700px wide → splitter no longer reacts to mouse (consistent with the existing sidebar-resize handle).
- [ ] Floating mode (`sidebar.enabled: false` or unset) → no visual change.