### PR TITLE
fix(mcp-client): don't permanently latch on transient MCP failures (closes #235)

### DIFF
--- a/app/mcp-client.js
+++ b/app/mcp-client.js
@@ -19,6 +19,11 @@ export class MCPClient {
         this.tools = [];
         this.reconnectAttempts = 0;
         this.maxReconnectAttempts = 3;
+        // The attempt budget caps a single burst of failures, but it must not
+        // latch forever — after this much quiet time, the next attempt gets a
+        // fresh budget so a transient outage can't permanently disable MCP.
+        this.reconnectResetMs = 30000;
+        this.lastReconnectTime = 0;
         this._connectPromise = null;
         this._onReconnect = null;
     }
@@ -98,8 +103,17 @@ export class MCPClient {
      * Reconnect with exponential backoff.
      */
     async reconnect() {
+        const now = Date.now();
+        // A fresh attempt after a quiet period gets a clean budget. Rapid
+        // retries within one burst still hit the cap (no hammering), but a
+        // user action after the outage clears retries instead of failing.
+        if (now - this.lastReconnectTime > this.reconnectResetMs) {
+            this.reconnectAttempts = 0;
+        }
+        this.lastReconnectTime = now;
+
         if (this.reconnectAttempts >= this.maxReconnectAttempts) {
-            throw new Error('MCP server unreachable after multiple attempts. Please refresh the page.');
+            throw new Error('MCP server temporarily unavailable. Please try again in a moment.');
         }
 
         this.reconnectAttempts++;

--- a/test/mcp-client.test.js
+++ b/test/mcp-client.test.js
@@ -106,10 +106,35 @@ describe('MCPClient ensureConnected and reconnect', () => {
         }
     });
 
-    it('throws after maxReconnectAttempts', async () => {
+    it('throws when the reconnect budget is exhausted within the cooldown window', async () => {
         const c = new MCPClient('https://mcp/');
         c.reconnectAttempts = c.maxReconnectAttempts;
-        await expect(c.reconnect()).rejects.toThrow(/unreachable after multiple attempts/i);
+        c.lastReconnectTime = Date.now();   // recent burst → no budget reset
+        await expect(c.reconnect()).rejects.toThrow(/temporarily unavailable/i);
+    });
+
+    it('does not latch permanently — after the cooldown window a fresh reconnect is attempted', async () => {
+        vi.useFakeTimers();
+        try {
+            const c = new MCPClient('https://mcp/');
+            // Simulate a burst that exhausted the reconnect budget.
+            c.reconnectAttempts = c.maxReconnectAttempts;
+            c.lastReconnectTime = Date.now();
+
+            // User pauses past the reset window, then acts again.
+            vi.advanceTimersByTime(c.reconnectResetMs + 1000);
+
+            const promise = c.reconnect();
+            await vi.advanceTimersByTimeAsync(1000); // backoff for the fresh attempt
+            await promise;
+
+            // The counter was reset and a real connection was made, instead of
+            // throwing the permanent "refresh the page" error forever.
+            expect(c.isConnected).toBe(true);
+            expect(c.reconnectAttempts).toBe(0);
+        } finally {
+            vi.useRealTimers();
+        }
     });
 });
 


### PR DESCRIPTION
Closes #235.

## Problem

`app/mcp-client.js` turned a **transient** MCP failure into a **permanent** one for the page session. `reconnectAttempts` only reset on a successful call, so 3 reconnect failures in a row latched the client — every subsequent tool call threw `"MCP server unreachable after multiple attempts. Please refresh the page."` *without attempting a connection*, until a full page reload. Observed live on bosl-high-seas: `get_schema`/`query` worked one minute, then failed for the rest of the session while the model looped against a dead client and local map tools kept working.

## Fix

Time-window the reconnect budget. The per-burst cap (`maxReconnectAttempts = 3`) still prevents tight-loop hammering during a single outage, but after `reconnectResetMs` (30s) of quiet the next attempt gets a fresh budget — so a user action after the blip retries cleanly instead of failing forever. The error message changes from "refresh the page" to "temporarily unavailable, try again," since a retry can now succeed.

```js
async reconnect() {
    const now = Date.now();
    if (now - this.lastReconnectTime > this.reconnectResetMs) {
        this.reconnectAttempts = 0;   // fresh budget after a quiet period
    }
    this.lastReconnectTime = now;
    if (this.reconnectAttempts >= this.maxReconnectAttempts) {
        throw new Error('MCP server temporarily unavailable. Please try again in a moment.');
    }
    this.reconnectAttempts++;
    ...
}
```

## Tests

- New: after the cooldown window, an exhausted client attempts a fresh reconnect (succeeds) instead of throwing — fails on the old code, passes now.
- Updated: the "budget exhausted" test now pins the within-window behavior + new message.
- Full suite: 544 passing.

## Notes

- Scoped to `app/mcp-client.js`; independent of #234.
- The incident that surfaced this was amplified by the 2-replica **dev** MCP being easily exhausted, but the latching is endpoint-agnostic and could bite production on any brief hiccup.