### PR TITLE
feat(sidebar): configurable persistent chat heading (sidebar.chat_title)

### DIFF
--- a/app/layout-manager.js
+++ b/app/layout-manager.js
@@ -125,10 +125,14 @@ function buildSidebarLayout(appConfig, title) {
     const splitter = el('div', { class: 'sidebar-splitter', title: 'Drag to resize' });
 
     // Chat section header — mirrors the layers .menu-header pattern so the
-    // chat can be collapsed independently. Title only shows while collapsed.
+    // chat can be collapsed independently. By default the title only shows
+    // while collapsed; set sidebar.chat_title to render it as a persistent
+    // heading above the chat (parallel to the layers "Overlays" label).
     const chatSectionHeader = el('div', { id: 'chat-section-header' });
     const chatSectionTitle = el('label', { class: 'section-title' });
-    chatSectionTitle.textContent = 'Chat';
+    const chatTitle = appConfig.sidebar?.chat_title;
+    chatSectionTitle.textContent = chatTitle || 'Chat';
+    if (chatTitle) chatSectionHeader.classList.add('has-chat-title');
     const chatToggle = el('button', {
         id: 'chat-section-toggle',
         title: 'Toggle chat',

--- a/app/sidebar.css
+++ b/app/sidebar.css
@@ -189,6 +189,16 @@ body.sidebar-mode.chat-collapsed #chat-section-header .section-title {
     display: inline;
 }
 
+/* Opt-in via sidebar.chat_title: show the heading persistently (not just
+ * while collapsed), mirroring the always-visible layers "Overlays" label. */
+body.sidebar-mode #chat-section-header.has-chat-title {
+    justify-content: space-between;
+}
+
+body.sidebar-mode #chat-section-header.has-chat-title .section-title {
+    display: inline;
+}
+
 body.sidebar-mode #chat-section-toggle {
     background: transparent;
     border: none;

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -316,6 +316,13 @@ left edge is draggable (width clamps to `[280px, 60vw]`), and a header button
 collapses it off-screen for an unobstructed map. A floating "show" button on
 the map restores the sidebar when collapsed.
 
+Within the panel, the layer-controls menu sits on top (under its "Overlays"
+heading) and the chat below, separated by a draggable splitter that lets you
+rebalance the two. Each section can be collapsed independently. Set
+`chat_title` to give the chat section a persistent heading that mirrors the
+layers "Overlays" label; otherwise the chat has no heading except while
+collapsed.
+
 Below a viewport width of 700px (tablets, phones), the sidebar automatically
 switches to overlay mode: it floats above the map rather than pushing it, and
 drag-resize is disabled. It also starts collapsed by default, so mobile users

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -296,7 +296,8 @@ If your `index.html` contains a `<div id="chat-container">` block with nested ch
 "sidebar": {
     "enabled": true,
     "default_width": 420,
-    "title": "Data Assistant"
+    "title": "Data Assistant",
+    "chat_title": "Chatbot"
 }
 ```
 
@@ -304,7 +305,8 @@ If your `index.html` contains a `<div id="chat-container">` block with nested ch
 |---|---|---|---|
 | `enabled` | boolean | `false` | Opts in to sidebar mode. Omitting the whole `sidebar` block is equivalent to `false`. |
 | `default_width` | number | `420` | Starting width in pixels. The user's last-dragged width (stored in `localStorage`) overrides this on reload, as long as it's within bounds. |
-| `title` | string | `"Data Assistant"` | Text shown in the sidebar header (and in the floating panel header too — this key applies to both modes). |
+| `title` | string | `"Data Assistant"` | Text shown in the sidebar header (and in the floating panel header too — this key applies to both modes). This is the header at the **top** of the sidebar, above both the layers and the chat. |
+| `chat_title` | string | _(unset)_ | Optional heading shown **persistently above the chat section**, mirroring the layers "Overlays" label. When unset, the chat section has no visible heading except a "Chat" label that appears only while the chat pane is collapsed. |
 
 ### Behavior
 


### PR DESCRIPTION
Closes #230.

## What

Adds an opt-in `sidebar.chat_title` config field. When an app sets it, the chat section header renders as a **persistent heading above the chat** — mirroring the always-visible layers "Overlays" label. When unset, behavior is unchanged (text `Chat`, shown only while the chat pane is collapsed), so existing apps are unaffected.

```json
"sidebar": {
    "enabled": true,
    "title": "TPL Data Assistant",
    "chat_title": "Chatbot"
}
```

## Changes
- `app/layout-manager.js` — read `sidebar.chat_title`; use it as the header text and add a `has-chat-title` class when present.
- `app/sidebar.css` — when `.has-chat-title` is set, show the `.section-title` persistently and switch the header to `space-between` (title left, collapse toggle right).
- `docs/guide/configuration.md` — document the new field; clarify that `title` is the top-of-sidebar header (above both panes).

## Why not `sidebar.title`?
`sidebar.title` renders the header at the very top of the sidebar, above *both* the layers and the chat — it can't label the chat section specifically. This was the gap reported in #230.

## Notes
- Opt-in: no visual change for apps that don't set `chat_title`.
- CSS specificity: `.has-chat-title` rules (1,3,1)/(1,2,1) override the base hide rule (1,2,1)/(1,1,1), so the title shows without `!important`.