### PR TITLE
Checkpoint-and-resume for long agent turns (closes #216)

### DIFF
--- a/app/agent.js
+++ b/app/agent.js
@@ -30,6 +30,9 @@ export class Agent {
         // null/0 in either disables the checkpoint for that mode.
         this.maxToolCalls = config.max_tool_calls ?? 15;
         this.maxToolCallsManual = config.max_tool_calls_manual ?? 100;
+        // In-flight turn state preserved across user messages when a turn pauses
+        // at a checkpoint. null when no turn is suspended.
+        this.suspendedTurn = null;
         this.autoApprove = config.auto_approve ?? true;
         this.sessionId = crypto.randomUUID();
         this.abortController = null;
@@ -158,11 +161,14 @@ export class Agent {
             const embeddedCalls = toolCalls.length === 0 ? this.parseEmbeddedToolCalls(message.content) : [];
 
             if (toolCalls.length > 0 || embeddedCalls.length > 0) {
-                iterations++;
                 const calls = toolCalls.length > 0 ? toolCalls : this.syntheticToolCalls(embeddedCalls);
 
                 // Classify: are all calls local (auto-approve) or mixed?
                 const allLocal = calls.every(tc => this.toolRegistry.isLocal(tc.function.name));
+
+                // Only remote (MCP/SQL) rounds count toward the checkpoint
+                // threshold — local map tools are cheap and never gated.
+                if (!allLocal) iterations++;
 
                 // Strip embedded <tool_call> tags from content before displaying to user
                 const displayContent = message.content

--- a/app/agent.js
+++ b/app/agent.js
@@ -47,6 +47,7 @@ export class Agent {
         this.onResponse = () => { };
         this.onError = () => { };
         this.onRetry = () => { };
+        this.onCheckpoint = () => { };
     }
 
     /**
@@ -137,7 +138,11 @@ export class Agent {
         let iterations = 0;
 
         try {
-        while (iterations < this.maxToolCalls) {
+        while (true) {
+            const threshold = this.activeThreshold();
+            if (threshold && iterations >= threshold) {
+                return await this._checkpoint(endpoint, modelConfig, turnMessages, sqlQueries, iterations);
+            }
             this.onThinkingStart();
 
             // Call LLM — no withAbort wrapper: the shared AbortController's
@@ -249,19 +254,52 @@ export class Agent {
 
             return { response: content, sqlQueries, cancelled: false };
         }
-
-        // Hit max iterations
-        return {
-            response: `I've reached the maximum number of steps (${this.maxToolCalls}). Please try a more specific question.`,
-            sqlQueries,
-            cancelled: false
-        };
         } catch (err) {
             if (err.name === 'AbortError') {
                 return { response: null, sqlQueries, cancelled: true };
             }
             throw err;
         }
+    }
+
+    /**
+     * Pause the turn at a checkpoint: make one no-tools LLM call to produce a
+     * human-readable progress report, persist the in-flight turn so the next
+     * user message resumes it, and emit onCheckpoint. Returns a result the UI
+     * renders as a checkpoint (summary + Continue), not an error.
+     */
+    async _checkpoint(endpoint, modelConfig, turnMessages, sqlQueries, iterations) {
+        turnMessages.push({
+            role: 'user',
+            content: `You have reached a checkpoint after ${iterations} data ${iterations === 1 ? 'query' : 'queries'}. `
+                + `Summarize for the user what you have done so far, the key findings, and what remains to be done. `
+                + `Then offer to continue.`,
+        });
+
+        let summary = '';
+        try {
+            const msg = await this.callLLM(endpoint, modelConfig, turnMessages, [] /* no tools → tool_choice none */);
+            summary = (msg.content || '').trim();
+            turnMessages.push(msg);
+        } catch (err) {
+            if (err.name === 'AbortError') {
+                return { response: null, sqlQueries, cancelled: true };
+            }
+            summary = `I've run ${iterations} data queries so far and paused to check in. `
+                + `Let me know if you'd like me to continue.`;
+        }
+        if (!summary) {
+            summary = `I've run ${iterations} data queries so far and paused to check in. `
+                + `Let me know if you'd like me to continue.`;
+        }
+
+        // Persist the live turn so the next message resumes it instead of
+        // rebuilding from scratch. Record the summary in cross-turn history.
+        this.suspendedTurn = { turnMessages, sqlQueries };
+        this.messages.push({ role: 'assistant', content: summary });
+
+        this.onCheckpoint(summary, iterations);
+        return { response: summary, sqlQueries, checkpoint: true, cancelled: false };
     }
 
     /**
@@ -274,7 +312,7 @@ export class Agent {
             model: this.selectedModel,
             messages,
             tools: tools.length > 0 ? tools : undefined,
-            tool_choice: tools.length > 0 ? 'auto' : undefined,
+            tool_choice: tools.length > 0 ? 'auto' : 'none',
             user: this.sessionId,
         };
 

--- a/app/agent.js
+++ b/app/agent.js
@@ -23,7 +23,13 @@ export class Agent {
         this.systemPrompt = '';
         this.messages = [];
         this.selectedModel = config.llm_model || config.llm_models?.[0]?.value || 'default';
-        this.maxToolCalls = 20;
+        // Checkpoint thresholds: how many *remote* tool-call rounds before the
+        // agent pauses to report progress and ask to continue. Auto-approve uses
+        // the tighter value (the checkpoint is the user's periodic gate); manual
+        // mode uses a high value since per-call approval is already the guard.
+        // null/0 in either disables the checkpoint for that mode.
+        this.maxToolCalls = config.max_tool_calls ?? 15;
+        this.maxToolCallsManual = config.max_tool_calls_manual ?? 100;
         this.autoApprove = config.auto_approve ?? true;
         this.sessionId = crypto.randomUUID();
         this.abortController = null;
@@ -64,6 +70,14 @@ export class Agent {
             endpoint: 'https://llm-proxy.nrp-nautilus.io/v1',
             api_key: 'EMPTY'
         };
+    }
+
+    /**
+     * The active remote-round checkpoint threshold for the current mode.
+     * 0 or null means "no checkpoint" for that mode.
+     */
+    activeThreshold() {
+        return this.autoApprove ? this.maxToolCalls : this.maxToolCallsManual;
     }
 
     /**

--- a/app/agent.js
+++ b/app/agent.js
@@ -283,6 +283,9 @@ export class Agent {
      * renders as a checkpoint (summary + Continue), not an error.
      */
     async _checkpoint(endpoint, modelConfig, turnMessages, sqlQueries, iterations) {
+        const fallbackSummary = `I've run ${iterations} data queries so far and paused to check in. `
+            + `Let me know if you'd like me to continue.`;
+
         turnMessages.push({
             role: 'user',
             content: `You have reached a checkpoint after ${iterations} data ${iterations === 1 ? 'query' : 'queries'}. `
@@ -297,14 +300,18 @@ export class Agent {
             turnMessages.push(msg);
         } catch (err) {
             if (err.name === 'AbortError') {
+                // User stopped during the summary call. The completed tool work
+                // is still valuable — preserve it (minus the checkpoint
+                // instruction we just appended) so "continue" resumes the
+                // investigation rather than discarding the remote rounds.
+                turnMessages.pop();
+                this.suspendedTurn = { turnMessages, sqlQueries };
                 return { response: null, sqlQueries, cancelled: true };
             }
-            summary = `I've run ${iterations} data queries so far and paused to check in. `
-                + `Let me know if you'd like me to continue.`;
+            summary = fallbackSummary;
         }
         if (!summary) {
-            summary = `I've run ${iterations} data queries so far and paused to check in. `
-                + `Let me know if you'd like me to continue.`;
+            summary = fallbackSummary;
         }
 
         // Persist the live turn so the next message resumes it instead of

--- a/app/agent.js
+++ b/app/agent.js
@@ -103,8 +103,10 @@ export class Agent {
      * @returns {Promise<{response: string, sqlQueries: string[], cancelled: boolean}>}
      */
     async processMessage(userMessage) {
-        // Track SQL queries for this turn
-        const sqlQueries = [];
+        // Track SQL queries for this turn. When resuming a suspended turn, carry
+        // forward the queries already collected before the pause.
+        const resuming = this.suspendedTurn;
+        const sqlQueries = resuming ? resuming.sqlQueries : [];
 
         // Per-turn AbortController — triggered by abort() (user-pressed Stop)
         // or by the 5-min timeout inside callLLM(). Either path rejects any
@@ -123,10 +125,21 @@ export class Agent {
 
         this.messages.push({ role: 'user', content: userMessage });
 
-        const turnMessages = [
-            { role: 'system', content: this.systemPrompt },
-            ...this.messages.slice(-12),
-        ];
+        let turnMessages;
+        if (resuming) {
+            // Resume the paused turn: reuse its full tool-call history and append
+            // the new user message (a canned "continue" or a steering instruction).
+            // Do NOT rebuild from this.messages — that would discard the in-flight
+            // work and restart from scratch.
+            this.suspendedTurn = null;
+            turnMessages = resuming.turnMessages;
+            turnMessages.push({ role: 'user', content: userMessage });
+        } else {
+            turnMessages = [
+                { role: 'system', content: this.systemPrompt },
+                ...this.messages.slice(-12),
+            ];
+        }
 
         const tools = this.toolRegistry.getToolsForLLM();
         const modelConfig = this.getModelConfig();
@@ -251,6 +264,7 @@ export class Agent {
 
             // Store in conversation history
             this.messages.push({ role: 'assistant', content });
+            this.suspendedTurn = null;
 
             return { response: content, sqlQueries, cancelled: false };
         }

--- a/app/chat-ui.js
+++ b/app/chat-ui.js
@@ -587,6 +587,13 @@ export class ChatUI {
             } else {
                 this.endTurn('done');
             }
+
+            // If the turn paused with work preserved — a checkpoint, or Stop
+            // pressed during the checkpoint summary — offer a one-click resume.
+            // Typing any message also resumes (and can steer) the paused turn.
+            if (this.agent.suspendedTurn) {
+                this.renderContinueButton();
+            }
         } catch (err) {
             console.error('[ChatUI] Error:', err);
             this.endTurn('error');
@@ -619,6 +626,10 @@ export class ChatUI {
      * assistant's final answer arrives.
      */
     startTurn() {
+        // A new turn supersedes any prior checkpoint prompt — drop stale
+        // Continue buttons so only the latest pause offers a resume.
+        this.messagesEl.querySelectorAll('.checkpoint-actions').forEach(el => el.remove());
+
         const container = document.createElement('details');
         container.className = 'agent-turn running';
         container.open = true;
@@ -1116,6 +1127,32 @@ body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-
             if (typeof hljs !== 'undefined') hljs.highlightElement(block);
         });
 
+        this.scrollToBottom();
+    }
+
+    /**
+     * Offer a one-click resume after the agent pauses at a checkpoint (or the
+     * user stopped during the checkpoint summary). The agent keeps the
+     * in-flight work in suspendedTurn; sending "continue" resumes it, while
+     * typing any other message resumes with that steer instead.
+     */
+    renderContinueButton() {
+        const wrap = document.createElement('div');
+        wrap.className = 'chat-message checkpoint-actions';
+
+        const btn = document.createElement('button');
+        btn.className = 'continue-btn';
+        btn.textContent = '▶ Continue';
+        btn.title = 'Resume where the agent paused';
+        btn.addEventListener('click', () => {
+            if (this.busy) return;
+            btn.disabled = true;
+            this.inputEl.value = 'continue';
+            this.handleSend();
+        });
+
+        wrap.appendChild(btn);
+        this.messagesEl.appendChild(wrap);
         this.scrollToBottom();
     }
 

--- a/app/chat-ui.js
+++ b/app/chat-ui.js
@@ -1147,7 +1147,8 @@ body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-
         btn.addEventListener('click', () => {
             if (this.busy) return;
             btn.disabled = true;
-            this.inputEl.value = 'continue';
+            // Preserve a steer the user already typed; default to a plain resume.
+            if (!this.inputEl.value.trim()) this.inputEl.value = 'continue';
             this.handleSend();
         });
 

--- a/app/chat.css
+++ b/app/chat.css
@@ -372,6 +372,31 @@
     max-width: 95%;
 }
 
+/* Checkpoint "Continue" affordance, shown when the agent pauses mid-turn */
+.chat-message.checkpoint-actions {
+    align-self: flex-start;
+    padding: 0;
+}
+
+.continue-btn {
+    padding: 6px 14px;
+    border: none;
+    border-radius: 8px;
+    background: rgba(0, 122, 255, 0.85);
+    color: #fff;
+    font-size: 13px;
+    cursor: pointer;
+}
+
+.continue-btn:hover {
+    background: rgba(0, 122, 255, 1);
+}
+
+.continue-btn:disabled {
+    opacity: 0.5;
+    cursor: default;
+}
+
 /* Thinking indicator */
 .chat-message.assistant-thinking {
     align-self: flex-start;

--- a/app/main.js
+++ b/app/main.js
@@ -34,6 +34,9 @@ async function main() {
         if (runtimeConfig.mcp_auth_token) appConfig.mcp_auth_token = runtimeConfig.mcp_auth_token;
         if (runtimeConfig.catalog_token) appConfig.catalog_token = runtimeConfig.catalog_token;
         if (runtimeConfig.draw_enabled != null) appConfig.draw_enabled = runtimeConfig.draw_enabled;
+        // != null (not truthiness) so 0 — which disables the checkpoint — survives.
+        if (runtimeConfig.max_tool_calls != null) appConfig.max_tool_calls = runtimeConfig.max_tool_calls;
+        if (runtimeConfig.max_tool_calls_manual != null) appConfig.max_tool_calls_manual = runtimeConfig.max_tool_calls_manual;
     }
 
     // If no server-provided LLM config, check for user-provided key mode

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -458,6 +458,10 @@ Continuing preserves the agent's in-flight work, so it resumes where it left off
 
 Both keys may also be supplied at deploy time via `config.json`, which overrides the static `layers-input.json` value.
 
+::: warning
+The checkpoint is the only per-turn cap on tool use. Setting a value to `0` removes it entirely for that mode — a misbehaving model could then loop indefinitely, stopped only by the per-call timeout or a manual **Stop**. Prefer a high value (e.g. several hundred) over `0` unless you have another guard in place.
+:::
+
 ## Chat export
 
 A 💾 save button in the chat footer saves the current conversation as a self-contained HTML document you can share or print. The button is disabled until the first user message and enables automatically after. No configuration — it's always present.

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -16,6 +16,8 @@ Client apps configure geo-agent via `layers-input.json`. All fields except `cata
 | `default_basemap` | No | Which basemap is active on load: `"natgeo"` (default), `"satellite"`, or `"plain"`. |
 | `custom_basemap` | No | Replace the NatGeo slot with a custom tile URL — see below. |
 | `auto_approve` | No | Start with remote tool calls auto-approved (no confirmation prompt). Default: `true`. |
+| `max_tool_calls` | No | Remote queries in auto-approve mode before the agent pauses at a checkpoint. Default: `15`. |
+| `max_tool_calls_manual` | No | Remote queries in manual mode before a checkpoint. Default: `100`. |
 | `links` | No | Optional links shown in the chat UI — see below. |
 
 ## View
@@ -438,6 +440,23 @@ Set `auto_approve: false` to require a **Run** / **Cancel** confirmation before 
 | `auto_approve` | boolean | `true` | When `true`, remote tool calls execute immediately without user confirmation. Set to `false` to require manual approval. |
 
 A ⚡ toggle button in the chat footer lets users switch auto-approve on or off at runtime. The toggle affects only the current session — every page load resets to the `auto_approve` value from config.
+
+## Tool call checkpoints
+
+On a complex question the agent may run many data queries. Rather than cutting it off at a hard limit, the agent pauses at a **checkpoint** after a configurable number of **remote queries** (MCP/SQL): it summarizes what it has done, the key findings, and what remains, then offers a **▶ Continue** button. Local map actions — `show_layer`, `fly_to`, `set_filter`, and the like — are instant and never count toward the limit.
+
+Continuing preserves the agent's in-flight work, so it resumes where it left off instead of re-running earlier queries. Each Continue grants another full interval, so a session is effectively unlimited as long as you keep approving. You can also just type a follow-up to steer the resumed work (e.g. *"continue, but only for Alameda County"*).
+
+```json
+{ "max_tool_calls": 15, "max_tool_calls_manual": 100 }
+```
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `max_tool_calls` | number | `15` | Remote queries in auto-approve mode before a checkpoint. The checkpoint is the user's periodic gate plus a progress report. Set to `0` to disable. |
+| `max_tool_calls_manual` | number | `100` | Remote queries in manual mode (⚡ off) before a checkpoint. Set high because you already approve each remote call individually. Set to `0` to disable. |
+
+Both keys may also be supplied at deploy time via `config.json`, which overrides the static `layers-input.json` value.
 
 ## Chat export
 

--- a/test/agent-checkpoint.test.js
+++ b/test/agent-checkpoint.test.js
@@ -120,3 +120,34 @@ describe('Agent checkpoint', () => {
         expect(response).toBe('final');
     });
 });
+
+describe('Agent resume', () => {
+    afterEach(() => { vi.restoreAllMocks(); });
+
+    it('resumes the saved turnMessages instead of rebuilding, then clears on final answer', async () => {
+        global.fetch = vi.fn()
+            .mockResolvedValueOnce(okToolCall('remote_tool'))
+            .mockResolvedValueOnce(okText('Summary so far.'));
+        const agent = new Agent(
+            baseConfig({ max_tool_calls: 1 }),
+            stubRegistry({ isLocal: () => false, execute: async () => ({ result: 'rows', sqlQuery: 'SELECT 1' }) }),
+        );
+        agent.autoApprove = true;
+        await agent.processMessage('hard question');
+        expect(agent.suspendedTurn).not.toBe(null);
+        const savedTurn = agent.suspendedTurn.turnMessages;
+        const lenBeforeResume = savedTurn.length;
+
+        let sentMessages = null;
+        global.fetch = vi.fn(async (url, opts) => {
+            sentMessages = JSON.parse(opts.body).messages;
+            return okText('Final answer.');
+        });
+        const { response } = await agent.processMessage('continue');
+
+        expect(response).toBe('Final answer.');
+        expect(sentMessages.length).toBe(lenBeforeResume + 1); // + the "continue" user msg
+        expect(sentMessages[sentMessages.length - 1]).toEqual({ role: 'user', content: 'continue' });
+        expect(agent.suspendedTurn).toBe(null);
+    });
+});

--- a/test/agent-checkpoint.test.js
+++ b/test/agent-checkpoint.test.js
@@ -76,3 +76,47 @@ describe('Agent remote-round counting', () => {
         expect(agent.suspendedTurn).toBe(null);
     });
 });
+
+describe('Agent checkpoint', () => {
+    afterEach(() => { vi.restoreAllMocks(); });
+
+    it('pauses at the threshold, makes a no-tools summary call, and suspends', async () => {
+        const fetchMock = vi.fn()
+            .mockResolvedValueOnce(okToolCall('remote_tool'))      // round 1 (remote)
+            .mockResolvedValueOnce(okText('Progress: ran 1 query; next I would join counties.'));
+        global.fetch = fetchMock;
+
+        const onCheckpoint = vi.fn();
+        const agent = new Agent(
+            baseConfig({ max_tool_calls: 1 }),
+            stubRegistry({ isLocal: () => false, execute: async () => ({ result: 'rows', sqlQuery: 'SELECT 1' }) }),
+        );
+        agent.autoApprove = true;
+        agent.onCheckpoint = onCheckpoint;
+
+        const { response, checkpoint } = await agent.processMessage('hard question');
+
+        expect(checkpoint).toBe(true);
+        expect(response).toContain('Progress');
+        expect(onCheckpoint).toHaveBeenCalledOnce();
+        expect(agent.suspendedTurn).not.toBe(null);
+        const summaryBody = JSON.parse(fetchMock.mock.calls[1][1].body);
+        expect(summaryBody.tool_choice).toBe('none');
+        expect(summaryBody.tools).toBeUndefined();
+    });
+
+    it('does not checkpoint when threshold is 0 (disabled)', async () => {
+        global.fetch = vi.fn()
+            .mockResolvedValueOnce(okToolCall('remote_tool'))
+            .mockResolvedValueOnce(okToolCall('remote_tool', 'c2'))
+            .mockResolvedValueOnce(okText('final'));
+        const agent = new Agent(
+            baseConfig({ max_tool_calls: 0 }),
+            stubRegistry({ isLocal: () => false }),
+        );
+        agent.autoApprove = true;
+        const { response, checkpoint } = await agent.processMessage('q');
+        expect(checkpoint).toBeFalsy();
+        expect(response).toBe('final');
+    });
+});

--- a/test/agent-checkpoint.test.js
+++ b/test/agent-checkpoint.test.js
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { Agent } from '../app/agent.js';
+
+const stubRegistry = (overrides = {}) => ({
+    getToolsForLLM: () => [],
+    isLocal: () => true,
+    execute: async () => ({ result: '' }),
+    ...overrides,
+});
+
+const baseConfig = (overrides = {}) => ({
+    llm_models: [{ value: 'm', endpoint: 'https://x/v1', api_key: 'k' }],
+    ...overrides,
+});
+
+const okText = (content = 'done') => ({
+    ok: true,
+    json: async () => ({ choices: [{ message: { role: 'assistant', content } }] }),
+});
+
+const okToolCall = (name = 'remote_tool', id = 'c1') => ({
+    ok: true,
+    json: async () => ({
+        choices: [{ message: { role: 'assistant', content: null, tool_calls: [
+            { id, type: 'function', function: { name, arguments: '{}' } },
+        ] } }],
+    }),
+});
+
+describe('Agent threshold configuration', () => {
+    it('defaults to 15 (auto) and 100 (manual)', () => {
+        const agent = new Agent(baseConfig(), stubRegistry());
+        expect(agent.maxToolCalls).toBe(15);
+        expect(agent.maxToolCallsManual).toBe(100);
+    });
+
+    it('reads overrides from config', () => {
+        const agent = new Agent(
+            baseConfig({ max_tool_calls: 8, max_tool_calls_manual: 50 }),
+            stubRegistry(),
+        );
+        expect(agent.maxToolCalls).toBe(8);
+        expect(agent.maxToolCallsManual).toBe(50);
+    });
+
+    it('activeThreshold picks the mode-specific value', () => {
+        const agent = new Agent(baseConfig({ max_tool_calls: 8, max_tool_calls_manual: 50 }), stubRegistry());
+        agent.autoApprove = true;
+        expect(agent.activeThreshold()).toBe(8);
+        agent.autoApprove = false;
+        expect(agent.activeThreshold()).toBe(50);
+    });
+});

--- a/test/agent-checkpoint.test.js
+++ b/test/agent-checkpoint.test.js
@@ -51,3 +51,28 @@ describe('Agent threshold configuration', () => {
         expect(agent.activeThreshold()).toBe(50);
     });
 });
+
+describe('Agent remote-round counting', () => {
+    beforeEach(() => { vi.useRealTimers(); });
+    afterEach(() => { vi.restoreAllMocks(); });
+
+    it('initializes suspendedTurn to null', () => {
+        const agent = new Agent(baseConfig(), stubRegistry());
+        expect(agent.suspendedTurn).toBe(null);
+    });
+
+    it('does not checkpoint a turn that only uses local tools', async () => {
+        // One local tool round, then a final text answer.
+        global.fetch = vi.fn()
+            .mockResolvedValueOnce(okToolCall('local_tool'))
+            .mockResolvedValueOnce(okText('all done'));
+        const agent = new Agent(
+            baseConfig({ max_tool_calls: 1 }),    // tiny threshold
+            stubRegistry({ isLocal: () => true }), // every call is local
+        );
+        agent.autoApprove = true;
+        const { response } = await agent.processMessage('hi');
+        expect(response).toBe('all done');
+        expect(agent.suspendedTurn).toBe(null);
+    });
+});

--- a/test/agent-checkpoint.test.js
+++ b/test/agent-checkpoint.test.js
@@ -119,6 +119,29 @@ describe('Agent checkpoint', () => {
         expect(checkpoint).toBeFalsy();
         expect(response).toBe('final');
     });
+
+    it('preserves the suspended turn when the summary call is aborted', async () => {
+        // Round 1 (remote) trips the threshold; the summary call then aborts.
+        global.fetch = vi.fn()
+            .mockResolvedValueOnce(okToolCall('remote_tool'))
+            .mockRejectedValueOnce(new DOMException('Aborted', 'AbortError'));
+        const agent = new Agent(
+            baseConfig({ max_tool_calls: 1 }),
+            stubRegistry({ isLocal: () => false, execute: async () => ({ result: 'rows', sqlQuery: 'SELECT 1' }) }),
+        );
+        agent.autoApprove = true;
+
+        const { response, cancelled } = await agent.processMessage('hard question');
+
+        expect(cancelled).toBe(true);
+        expect(response).toBe(null);
+        // Work is preserved so "continue" can resume, not restart.
+        expect(agent.suspendedTurn).not.toBe(null);
+        expect(agent.suspendedTurn.sqlQueries).toContain('SELECT 1');
+        // The checkpoint-summary instruction was stripped; last message is the tool result.
+        const last = agent.suspendedTurn.turnMessages[agent.suspendedTurn.turnMessages.length - 1];
+        expect(last.role).toBe('tool');
+    });
 });
 
 describe('Agent resume', () => {

--- a/test/agent-checkpoint.test.js
+++ b/test/agent-checkpoint.test.js
@@ -173,4 +173,30 @@ describe('Agent resume', () => {
         expect(sentMessages[sentMessages.length - 1]).toEqual({ role: 'user', content: 'continue' });
         expect(agent.suspendedTurn).toBe(null);
     });
+
+    it('resumes an already-checkpointed turn and can checkpoint again, accumulating in place', async () => {
+        global.fetch = vi.fn()
+            .mockResolvedValueOnce(okToolCall('remote_tool'))        // turn 1 round 1 (remote)
+            .mockResolvedValueOnce(okText('Summary 1.'))             // turn 1 checkpoint summary
+            .mockResolvedValueOnce(okToolCall('remote_tool', 'c2'))  // turn 2 round 1 (remote)
+            .mockResolvedValueOnce(okText('Summary 2.'));            // turn 2 checkpoint summary
+        const agent = new Agent(
+            baseConfig({ max_tool_calls: 1 }),
+            stubRegistry({ isLocal: () => false, execute: async () => ({ result: 'rows', sqlQuery: 'SELECT 1' }) }),
+        );
+        agent.autoApprove = true;
+
+        const first = await agent.processMessage('hard question');
+        expect(first.checkpoint).toBe(true);
+        const arrayRef = agent.suspendedTurn.turnMessages;
+        const lenAfterFirst = arrayRef.length;
+
+        const second = await agent.processMessage('continue');
+        expect(second.checkpoint).toBe(true);
+        // Same array, accumulated in place — not rebuilt from history.
+        expect(agent.suspendedTurn.turnMessages).toBe(arrayRef);
+        expect(agent.suspendedTurn.turnMessages.length).toBeGreaterThan(lenAfterFirst);
+        // sqlQueries carried across both turns.
+        expect(agent.suspendedTurn.sqlQueries.length).toBe(2);
+    });
 });


### PR DESCRIPTION
Closes #216.

Replaces the hard 20-tool-call-per-turn wall with a **configurable, mode-aware checkpoint** that preserves in-flight work, so the agent pauses to report progress and can genuinely *resume* a long investigation instead of restarting from scratch.

## The root problem this fixes

The old cap counted every LLM round (local map tweaks + remote queries alike) and, when hit, returned a generic message **without persisting the in-flight `turnMessages`** (tool calls + results). Those lived only in a local variable, so a follow-up "continue" rebuilt context from `this.messages` — which held only the original question and the final answers. The agent had genuine amnesia and re-ran everything. Resume is the foundation; the cap and messaging sit on top.

## What changed

- **Remote-only counting.** Only MCP/SQL rounds count toward the threshold; cheap, instant local map tools don't. The budget now constrains expensive queries, which is what actually runs out on hard questions.
- **Checkpoint instead of a wall.** At the threshold the agent makes one no-tools LLM call to produce a progress summary (what it did, key findings, what remains), preserves the turn in `suspendedTurn`, and pauses — harness-driven, so it fires reliably regardless of model size.
- **Real resume.** The next message reuses the saved `turnMessages` instead of rebuilding. A one-click **▶ Continue** sends `"continue"`; typing a follow-up resumes *and steers* (e.g. "continue, but only for Alameda County").
- **Mode-aware, configurable thresholds.** `max_tool_calls` (auto, default 15) and `max_tool_calls_manual` (manual, default 100). Manual mode already gates each remote call, so its checkpoint is set high. Settable in `layers-input.json` or runtime `config.json` (`!= null` so `0` — disable — survives).
- **Abort-during-summary preserves work.** If the user presses Stop while the summary is generating, the completed query work is kept (minus the checkpoint instruction) so Continue still resumes.

## Behavioral notes for reviewers

- **`0` disables the only per-turn cap** for that mode — documented with a warning. Defaults are safe.
- **A regular mid-turn Stop** (not during the summary) discards the in-flight turn and shows no Continue button — by design; the checkpoint is the resume point, not arbitrary stops.

## Testing

- `test/agent-checkpoint.test.js` — 10 new tests: thresholds, mode selection, remote-only counting, checkpoint + no-tools summary (`tool_choice: 'none'`), `0`-disabled, abort-during-summary preservation, resume (reuse-not-rebuild + clear on final answer), and checkpoint→resume→checkpoint in-place accumulation.
- Full suite: **553 passing**.
- `chat-ui.js` / `chat.css` are browser-bound (no harness) and were verified by reading against existing patterns; the Continue button uses the codebase's emoji/text button style (no icon library) and `handleSend`. Recommend a quick manual smoke on a downstream app with `max_tool_calls: 3`.

> Please **merge** (not squash) per project policy — downstream apps pin to commit SHAs.