### PR TITLE
chore: gitignore local Claude Code state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,8 @@ docs/superpowers/
 # Git worktrees
 .worktrees/
 coverage/
+
+# Claude Code (local, machine-specific). Shared project config such as
+# .claude/settings.json or .claude/commands/ can still be committed.
+.claude/settings.local.json
+.claude/worktrees/


### PR DESCRIPTION
Ignore the machine-local parts of `.claude/` that were showing up as untracked and triggering 'uncommitted change' warnings on every PR:

- `.claude/settings.local.json` — per-developer Claude Code settings/permission overrides.
- `.claude/worktrees/` — local git worktrees (these were also being picked up by vitest, inflating test-file counts with stale copies).

Targeted rather than a blanket `.claude/` so shared project config (`.claude/settings.json`, `.claude/commands/`, agent definitions) can still be committed intentionally later. No such files exist today.