### PR TITLE
security: fix XSS sinks, scrub live answers, pin and hash CDN assets

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,4 +21,4 @@ jobs:
       - run: npx vitest run --coverage --coverage.include='app/**' --coverage.reporter=json-summary --coverage.reporter=json --coverage.reporter=text
       - name: Coverage report comment
         if: github.event_name == 'pull_request'
-        uses: davelosert/vitest-coverage-report-action@v2
+        uses: davelosert/vitest-coverage-report-action@2500dafcee7dd64f85ab689c0b83798a8359770e # v2.9.3

--- a/app/chat-ui.js
+++ b/app/chat-ui.js
@@ -911,7 +911,7 @@ export class ChatUI {
             argDisplay = `<pre><code>${this.escapeHtml(String(args))}</code></pre>`;
         }
 
-        return `<div class="tool-call-item"><strong>${tc.function.name}</strong>${argDisplay}</div>`;
+        return `<div class="tool-call-item"><strong>${this.escapeHtml(tc.function.name)}</strong>${argDisplay}</div>`;
     }
 
     /**
@@ -944,7 +944,7 @@ export class ChatUI {
             const itemIcon = r.success ? '✓' : '✗';
             const sourceTag = r.source === 'remote' ? ' <span class="tool-tag remote">MCP</span>' : '';
             const truncated = this.truncateResult(r.result, 2000);
-            resultsHtml += `<div class="tool-result-item"><strong>${itemIcon} ${r.name}</strong>${sourceTag}`;
+            resultsHtml += `<div class="tool-result-item"><strong>${itemIcon} ${this.escapeHtml(r.name)}</strong>${sourceTag}`;
             if (r.sqlQuery) {
                 resultsHtml += `<details class="sql-detail"><summary>SQL</summary><pre><code class="language-sql">${this.escapeHtml(r.sqlQuery)}</code></pre></details>`;
             }

--- a/app/chat-ui.js
+++ b/app/chat-ui.js
@@ -67,6 +67,35 @@ export function scrubCredentials(text) {
  */
 export const REDACTED_KEYS = ['s3_key', 's3_secret', 's3_endpoint', 's3_scope', 'catalog_token'];
 
+/**
+ * Render LLM-derived text to HTML for innerHTML insertion. The model can be
+ * steered by anything it reads (dataset values, STAC descriptions), so its
+ * output may carry attacker-controlled markup: scrub credential-shaped
+ * tokens, parse markdown, then sanitize through DOMPurify. If either page
+ * global is missing, fail closed to escaped plain text rather than raw HTML.
+ *
+ * @param {string} md
+ * @returns {string} HTML safe to assign to innerHTML
+ */
+export function renderMarkdown(md) {
+    const text = scrubCredentials(String(md ?? ''));
+    if (typeof marked !== 'undefined' && typeof DOMPurify !== 'undefined') {
+        return DOMPurify.sanitize(marked.parse(text));
+    }
+    if (!renderMarkdown._warned) {
+        renderMarkdown._warned = true;
+        console.warn('[ChatUI] marked and/or DOMPurify not loaded — chat text will render as escaped plain text. Check the CDN <script> tags in index.html.');
+    }
+    return `<pre>${escapeHtmlText(text)}</pre>`;
+}
+
+/** DOM-free HTML escape (renderMarkdown fallback path). */
+function escapeHtmlText(str) {
+    return String(str).replace(/[&<>"']/g, (c) => ({
+        '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;',
+    }[c]));
+}
+
 export class ChatUI {
     /**
      * @param {import('./agent.js').Agent} agent
@@ -754,9 +783,7 @@ export class ChatUI {
 
         const body = document.createElement('div');
         body.className = 'agent-turn-row-body';
-        body.innerHTML = typeof marked !== 'undefined'
-            ? marked.parse(text)
-            : `<pre>${this.escapeHtml(text)}</pre>`;
+        body.innerHTML = renderMarkdown(text);
 
         row.appendChild(summary);
         row.appendChild(body);
@@ -809,7 +836,7 @@ export class ChatUI {
                 ? reasoningText.trim()
                 : this.describeToolCalls(calls);
             if (desc) {
-                const descHtml = typeof marked !== 'undefined' ? marked.parse(desc) : this.escapeHtml(desc);
+                const descHtml = renderMarkdown(desc);
                 body.insertAdjacentHTML('beforeend', `<div class="tool-reasoning">${descHtml}</div>`);
             }
         }
@@ -1119,7 +1146,7 @@ body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-
     addMarkdown(role, md) {
         const el = document.createElement('div');
         el.className = `chat-message ${role}`;
-        el.innerHTML = typeof marked !== 'undefined' ? marked.parse(md) : md;
+        el.innerHTML = renderMarkdown(md);
         this.messagesEl.appendChild(el);
 
         // Highlight code blocks

--- a/app/index.html
+++ b/app/index.html
@@ -37,7 +37,7 @@
     <!-- Markdown rendering (lib/marked.umd.js is the package-shipped artifact;
          marked.min.js is a CDN-generated file and unsafe to hash) -->
     <script src="https://cdn.jsdelivr.net/npm/marked@18.0.5/lib/marked.umd.js"
-        integrity="sha384-N76l9K/M8y4+xni3juApZIi84bu9Pns/JxAoHjePfV+MXT0z6a2SHfKVdGDs3C5T"
+        integrity="sha384-ZD0fTOwPMHi7zM6WTVIWJR21I07lq0ccnqz3J6WMvQKG9thh4y7TA1QE6PJu0Af8"
         crossorigin="anonymous"></script>
 
     <!-- HTML sanitizer — chat-ui.js refuses to render markdown without it -->

--- a/app/index.html
+++ b/app/index.html
@@ -17,22 +17,44 @@
     </script>
 
     <!-- MapLibre GL JS -->
-    <script src="https://unpkg.com/maplibre-gl@5.22.0/dist/maplibre-gl.js"></script>
-    <link href="https://unpkg.com/maplibre-gl@5.22.0/dist/maplibre-gl.css" rel="stylesheet" />
+    <script src="https://unpkg.com/maplibre-gl@5.22.0/dist/maplibre-gl.js"
+        integrity="sha384-U054LTKiMIJKEecR8PKFiUZdvkGWHjfPBnen5hSmR9TwfOfgZmKbskC8Rs9dCm/1"
+        crossorigin="anonymous"></script>
+    <link href="https://unpkg.com/maplibre-gl@5.22.0/dist/maplibre-gl.css" rel="stylesheet"
+        integrity="sha384-MGCxhspF/+ufueUgol3FDkiAYQbpSNRhBT0VWHJt64U8qIy9qlnXWx8LAbj6niPH"
+        crossorigin="anonymous" />
 
     <!-- PMTiles protocol -->
-    <script src="https://unpkg.com/pmtiles@3.0.7/dist/pmtiles.js"></script>
+    <script src="https://unpkg.com/pmtiles@3.0.7/dist/pmtiles.js"
+        integrity="sha384-MjejsnWXHmuz93aE35YWLh5AbS/6ceRB3Vb+ukOwqFzJRTpQ8vvbkLbNV7I0QK4f"
+        crossorigin="anonymous"></script>
 
     <!-- h3-js (for hex grid overlay) -->
-    <script src="https://unpkg.com/h3-js@4.1.0/dist/h3-js.umd.js"></script>
+    <script src="https://unpkg.com/h3-js@4.1.0/dist/h3-js.umd.js"
+        integrity="sha384-nKUDlg+fT0U/eEt4KWP9n034kLe/eVj6k7CVjbu6qfRhJdEyinlGajS9+9AU+UZ5"
+        crossorigin="anonymous"></script>
 
-    <!-- Markdown rendering -->
-    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+    <!-- Markdown rendering (lib/marked.umd.js is the package-shipped artifact;
+         marked.min.js is a CDN-generated file and unsafe to hash) -->
+    <script src="https://cdn.jsdelivr.net/npm/marked@18.0.5/lib/marked.umd.js"
+        integrity="sha384-N76l9K/M8y4+xni3juApZIi84bu9Pns/JxAoHjePfV+MXT0z6a2SHfKVdGDs3C5T"
+        crossorigin="anonymous"></script>
+
+    <!-- HTML sanitizer — chat-ui.js refuses to render markdown without it -->
+    <script src="https://cdn.jsdelivr.net/npm/dompurify@3.4.8/dist/purify.min.js"
+        integrity="sha384-jrsBdrv4eDpEYIq32u13DPbvB6tRmqIDnA6UlgFBoexpetaiWi7g/VbfMEL1WVen"
+        crossorigin="anonymous"></script>
 
     <!-- Code highlighting -->
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github-dark.min.css">
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/languages/sql.min.js"></script>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github-dark.min.css"
+        integrity="sha384-wH75j6z1lH97ZOpMOInqhgKzFkAInZPPSPlZpYKYTOqsaizPvhQZmAtLcPKXpLyH"
+        crossorigin="anonymous">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"
+        integrity="sha384-F/bZzf7p3Joyp5psL90p/p89AZJsndkSoGwRpXcZhleCWhd8SnRuoYo4d0yirjJp"
+        crossorigin="anonymous"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/languages/sql.min.js"
+        integrity="sha384-8q00eP+tyV9451aJYD5ML3ftuHKsGnDcezp7EXMEclDg1fZVSoj8O+3VyJTkXmWp"
+        crossorigin="anonymous"></script>
 
     <!-- Analytics -->
     <script defer src="https://cloud.umami.is/script.js"

--- a/app/map-draw.js
+++ b/app/map-draw.js
@@ -7,13 +7,19 @@
  */
 
 const DRAW_JS  = 'https://unpkg.com/@mapbox/mapbox-gl-draw@1.4.3/dist/mapbox-gl-draw.js';
+const DRAW_JS_SRI = 'sha384-9tKNac0N0Yq08XtOQRfX8ivYwyzoSOriQtGhBKAxi2ezpT1C859IZ9bO1QNrKmMX';
 const DRAW_CSS = 'https://unpkg.com/@mapbox/mapbox-gl-draw@1.4.3/dist/mapbox-gl-draw.css';
+const DRAW_CSS_SRI = 'sha384-4Y8+jUOlZUhQTrhjMAldWS0wpm/HjKvwEzKSXzLoaf3HJozxCpjiRXmXq71XbLT6';
 
 /** Load a JS script by URL, resolves when loaded. */
-function loadScript(url) {
+function loadScript(url, integrity) {
     return new Promise((resolve, reject) => {
         const s = document.createElement('script');
         s.src = url;
+        if (integrity) {
+            s.integrity = integrity;
+            s.crossOrigin = 'anonymous';
+        }
         s.onload = resolve;
         s.onerror = () => reject(new Error(`Failed to load ${url}`));
         document.head.appendChild(s);
@@ -21,10 +27,14 @@ function loadScript(url) {
 }
 
 /** Load a CSS stylesheet by URL. */
-function loadCSS(url) {
+function loadCSS(url, integrity) {
     const link = document.createElement('link');
     link.rel = 'stylesheet';
     link.href = url;
+    if (integrity) {
+        link.integrity = integrity;
+        link.crossOrigin = 'anonymous';
+    }
     document.head.appendChild(link);
 }
 
@@ -64,8 +74,8 @@ export class MapDraw {
 
     /** Initialize: load library, add controls, wire events. */
     async init() {
-        loadCSS(DRAW_CSS);
-        await loadScript(DRAW_JS);
+        loadCSS(DRAW_CSS, DRAW_CSS_SRI);
+        await loadScript(DRAW_JS, DRAW_JS_SRI);
 
         /* global MapboxDraw */
         this.draw = new MapboxDraw({

--- a/app/map-manager.js
+++ b/app/map-manager.js
@@ -1288,25 +1288,39 @@ export class MapManager {
         const item = document.createElement('div');
         item.className = 'legend-section';
 
+        // Display name, class names, and color hints come from STAC metadata
+        // (untrusted) — build the legend via textContent and validate colors
+        // before they reach a style attribute.
+        const heading = document.createElement('h4');
+        heading.textContent = state.displayName;
+        item.appendChild(heading);
+
         if (state.legendType === 'categorical' && state.legendClasses?.length) {
-            const rows = state.legendClasses.map(cls => {
-                const color = cls['color-hint'] || cls.color_hint ? `#${cls['color-hint'] || cls.color_hint}` : '#888888';
-                const label = cls.name || `Class ${cls.value}`;
-                return `<div class="legend-item"><span style="background:${color};"></span>${label}</div>`;
-            }).join('');
-            item.innerHTML = `<h4>${state.displayName}</h4>${rows}`;
+            for (const cls of state.legendClasses) {
+                const row = document.createElement('div');
+                row.className = 'legend-item';
+                const swatch = document.createElement('span');
+                swatch.style.background = this._safeColorHint(cls['color-hint'] || cls.color_hint);
+                row.appendChild(swatch);
+                row.appendChild(document.createTextNode(cls.name || `Class ${cls.value}`));
+                item.appendChild(row);
+            }
         } else {
             const gradient = await this._getColormapGradient(state.colormap || 'reds');
             const [minVal, maxVal] = (state.rescale || '0,1').split(',');
             const unit = state.legendLabel ? ` ${state.legendLabel}` : '';
-            item.innerHTML = `
-                <h4>${state.displayName}</h4>
-                <div class="legend-colorbar" style="background: ${gradient};"></div>
-                <div class="legend-labels">
-                    <span>${minVal}${unit}</span>
-                    <span>${maxVal}${unit}</span>
-                </div>
-            `;
+            const bar = document.createElement('div');
+            bar.className = 'legend-colorbar';
+            bar.style.background = gradient;
+            const labels = document.createElement('div');
+            labels.className = 'legend-labels';
+            for (const v of [minVal, maxVal]) {
+                const span = document.createElement('span');
+                span.textContent = `${v}${unit}`;
+                labels.appendChild(span);
+            }
+            item.appendChild(bar);
+            item.appendChild(labels);
         }
 
         this._legendContent.appendChild(item);
@@ -1331,12 +1345,23 @@ export class MapManager {
             if (!fields || fields.length === 0) return;
             if (!e.features || e.features.length === 0) return;
             const props = e.features[0].properties;
-            const rows = fields
-                .filter(f => props[f] !== undefined && props[f] !== null && props[f] !== '')
-                .map(f => `<tr><th>${f}</th><td>${this._formatTooltipValue(f, props[f])}</td></tr>`)
-                .join('');
-            if (!rows) return;
-            this._tooltip.innerHTML = `<table>${rows}</table>`;
+            const present = fields
+                .filter(f => props[f] !== undefined && props[f] !== null && props[f] !== '');
+            if (present.length === 0) return;
+            // Field names and feature values are untrusted (LLM-chosen /
+            // dataset-supplied) — build the table via textContent, never HTML.
+            const table = document.createElement('table');
+            for (const f of present) {
+                const tr = document.createElement('tr');
+                const th = document.createElement('th');
+                th.textContent = f;
+                const td = document.createElement('td');
+                td.textContent = String(this._formatTooltipValue(f, props[f]));
+                tr.appendChild(th);
+                tr.appendChild(td);
+                table.appendChild(tr);
+            }
+            this._tooltip.replaceChildren(table);
             this._tooltip.style.display = 'block';
             this._tooltip.style.left = (e.originalEvent.clientX + 12) + 'px';
             this._tooltip.style.top = (e.originalEvent.clientY - 12) + 'px';
@@ -1347,6 +1372,16 @@ export class MapManager {
             this._tooltip.style.display = 'none';
             this.map.getCanvas().style.cursor = '';
         });
+    }
+
+    /**
+     * STAC `color-hint` values land in a style attribute — accept only hex
+     * colors (with or without leading '#'), grey fallback for anything else.
+     */
+    _safeColorHint(raw) {
+        if (raw == null || !/^#?[0-9a-fA-F]{3,8}$/.test(String(raw))) return '#888888';
+        const hex = String(raw);
+        return hex.startsWith('#') ? hex : `#${hex}`;
     }
 
     _formatTooltipValue(field, value) {

--- a/app/map-tools.js
+++ b/app/map-tools.js
@@ -415,6 +415,13 @@ ${formatLayerList(vectorLayers())}`,
                 // (space-separated, no commas — e.g. "[ 1  2  3]") is not valid JSON,
                 // so without it the extractJsonArray() call below fails to parse.
                 const col = args.id_property;
+                // col is quoted into wrappedSql — restrict to plain identifier chars.
+                if (!/^[A-Za-z0-9_]+$/.test(col || '')) {
+                    return JSON.stringify({
+                        success: false,
+                        error: `Invalid id_property "${col}" — must contain only letters, digits, or underscores. Check get_stac_details for the feature ID column name.`,
+                    });
+                }
                 const wrappedSql = `SELECT to_json(array_agg("${col}") FILTER (WHERE "${col}" IS NOT NULL)) AS ids FROM (${args.sql}) _filter_subquery`;
 
                 let rawResult;

--- a/docs/guide/quickstart.md
+++ b/docs/guide/quickstart.md
@@ -27,23 +27,81 @@ No JavaScript to write. The core library (map, chat, agent, tools) loads from CD
 
 ## index.html
 
-The HTML shell loads core JS/CSS from the CDN. The `<body>` only needs two placeholder `<div>`s — the layout manager builds the rest (chat panel, controls, etc.) dynamically.
+The HTML shell loads two kinds of code: a set of **pinned third-party libraries** (MapLibre, PMTiles, marked, DOMPurify, highlight.js) as page-global `<script>` tags, and the **geo-agent core** (JS + CSS) from the CDN. The `<body>` only needs two placeholder `<div>`s — the layout manager builds the rest (chat panel, controls, etc.) dynamically.
+
+::: warning Copy this file from the template — don't hand-author it
+The canonical `index.html` lives in [boettiger-lab/geo-agent-template](https://github.com/boettiger-lab/geo-agent-template). **Copy it verbatim** rather than retyping the script tags below. In particular, never hand-edit the `integrity="sha384-…"` hashes — see [Subresource Integrity](#about-the-integrity-hashes) for why. The block below is reproduced for reference and matches the template at the pinned release.
+:::
 
 ```html
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
   <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>My Map App</title>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@v3.6.0/app/style.css">
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@v3.6.0/app/chat.css">
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@v3.6.0/app/sidebar.css">
+
+  <!-- MCP SDK import map -->
+  <script type="importmap">
+  {
+    "imports": {
+      "@modelcontextprotocol/sdk/client/index.js": "https://esm.sh/@modelcontextprotocol/sdk@1.12.0/client/index",
+      "@modelcontextprotocol/sdk/client/streamableHttp.js": "https://esm.sh/@modelcontextprotocol/sdk@1.12.0/client/streamableHttp"
+    }
+  }
+  </script>
+
+  <!-- MapLibre GL JS -->
+  <script src="https://unpkg.com/maplibre-gl@5.22.0/dist/maplibre-gl.js"
+    integrity="sha384-U054LTKiMIJKEecR8PKFiUZdvkGWHjfPBnen5hSmR9TwfOfgZmKbskC8Rs9dCm/1"
+    crossorigin="anonymous"></script>
+  <link href="https://unpkg.com/maplibre-gl@5.22.0/dist/maplibre-gl.css" rel="stylesheet"
+    integrity="sha384-MGCxhspF/+ufueUgol3FDkiAYQbpSNRhBT0VWHJt64U8qIy9qlnXWx8LAbj6niPH"
+    crossorigin="anonymous" />
+
+  <!-- PMTiles protocol -->
+  <script src="https://unpkg.com/pmtiles@3.0.7/dist/pmtiles.js"
+    integrity="sha384-MjejsnWXHmuz93aE35YWLh5AbS/6ceRB3Vb+ukOwqFzJRTpQ8vvbkLbNV7I0QK4f"
+    crossorigin="anonymous"></script>
+
+  <!-- h3-js (hex grid overlay) -->
+  <script src="https://unpkg.com/h3-js@4.1.0/dist/h3-js.umd.js"
+    integrity="sha384-nKUDlg+fT0U/eEt4KWP9n034kLe/eVj6k7CVjbu6qfRhJdEyinlGajS9+9AU+UZ5"
+    crossorigin="anonymous"></script>
+
+  <!-- Markdown rendering (lib/marked.umd.js is the package-shipped artifact;
+       marked.min.js is CDN-generated and unsafe to hash) -->
+  <script src="https://cdn.jsdelivr.net/npm/marked@18.0.5/lib/marked.umd.js"
+    integrity="sha384-ZD0fTOwPMHi7zM6WTVIWJR21I07lq0ccnqz3J6WMvQKG9thh4y7TA1QE6PJu0Af8"
+    crossorigin="anonymous"></script>
+
+  <!-- HTML sanitizer — chat-ui.js refuses to render markdown without it -->
+  <script src="https://cdn.jsdelivr.net/npm/dompurify@3.4.8/dist/purify.min.js"
+    integrity="sha384-jrsBdrv4eDpEYIq32u13DPbvB6tRmqIDnA6UlgFBoexpetaiWi7g/VbfMEL1WVen"
+    crossorigin="anonymous"></script>
+
+  <!-- Code highlighting -->
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github-dark.min.css"
+    integrity="sha384-wH75j6z1lH97ZOpMOInqhgKzFkAInZPPSPlZpYKYTOqsaizPvhQZmAtLcPKXpLyH"
+    crossorigin="anonymous">
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"
+    integrity="sha384-F/bZzf7p3Joyp5psL90p/p89AZJsndkSoGwRpXcZhleCWhd8SnRuoYo4d0yirjJp"
+    crossorigin="anonymous"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/languages/sql.min.js"
+    integrity="sha384-8q00eP+tyV9451aJYD5ML3ftuHKsGnDcezp7EXMEclDg1fZVSoj8O+3VyJTkXmWp"
+    crossorigin="anonymous"></script>
+
+  <!-- geo-agent core styles (pinned) -->
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@v3.9.0/app/style.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@v3.9.0/app/chat.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@v3.9.0/app/sidebar.css">
 </head>
 <body>
   <div id="map"></div>
   <div id="menu"></div>
+  <!-- geo-agent bootstrap (pinned) -->
   <script type="module"
-    src="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@v3.6.0/app/main.js">
+    src="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@v3.9.0/app/main.js">
   </script>
 </body>
 </html>
@@ -52,6 +110,21 @@ The HTML shell loads core JS/CSS from the CDN. The `<body>` only needs two place
 ::: tip Sidebar CSS is safe to always include
 `sidebar.css` is scoped to `body.sidebar-mode` and sidebar-only IDs, so it has zero effect on floating-mode apps. Include it unconditionally to keep all apps on the same scaffold.
 :::
+
+### About the `integrity` hashes
+
+Each third-party `<script>`/`<link>` carries an `integrity="sha384-…"` attribute — that's [Subresource Integrity (SRI)](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity). The browser downloads the file, hashes it, and **refuses to run it unless the hash matches**. If a CDN were ever compromised and served a tampered library, the mismatch blocks the swapped-in code instead of executing it. This matters here specifically because the agent renders model output (which can be steered by attacker-controllable data) into the page — DOMPurify sanitizes it, and SRI guarantees the *real* DOMPurify is the thing that loaded. `crossorigin="anonymous"` is required for SRI to work on cross-origin files.
+
+**You normally never touch these values.** They're maintained in the template repo and this repo's `app/index.html`, kept in lockstep with the release the app pins. Copy them; don't retype them.
+
+A hash needs updating in exactly one situation: **you bump a pinned library to a new version** (e.g. `marked@18.0.5` → a later release). A new version is different bytes, so the old hash will no longer match and the browser will block the file — chat text then renders as escaped plain markdown (a deliberate fail-closed, with a console warning), which is your signal that a hash and its URL have drifted apart. Recompute with:
+
+```bash
+curl -sL "<the pinned URL>" | openssl dgst -sha384 -binary | openssl base64 -A
+# prefix the result with "sha384-"
+```
+
+Update the URL and its `integrity` value together in the same commit. Because every URL pins an *exact* version (never a floating range like `@18` or bare `marked`), the served bytes are immutable and the hash is stable indefinitely — so this is rare and only done by maintainers bumping a dependency.
 
 | CDN reference | When to use |
 |---|---|

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,9 @@
       "version": "1.0.0",
       "devDependencies": {
         "@vitest/coverage-v8": "^2.1.9",
+        "dompurify": "3.4.8",
+        "jsdom": "26.1.0",
+        "marked": "18.0.5",
         "vitepress": "^1.6.3",
         "vitest": "^2.1.9"
       }
@@ -286,63 +289,18 @@
       }
     },
     "node_modules/@asamuzakjp/css-color": {
-      "version": "5.1.11",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
-      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
-        "@asamuzakjp/generational-cache": "^1.0.1",
-        "@csstools/css-calc": "^3.2.0",
-        "@csstools/css-color-parser": "^4.1.0",
-        "@csstools/css-parser-algorithms": "^4.0.0",
-        "@csstools/css-tokenizer": "^4.0.0"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
       }
-    },
-    "node_modules/@asamuzakjp/dom-selector": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
-      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@asamuzakjp/generational-cache": "^1.0.1",
-        "@asamuzakjp/nwsapi": "^2.3.9",
-        "bidi-js": "^1.0.3",
-        "css-tree": "^3.2.1",
-        "is-potential-custom-element-name": "^1.0.1"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@asamuzakjp/generational-cache": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
-      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@asamuzakjp/nwsapi": {
-      "version": "2.3.9",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
-      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
     },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.27.1",
@@ -401,25 +359,10 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@bramus/specificity": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
-      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "css-tree": "^3.0.0"
-      },
-      "bin": {
-        "specificity": "bin/cli.js"
-      }
-    },
     "node_modules/@csstools/color-helpers": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
-      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
       "dev": true,
       "funding": [
         {
@@ -432,16 +375,14 @@
         }
       ],
       "license": "MIT-0",
-      "optional": true,
-      "peer": true,
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=18"
       }
     },
     "node_modules/@csstools/css-calc": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
-      "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
       "dev": true,
       "funding": [
         {
@@ -454,20 +395,18 @@
         }
       ],
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=18"
       },
       "peerDependencies": {
-        "@csstools/css-parser-algorithms": "^4.0.0",
-        "@csstools/css-tokenizer": "^4.0.0"
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
       }
     },
     "node_modules/@csstools/css-color-parser": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.1.tgz",
-      "integrity": "sha512-eZ5XOtyhK+mggRafYUWzA0tvaYOFgdY8AkgQiCJF9qNAePnUo/zmsqqYubBBb3sQ8uNUaSKTY9s9klfRaAXL0g==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
       "dev": true,
       "funding": [
         {
@@ -480,24 +419,22 @@
         }
       ],
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
-        "@csstools/color-helpers": "^6.0.2",
-        "@csstools/css-calc": "^3.2.1"
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
       },
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=18"
       },
       "peerDependencies": {
-        "@csstools/css-parser-algorithms": "^4.0.0",
-        "@csstools/css-tokenizer": "^4.0.0"
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
       }
     },
     "node_modules/@csstools/css-parser-algorithms": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
-      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
       "dev": true,
       "funding": [
         {
@@ -510,46 +447,17 @@
         }
       ],
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=18"
       },
       "peerDependencies": {
-        "@csstools/css-tokenizer": "^4.0.0"
-      }
-    },
-    "node_modules/@csstools/css-syntax-patches-for-csstree": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.4.tgz",
-      "integrity": "sha512-wgsqt92b7C7tQhIdPNxj0n9zuUbQlvAuI1exyzeNrOKOi62SD7ren8zqszmpVREjAOqg8cD2FqYhQfAuKjk4sw==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/csstools"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/csstools"
-        }
-      ],
-      "license": "MIT-0",
-      "optional": true,
-      "peer": true,
-      "peerDependencies": {
-        "css-tree": "^3.2.1"
-      },
-      "peerDependenciesMeta": {
-        "css-tree": {
-          "optional": true
-        }
+        "@csstools/css-tokenizer": "^3.0.4"
       }
     },
     "node_modules/@csstools/css-tokenizer": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
-      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
       "dev": true,
       "funding": [
         {
@@ -562,10 +470,8 @@
         }
       ],
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=18"
       }
     },
     "node_modules/@docsearch/css": {
@@ -1008,26 +914,6 @@
       ],
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/@exodus/bytes": {
-      "version": "1.15.1",
-      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
-      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
-      },
-      "peerDependencies": {
-        "@noble/hashes": "^1.8.0 || ^2.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@noble/hashes": {
-          "optional": true
-        }
       }
     },
     "node_modules/@iconify-json/simple-icons": {
@@ -1614,6 +1500,14 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@types/unist": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
@@ -2060,6 +1954,16 @@
         "url": "https://github.com/sponsors/antfu"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/algoliasearch": {
       "version": "5.52.1",
       "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.52.1.tgz",
@@ -2130,18 +2034,6 @@
       "license": "MIT",
       "engines": {
         "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/bidi-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
-      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/birpc": {
@@ -2299,20 +2191,18 @@
         "node": ">= 8"
       }
     },
-    "node_modules/css-tree": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
-      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
-        "mdn-data": "2.27.1",
-        "source-map-js": "^1.2.1"
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
       },
       "engines": {
-        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+        "node": ">=18"
       }
     },
     "node_modules/csstype": {
@@ -2323,19 +2213,17 @@
       "license": "MIT"
     },
     "node_modules/data-urls": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
-      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
-        "whatwg-mimetype": "^5.0.0",
-        "whatwg-url": "^16.0.0"
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+        "node": ">=18"
       }
     },
     "node_modules/debug": {
@@ -2361,9 +2249,7 @@
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
       "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/deep-eql": {
       "version": "5.0.2",
@@ -2397,6 +2283,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.8",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.8.tgz",
+      "integrity": "sha512-yb1cEmaOum7wFvOCSQxyfgVlv5D47Rc30iZWoMpbDIWTnJ6grDDQyu2KFJzB2k7u0pMuJcQ1zphH//fFnw2tjQ==",
+      "dev": true,
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/eastasianwidth": {
@@ -2652,18 +2548,16 @@
       "license": "MIT"
     },
     "node_modules/html-encoding-sniffer": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
-      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
-        "@exodus/bytes": "^1.6.0"
+        "whatwg-encoding": "^3.1.1"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+        "node": ">=18"
       }
     },
     "node_modules/html-escaper": {
@@ -2684,6 +2578,47 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -2699,9 +2634,7 @@
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/is-what": {
       "version": "5.5.0",
@@ -2794,38 +2727,35 @@
       }
     },
     "node_modules/jsdom": {
-      "version": "29.1.1",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
-      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
+      "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
-        "@asamuzakjp/css-color": "^5.1.11",
-        "@asamuzakjp/dom-selector": "^7.1.1",
-        "@bramus/specificity": "^2.4.2",
-        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
-        "@exodus/bytes": "^1.15.0",
-        "css-tree": "^3.2.1",
-        "data-urls": "^7.0.0",
-        "decimal.js": "^10.6.0",
-        "html-encoding-sniffer": "^6.0.0",
+        "cssstyle": "^4.2.1",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.5.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
         "is-potential-custom-element-name": "^1.0.1",
-        "lru-cache": "^11.3.5",
-        "parse5": "^8.0.1",
+        "nwsapi": "^2.2.16",
+        "parse5": "^7.2.1",
+        "rrweb-cssom": "^0.8.0",
         "saxes": "^6.0.0",
         "symbol-tree": "^3.2.4",
-        "tough-cookie": "^6.0.1",
-        "undici": "^7.25.0",
+        "tough-cookie": "^5.1.1",
         "w3c-xmlserializer": "^5.0.0",
-        "webidl-conversions": "^8.0.1",
-        "whatwg-mimetype": "^5.0.0",
-        "whatwg-url": "^16.0.1",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.1.1",
+        "ws": "^8.18.0",
         "xml-name-validator": "^5.0.0"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+        "node": ">=18"
       },
       "peerDependencies": {
         "canvas": "^3.0.0"
@@ -2834,18 +2764,6 @@
         "canvas": {
           "optional": true
         }
-      }
-    },
-    "node_modules/jsdom/node_modules/lru-cache": {
-      "version": "11.5.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.0.tgz",
-      "integrity": "sha512-5YgH9UJd7wVb9hIouI2adWpgqrrICkt070Dnj8EUY1+B4B2P9eRLPAkAAo6NICA7CEhOIeBHl46u9zSNpNu7zA==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": "20 || >=22"
       }
     },
     "node_modules/loupe": {
@@ -2907,6 +2825,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/marked": {
+      "version": "18.0.5",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.5.tgz",
+      "integrity": "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "node_modules/mdast-util-to-hast": {
       "version": "13.2.1",
       "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
@@ -2928,15 +2859,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
-    },
-    "node_modules/mdn-data": {
-      "version": "2.27.1",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
-      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
-      "dev": true,
-      "license": "CC0-1.0",
-      "optional": true,
-      "peer": true
     },
     "node_modules/micromark-util-character": {
       "version": "2.1.1",
@@ -3098,6 +3020,13 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/nwsapi": {
+      "version": "2.2.24",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.24.tgz",
+      "integrity": "sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/oniguruma-to-es": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-3.1.1.tgz",
@@ -3118,30 +3047,26 @@
       "license": "BlueOak-1.0.0"
     },
     "node_modules/parse5": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
-      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
-        "entities": "^8.0.0"
+        "entities": "^6.0.0"
       },
       "funding": {
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/parse5/node_modules/entities": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
-      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "optional": true,
-      "peer": true,
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=0.12"
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
@@ -3262,8 +3187,6 @@
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -3294,18 +3217,6 @@
       "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/require-from-string": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/rfdc": {
       "version": "1.4.1",
@@ -3359,14 +3270,26 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/saxes": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
       "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
       "dev": true,
       "license": "ISC",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "xmlchars": "^2.2.0"
       },
@@ -3650,9 +3573,7 @@
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/tabbable": {
       "version": "6.4.0",
@@ -3721,57 +3642,49 @@
       }
     },
     "node_modules/tldts": {
-      "version": "7.0.30",
-      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.30.tgz",
-      "integrity": "sha512-ELrFxuqsDdHUwoh0XxDbxuLD3Wnz49Z57IFvTtvWy1hJdcMZjXLIuonjilCiWHlT2GbE4Wlv1wKVTzDFnXH1aw==",
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
-        "tldts-core": "^7.0.30"
+        "tldts-core": "^6.1.86"
       },
       "bin": {
         "tldts": "bin/cli.js"
       }
     },
     "node_modules/tldts-core": {
-      "version": "7.0.30",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.30.tgz",
-      "integrity": "sha512-uiHN8PIB1VmWyS98eZYja4xzlYqeFZVjb4OuYlJQnZAuJhMw4PbKQOKgHKhBdJR3FE/t5mUQ1Kd80++B+qhD1Q==",
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
       "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/tough-cookie": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
-      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "optional": true,
-      "peer": true,
       "dependencies": {
-        "tldts": "^7.0.5"
+        "tldts": "^6.1.32"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/tr46": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
-      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "punycode": "^2.3.1"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=18"
       }
     },
     "node_modules/trim-lines": {
@@ -3783,18 +3696,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/undici": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
-      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=20.18.1"
       }
     },
     "node_modules/unist-util-is": {
@@ -4119,8 +4020,6 @@
       "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "xml-name-validator": "^5.0.0"
       },
@@ -4129,44 +4028,51 @@
       }
     },
     "node_modules/webidl-conversions": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
-      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "optional": true,
-      "peer": true,
       "engines": {
-        "node": ">=20"
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/whatwg-mimetype": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
-      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "engines": {
-        "node": ">=20"
+        "node": ">=18"
       }
     },
     "node_modules/whatwg-url": {
-      "version": "16.0.1",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
-      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
-        "@exodus/bytes": "^1.11.0",
-        "tr46": "^6.0.0",
-        "webidl-conversions": "^8.0.1"
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+        "node": ">=18"
       }
     },
     "node_modules/which": {
@@ -4300,14 +4206,34 @@
         "node": ">=8"
       }
     },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/xml-name-validator": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
       "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
       "dev": true,
       "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4317,9 +4243,7 @@
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/zwitch": {
       "version": "2.0.4",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
   },
   "devDependencies": {
     "@vitest/coverage-v8": "^2.1.9",
+    "dompurify": "3.4.8",
+    "jsdom": "26.1.0",
+    "marked": "18.0.5",
     "vitepress": "^1.6.3",
     "vitest": "^2.1.9"
   }

--- a/test/chat-ui-render.test.js
+++ b/test/chat-ui-render.test.js
@@ -1,0 +1,80 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeAll, afterEach } from 'vitest';
+import { marked } from 'marked';
+import DOMPurify from 'dompurify';
+import { renderMarkdown } from '../app/chat-ui.js';
+
+// chat-ui.js consumes marked and DOMPurify as page globals (CDN script
+// tags); mirror that here with the real libraries.
+beforeAll(() => {
+    globalThis.marked = marked;
+    globalThis.DOMPurify = DOMPurify;
+});
+
+afterEach(() => {
+    globalThis.marked = marked;
+    globalThis.DOMPurify = DOMPurify;
+});
+
+const render = (md) => {
+    const el = document.createElement('div');
+    el.innerHTML = renderMarkdown(md);
+    return el;
+};
+
+describe('renderMarkdown sanitization', () => {
+    it('strips event-handler XSS that marked passes through', () => {
+        const el = render('Here is the result: <img src=x onerror="window.__pwned=1">');
+        expect(el.querySelector('img[onerror]')).toBeNull();
+        expect(renderMarkdown('x <img src=x onerror=alert(1)>')).not.toContain('onerror');
+    });
+
+    it('strips script tags', () => {
+        expect(renderMarkdown('hello <script>alert(1)</script> world')).not.toContain('<script');
+    });
+
+    it('strips javascript: URLs in links', () => {
+        const el = render('[click me](javascript:alert(1))');
+        const a = el.querySelector('a');
+        if (a) expect(a.getAttribute('href') || '').not.toMatch(/^javascript:/i);
+    });
+
+    it('preserves markdown tables', () => {
+        const el = render('| a | b |\n|---|---|\n| 1 | 2 |');
+        expect(el.querySelector('table')).not.toBeNull();
+        expect(el.querySelectorAll('td')).toHaveLength(2);
+    });
+
+    it('preserves fenced code blocks with language class (hljs hook)', () => {
+        const el = render('```sql\nSELECT 1;\n```');
+        const code = el.querySelector('pre code');
+        expect(code).not.toBeNull();
+        expect(code.className).toContain('language-sql');
+        expect(code.textContent).toContain('SELECT 1;');
+    });
+
+    it('preserves ordinary links', () => {
+        const el = render('[docs](https://example.com/page)');
+        expect(el.querySelector('a[href="https://example.com/page"]')).not.toBeNull();
+    });
+
+    it('scrubs credential-shaped tokens before rendering (SEC-4)', () => {
+        const out = renderMarkdown("Run: CREATE SECRET (KEY_ID 'AKIAXXXX', SECRET 'shhh-very-secret');");
+        expect(out).not.toContain('AKIAXXXX');
+        expect(out).not.toContain('shhh-very-secret');
+        expect(out).toContain('[REDACTED]');
+    });
+
+    it('fails closed (escaped text, no raw HTML) when DOMPurify is missing', () => {
+        delete globalThis.DOMPurify;
+        const el = render('**bold** <img src=x onerror=alert(1)>');
+        expect(el.querySelector('img')).toBeNull();
+        expect(el.textContent).toContain('<img');
+    });
+
+    it('fails closed when marked is missing', () => {
+        delete globalThis.marked;
+        const el = render('<img src=x onerror=alert(1)>');
+        expect(el.querySelector('img')).toBeNull();
+    });
+});

--- a/test/chat-ui-render.test.js
+++ b/test/chat-ui-render.test.js
@@ -2,7 +2,7 @@
 import { describe, it, expect, beforeAll, afterEach } from 'vitest';
 import { marked } from 'marked';
 import DOMPurify from 'dompurify';
-import { renderMarkdown } from '../app/chat-ui.js';
+import { renderMarkdown, ChatUI } from '../app/chat-ui.js';
 
 // chat-ui.js consumes marked and DOMPurify as page globals (CDN script
 // tags); mirror that here with the real libraries.
@@ -76,5 +76,39 @@ describe('renderMarkdown sanitization', () => {
         delete globalThis.marked;
         const el = render('<img src=x onerror=alert(1)>');
         expect(el.querySelector('img')).toBeNull();
+    });
+});
+
+/**
+ * Tool-call names come from the LLM response JSON (structured tool_calls),
+ * which prompt injection can steer — they must be escaped like every other
+ * value in the tool rows.
+ */
+describe('tool-call name escaping', () => {
+    it('escapes HTML in proposed tool-call names (renderToolCallArgs)', () => {
+        const ui = Object.create(ChatUI.prototype);
+        const html = ui.renderToolCallArgs({
+            function: { name: '<img src=x onerror=alert(1)>', arguments: '{}' },
+        });
+        const el = document.createElement('div');
+        el.innerHTML = html;
+        expect(el.querySelector('img')).toBeNull();
+        expect(el.textContent).toContain('<img');
+    });
+
+    it('escapes HTML in result names (showToolResults)', () => {
+        const ui = Object.create(ChatUI.prototype);
+        const row = document.createElement('details');
+        row.innerHTML = '<summary><span class="row-status running"></span></summary>' +
+            '<div class="agent-turn-row-body"></div>';
+        ui.currentTurn = { rowsByIter: new Map([[1, row]]) };
+        ui.scrollToBottom = () => {};
+        ui.showToolResults(
+            [{ name: '<img src=x onerror=alert(1)>', success: true, result: 'ok' }],
+            1
+        );
+        const body = row.querySelector('.agent-turn-row-body');
+        expect(body.querySelector('img')).toBeNull();
+        expect(body.textContent).toContain('<img');
     });
 });

--- a/test/map-manager.tooltip-legend.test.js
+++ b/test/map-manager.tooltip-legend.test.js
@@ -1,0 +1,139 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest';
+import { MapManager } from '../app/map-manager.js';
+
+/**
+ * Tooltip and legend render untrusted strings: vector-tile feature values,
+ * LLM-chosen tooltip field names, and STAC metadata (display names, class
+ * names, color hints). These tests pin that none of them can inject DOM.
+ */
+
+function createTooltipManager(tooltipFields) {
+    const handlers = {};
+    const map = {
+        on: (event, layerId, cb) => { handlers[`${event}:${layerId}`] = cb; },
+        getCanvas: () => ({ style: {} }),
+    };
+    const mm = Object.create(MapManager.prototype);
+    mm.map = map;
+    mm._tooltip = document.createElement('div');
+    mm._tooltip.style.display = 'none';
+    mm.layers = new Map([['A', { mapLayerId: 'layer-A', tooltipFields }]]);
+    mm._wireTooltip('layer-A', 'A');
+    const hover = (props) => handlers['mousemove:layer-A']({
+        features: [{ properties: props }],
+        originalEvent: { clientX: 10, clientY: 20 },
+    });
+    return { mm, hover };
+}
+
+describe('MapManager tooltip (SEC-2)', () => {
+    it('renders HTML in feature values as inert text', () => {
+        const { mm, hover } = createTooltipManager(['name']);
+        hover({ name: '<img src=x onerror="window.__pwned=1">' });
+        expect(mm._tooltip.querySelector('img')).toBeNull();
+        expect(mm._tooltip.textContent).toContain('<img');
+    });
+
+    it('renders HTML in field names as inert text', () => {
+        const field = '<b onmouseover=alert(1)>owner</b>';
+        const { mm, hover } = createTooltipManager([field]);
+        hover({ [field]: 'Jane' });
+        expect(mm._tooltip.querySelector('b')).toBeNull();
+        expect(mm._tooltip.textContent).toContain('Jane');
+    });
+
+    it('keeps currency and acreage number formatting', () => {
+        const { mm, hover } = createTooltipManager(['assessed_value', 'acres']);
+        hover({ assessed_value: 1234567, acres: 12345.67 });
+        const cells = [...mm._tooltip.querySelectorAll('td')].map(td => td.textContent);
+        expect(cells).toContain('$1,234,567');
+        expect(cells).toContain('12,345.7');
+    });
+
+    it('still renders a table with one row per non-empty field', () => {
+        const { mm, hover } = createTooltipManager(['a', 'b', 'c']);
+        hover({ a: 'x', b: '', c: 'z' });
+        expect(mm._tooltip.querySelectorAll('tr')).toHaveLength(2);
+        expect(mm._tooltip.style.display).toBe('block');
+    });
+
+    it('bails out without showing the tooltip when all values are empty', () => {
+        const { mm, hover } = createTooltipManager(['a']);
+        hover({ a: '' });
+        expect(mm._tooltip.style.display).toBe('none');
+    });
+});
+
+function createLegendManager(state) {
+    const mm = Object.create(MapManager.prototype);
+    mm.layers = new Map([['A', state]]);
+    mm._legendEl = document.createElement('div');
+    mm._legendContent = document.createElement('div');
+    mm._legendItems = new Map();
+    mm._ensureLegend = () => {};
+    return mm;
+}
+
+describe('MapManager raster legend (SEC-3)', () => {
+    it('renders HTML in categorical class names as inert text', async () => {
+        const mm = createLegendManager({
+            displayName: 'Land cover',
+            legendType: 'categorical',
+            legendClasses: [{ name: '<img src=x onerror=alert(1)>', 'color-hint': 'ff0000' }],
+        });
+        await mm._showRasterLegend('A');
+        expect(mm._legendContent.querySelector('img')).toBeNull();
+        expect(mm._legendContent.textContent).toContain('<img');
+    });
+
+    it('renders HTML in the display name as inert text (both branches)', async () => {
+        const mm = createLegendManager({
+            displayName: '<script>alert(1)</script>Cover',
+            legendType: 'categorical',
+            legendClasses: [{ name: 'Forest', 'color-hint': '00ff00' }],
+        });
+        await mm._showRasterLegend('A');
+        expect(mm._legendContent.querySelector('script')).toBeNull();
+        expect(mm._legendContent.querySelector('h4').textContent).toContain('Cover');
+    });
+
+    it('applies a valid color-hint to the swatch', async () => {
+        const mm = createLegendManager({
+            displayName: 'Land cover',
+            legendType: 'categorical',
+            legendClasses: [{ name: 'Forest', 'color-hint': '00ff00' }],
+        });
+        await mm._showRasterLegend('A');
+        const swatch = mm._legendContent.querySelector('.legend-item span');
+        expect(swatch.getAttribute('style')).toMatch(/00ff00|rgb\(0,\s*255,\s*0\)/i);
+    });
+
+    it('falls back to grey when color-hint is not a hex color (attribute breakout)', async () => {
+        const mm = createLegendManager({
+            displayName: 'Land cover',
+            legendType: 'categorical',
+            legendClasses: [{ name: 'Evil', 'color-hint': 'red;"></span><img src=x onerror=alert(1)>' }],
+        });
+        await mm._showRasterLegend('A');
+        expect(mm._legendContent.querySelector('img')).toBeNull();
+        const swatch = mm._legendContent.querySelector('.legend-item span');
+        expect(swatch.getAttribute('style')).toMatch(/888888|rgb\(136,\s*136,\s*136\)/i);
+    });
+
+    it('keeps the gradient branch: rescale labels with unit suffix, name as text', async () => {
+        const mm = createLegendManager({
+            displayName: '<i>Carbon</i>',
+            colormap: 'reds',
+            rescale: '0,100',
+            legendLabel: 'tC/ha',
+        });
+        mm._getColormapGradient = async () => 'linear-gradient(to right, #fff, #000)';
+        await mm._showRasterLegend('A');
+        expect(mm._legendContent.querySelector('i')).toBeNull();
+        const labels = [...mm._legendContent.querySelectorAll('.legend-labels span')].map(s => s.textContent);
+        expect(labels).toEqual(['0 tC/ha', '100 tC/ha']);
+        const bar = mm._legendContent.querySelector('.legend-colorbar');
+        expect(bar.getAttribute('style')).toContain('linear-gradient');
+    });
+});

--- a/test/map-tools.test.js
+++ b/test/map-tools.test.js
@@ -127,6 +127,38 @@ describe('filter_by_query', () => {
         expect(result.error).toContain('Could not parse ID list');
         expect(mapManager.setFilter).not.toHaveBeenCalled();
     });
+
+    it('rejects id_property containing SQL metacharacters without calling MCP', async () => {
+        const mapManager = stubMapManager();
+        const mcpClient = { callTool: vi.fn(async () => '[1]') };
+        const tool = getFilterTool(mapManager, mcpClient);
+
+        const raw = await tool.execute({
+            layer_id: 'parcels',
+            sql: 'SELECT id FROM x',
+            id_property: 'id") IS NOT NULL)) AS ids FROM evil --',
+        });
+        const result = JSON.parse(raw);
+
+        expect(result.success).toBe(false);
+        expect(result.error).toContain('id_property');
+        expect(mcpClient.callTool).not.toHaveBeenCalled();
+        expect(mapManager.setFilter).not.toHaveBeenCalled();
+    });
+
+    it('accepts underscore-prefixed and uppercase identifiers (_cng_fid, OBJECTID)', async () => {
+        for (const col of ['_cng_fid', 'OBJECTID', 'GEOID20']) {
+            const mapManager = stubMapManager();
+            const mcpClient = { callTool: vi.fn(async () => '[1,2]') };
+            const tool = getFilterTool(mapManager, mcpClient);
+
+            const raw = await tool.execute({ layer_id: 'parcels', sql: 'SELECT id FROM x', id_property: col });
+            const result = JSON.parse(raw);
+
+            expect(result.success).toBe(true);
+            expect(mcpClient.callTool).toHaveBeenCalledOnce();
+        }
+    });
 });
 
 describe('list_datasets', () => {


### PR DESCRIPTION
Addresses all seven findings from the 2026-06-09 security assessment (`assessment/security.md`, reviewed at `5fa2774`). The core risk was prompt-injection → XSS → credential theft: the model reads attacker-controllable data (dataset values, STAC metadata) and its output was rendered to `innerHTML` unsanitized.

## Changes

**SEC-1 (critical) — sanitize all LLM-derived markdown.** Final answers (`addMarkdown`), reasoning rows (`showReasoning`), and tool descriptions (`showToolProposal`) now render through a single `renderMarkdown()` chokepoint: `DOMPurify.sanitize(marked.parse(scrubCredentials(text)))`. If `marked` or DOMPurify is missing on the page, it **fails closed** to escaped plain text (with a console warning) instead of raw HTML. Markdown tables, links, fenced code, and the `hljs` highlight pass are preserved (covered by tests with the real libraries).

**SEC-2 — tooltip.** `_wireTooltip` builds rows with `createElement`/`textContent`; feature values and LLM-chosen field names can no longer inject DOM. Currency/acreage formatting and the empty-rows bail-out are unchanged.

**SEC-3 — raster legend.** `_showRasterLegend` builds via `createElement`/`textContent`; STAC `color-hint` values are validated against `/^#?[0-9a-fA-F]{3,8}$/` (grey fallback) before reaching a style attribute. Categorical and gradient branches, including the `legendLabel` unit suffix, behave as before.

**SEC-4 — live credential scrub.** The same `scrubCredentials()` already used by the export path now runs on every `renderMarkdown()` call, so answers/reasoning are scrubbed live. Scrubbing `agent.messages` history was considered and deferred — mutating what the model sees mid-conversation is a behavior change better evaluated separately.

**SEC-5 — supply chain.** `marked` pinned to 18.0.5 — deliberately to the package-shipped `lib/marked.umd.js`, because `marked.min.js` does not exist in the npm package (jsDelivr generates it; not safe to hash). DOMPurify 3.4.8 added. `integrity` + `crossorigin="anonymous"` on every pinned CDN `<script>`/`<link>`, including the runtime-loaded mapbox-gl-draw assets in `map-draw.js`. All hashes computed from the served bytes and cross-checked against a second CDN host. Not covered (documented residual risk): the umami analytics script (mutable, can't carry SRI) and the esm.sh import-map MCP SDK entries (multi-file resolution).

**SEC-6 — `filter_by_query`.** `id_property` validated as a plain identifier (`^[A-Za-z0-9_]+$`) before interpolation into the wrapping SQL; `_cng_fid` / `OBJECTID` / `GEOID20` style names still work.

**SEC-7 — CI.** Coverage action pinned to the v2.9.3 commit SHA.

**Review finding (second commit).** An adversarial review of this PR's own diff found one residual sink the assessment missed: the structured `tool_calls` function *name* was interpolated into `insertAdjacentHTML` unescaped in `renderToolCallArgs` and `showToolResults` (every sibling value was already escaped). Now escaped.

## Tests

239 passing (was 216). New jsdom-based tests use the **real** `marked` + `dompurify` (added as exact-pinned devDependencies) to pin the sanitizer behavior: XSS stripping, markdown feature preservation, fail-closed paths, tooltip/legend escaping, color-hint validation, `id_property` rejection, and tool-name escaping. The `package-lock.json` churn is jsdom's tree converting from optional-peer to direct dev deps. Verified with fresh `npm ci` + full suite on Node 20 (CI parity) and Node 22.

## Deployment notes — downstream apps must add one script tag

Production apps are pinned to existing tags/SHAs and are **unaffected until they bump**. When an app bumps to a release containing this PR, its `index.html` must add the DOMPurify tag (and should adopt the pinned `marked` tag + SRI attributes from `app/index.html`):

```html
<script src="https://cdn.jsdelivr.net/npm/dompurify@3.4.8/dist/purify.min.js"
    integrity="sha384-jrsBdrv4eDpEYIq32u13DPbvB6tRmqIDnA6UlgFBoexpetaiWi7g/VbfMEL1WVen"
    crossorigin="anonymous"></script>
```

Without it the app stays functional and safe but chat text renders as escaped plain text (fail-closed, with a console warning) — immediately visible in testing, not a silent break. Rollout sequencing across the fleet belongs to geo-agent-ops.

## Test plan

- [x] Full suite in clean containers (Node 20 + 22), fresh `npm ci`
- [ ] Manual verification against the **wyoming** app before merge (browser-bound modules `chat-ui.js` / `map-manager.js` have no jsdom harness for their DOM-heavy paths): chat markdown rendering (tables/code/links), reasoning rows, tool approval rows, tooltips, raster legends, draw tool, and that all SRI-tagged assets load (any 'integrity' console error = blocked asset)