### PR TITLE
Rename displayed product name to GLEN

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -15,6 +15,7 @@
    "description":"A reusable JavaScript library for building interactive map applications with an agentic chatbot for natural language data queries and map control. It pairs a MapLibre GL JS map (PMTiles vectors, cloud-optimized GeoTIFF rasters via TiTiler) with an LLM agent that answers complex, real-world natural language queries by running reproducible SQL analytics over H3-indexed parquet through the Model Context Protocol (MCP) and DuckDB, returning verifiable data summaries, charts, maps, and text. Datasets are described by a STAC catalog and surfaced as unified records with both visual and tabular assets. Downstream applications (with their own datasets, branding, and deployments) import these modules from a CDN and supply their own configuration.",
    "access_right":"open",
    "license":"apache-2.0",
+   "doi":"10.5281/zenodo.20673850",
    "upload_type":"software",
    "grants":[
       {

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -11,7 +11,7 @@
          "affiliation":"University of Colorado Boulder"
       }
    ],
-   "title":"geo-agent: A reusable library for map-based applications with LLM-powered data analysis",
+   "title":"GLEN (Geospatial LLM-Enabled Navigator): A reusable library for map-based applications with LLM-powered data analysis",
    "description":"A reusable JavaScript library for building interactive map applications with an agentic chatbot for natural language data queries and map control. It pairs a MapLibre GL JS map (PMTiles vectors, cloud-optimized GeoTIFF rasters via TiTiler) with an LLM agent that answers complex, real-world natural language queries by running reproducible SQL analytics over H3-indexed parquet through the Model Context Protocol (MCP) and DuckDB, returning verifiable data summaries, charts, maps, and text. Datasets are described by a STAC catalog and surfaced as unified records with both visual and tabular assets. Downstream applications (with their own datasets, branding, and deployments) import these modules from a CDN and supply their own configuration.",
    "access_right":"open",
    "license":"apache-2.0",

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-Thanks for your interest in `geo-agent` — we'd love to hear from you.
+Thanks for your interest in GLEN — we'd love to hear from you.
 
 This document covers how to contribute, and a note on our policy around AI-generated code.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Geo-Agent: Map + AI Data Analyst
+# GLEN: Map + AI Data Analyst
 
 [![DOI](https://zenodo.org/badge/1151803996.svg)](https://doi.org/10.5281/zenodo.20673849)
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Geo-Agent: Map + AI Data Analyst
 
+[![DOI](https://zenodo.org/badge/1151803996.svg)](https://doi.org/10.5281/zenodo.20673849)
+
 A reusable JavaScript library for interactive map applications with LLM-powered data analysis. MapLibre GL JS on the front end, agentic tool-use with MCP (Model Context Protocol) for SQL analytics via DuckDB.
 
 **This repo is the core library.** Individual apps (different datasets, URLs, branding) import these modules from the CDN and provide their own configuration.

--- a/app/chat-ui.js
+++ b/app/chat-ui.js
@@ -979,7 +979,7 @@ export class ChatUI {
         const title = this._exportTitle();
         const appUrl = window.location.href;
         const appUrlAttr = this.escapeHtml(appUrl).replace(/"/g, '&quot;');
-        const appTitle = document.title || 'Geo-Agent';
+        const appTitle = document.title || 'GLEN';
         const exportedAt = new Date().toLocaleString();
 
         const html =
@@ -992,7 +992,7 @@ export class ChatUI {
 </head>
 <body>
 <header class="export-header">
-  <h1>Geo-Agent chat transcript</h1>
+  <h1>GLEN chat transcript</h1>
   <p>Exported ${this.escapeHtml(exportedAt)} — <a href="${appUrlAttr}">${this.escapeHtml(appTitle)}</a></p>
   <p class="export-note">SQL queries below have been rewritten to use the public S3 endpoint
      (<code>https://s3-west.nrp-nautilus.io/</code>) so they can be re-run from any DuckDB
@@ -1058,7 +1058,7 @@ export class ChatUI {
         const pad = (n) => String(n).padStart(2, '0');
         const stamp = `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}` +
                       `-${pad(d.getHours())}${pad(d.getMinutes())}`;
-        return `geo-agent-chat-${stamp}.html`;
+        return `glen-chat-${stamp}.html`;
     }
 
     _exportTitle() {
@@ -1066,7 +1066,7 @@ export class ChatUI {
         const pad = (n) => String(n).padStart(2, '0');
         const stamp = `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ` +
                       `${pad(d.getHours())}:${pad(d.getMinutes())}`;
-        return `Geo-Agent chat — ${stamp}`;
+        return `GLEN chat — ${stamp}`;
     }
 
     /**

--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -1,5 +1,5 @@
 export default {
-  title: 'Geo-Agent',
+  title: 'GLEN',
   description: 'Map + AI Data Analyst — interactive MapLibre maps with LLM-powered data analysis.',
   base: '/geo-agent/',
 

--- a/docs/architecture.svg
+++ b/docs/architecture.svg
@@ -24,7 +24,7 @@
   <rect width="1000" height="800" fill="url(#grid)"/>
 
   <!-- ===== TITLE ===== -->
-  <text x="500" y="35" font-size="26" font-weight="900" text-anchor="middle" fill="#1A252F" letter-spacing="0.5">Geo-Agent Architecture</text>
+  <text x="500" y="35" font-size="26" font-weight="900" text-anchor="middle" fill="#1A252F" letter-spacing="0.5">GLEN Architecture</text>
   <text x="500" y="56" font-size="13" text-anchor="middle" fill="#95A5A6" font-style="italic">Modular components that snap together — like LEGO® bricks</text>
 
   <!-- ================================================================
@@ -75,7 +75,7 @@
   <!-- Top sheen -->
   <rect x="22" y="155" width="586" height="15" rx="6" fill="#FFD070" opacity="0.50"/>
   <!-- Title -->
-  <text x="315" y="188" font-size="15" font-weight="900" text-anchor="middle" fill="#5D3A00">geo-agent JS Client</text>
+  <text x="315" y="188" font-size="15" font-weight="900" text-anchor="middle" fill="#5D3A00">GLEN JS Client</text>
   <text x="315" y="206" font-size="10.5" text-anchor="middle" fill="#7A4F00">main.js · agent.js · tool-registry.js · mcp-client.js · dataset-catalog.js</text>
 
   <!-- Sub-brick: MapLibre GL JS -->

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -1,6 +1,6 @@
 # Configuration Reference
 
-Client apps configure geo-agent via `layers-input.json`. All fields except `catalog` and `collections` are optional.
+Client apps configure GLEN via `layers-input.json`. All fields except `catalog` and `collections` are optional.
 
 ## Top-level fields
 
@@ -268,7 +268,7 @@ Both fields are optional independently — you can swap the URL without changing
 
 ## Sidebar layout
 
-By default, geo-agent renders a small translucent chat panel floating in the
+By default, GLEN renders a small translucent chat panel floating in the
 bottom-right corner of the map. Apps that benefit from more chat real-estate
 (e.g., heavy analytical use, long tool-call transcripts, prominent layer menus)
 can opt in to a full-height, resizable sidebar via a top-level `sidebar` block

--- a/docs/guide/deployment.md
+++ b/docs/guide/deployment.md
@@ -1,6 +1,6 @@
 # Deployment
 
-Geo-agent apps are **static sites** — just HTML, JSON, and Markdown files. They can be hosted anywhere. The only variable is how the LLM API key reaches the app.
+GLEN apps are **static sites** — just HTML, JSON, and Markdown files. They can be hosted anywhere. The only variable is how the LLM API key reaches the app.
 
 ## Option 1: GitHub Pages (or any static host)
 

--- a/docs/guide/quickstart.md
+++ b/docs/guide/quickstart.md
@@ -27,7 +27,7 @@ No JavaScript to write. The core library (map, chat, agent, tools) loads from CD
 
 ## index.html
 
-The HTML shell loads two kinds of code: a set of **pinned third-party libraries** (MapLibre, PMTiles, marked, DOMPurify, highlight.js) as page-global `<script>` tags, and the **geo-agent core** (JS + CSS) from the CDN. The `<body>` only needs two placeholder `<div>`s — the layout manager builds the rest (chat panel, controls, etc.) dynamically.
+The HTML shell loads two kinds of code: a set of **pinned third-party libraries** (MapLibre, PMTiles, marked, DOMPurify, highlight.js) as page-global `<script>` tags, and the **GLEN core** (JS + CSS) from the CDN. The `<body>` only needs two placeholder `<div>`s — the layout manager builds the rest (chat panel, controls, etc.) dynamically.
 
 ::: warning Copy this file from the template — don't hand-author it
 The canonical `index.html` lives in [boettiger-lab/geo-agent-template](https://github.com/boettiger-lab/geo-agent-template). **Copy it verbatim** rather than retyping the script tags below. In particular, never hand-edit the `integrity="sha384-…"` hashes — see [Subresource Integrity](#about-the-integrity-hashes) for why. The block below is reproduced for reference and matches the template at the pinned release.
@@ -91,7 +91,7 @@ The canonical `index.html` lives in [boettiger-lab/geo-agent-template](https://g
     integrity="sha384-8q00eP+tyV9451aJYD5ML3ftuHKsGnDcezp7EXMEclDg1fZVSoj8O+3VyJTkXmWp"
     crossorigin="anonymous"></script>
 
-  <!-- geo-agent core styles (pinned) -->
+  <!-- GLEN core styles (pinned) -->
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@v3.9.0/app/style.css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@v3.9.0/app/chat.css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@v3.9.0/app/sidebar.css">
@@ -99,7 +99,7 @@ The canonical `index.html` lives in [boettiger-lab/geo-agent-template](https://g
 <body>
   <div id="map"></div>
   <div id="menu"></div>
-  <!-- geo-agent bootstrap (pinned) -->
+  <!-- GLEN bootstrap (pinned) -->
   <script type="module"
     src="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@v3.9.0/app/main.js">
   </script>

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,7 @@
 layout: home
 
 hero:
-  name: Geo-Agent
+  name: GLEN
   text: Map + AI Data Analyst
   tagline: Build interactive map applications with LLM-powered data analysis — no JavaScript required.
   actions:


### PR DESCRIPTION
Rebrands the **displayed** product name from "Geo-Agent" to **GLEN** (Geospatial LLM-Enabled Navigator).

## Scope
Only user-facing/displayed text was changed. Per the rename plan, the repo is **not** being renamed yet, so all infrastructure identifiers are left untouched:
- repo & CDN URLs (`boettiger-lab/geo-agent@...`)
- npm package name in `package.json`
- `localStorage` keys (`geo-agent-api-key`, `geo-agent-sidebar-width`, etc.) — renaming would orphan existing users' stored keys/settings
- `geo-agent-template` reference and the VitePress `base: '/geo-agent/'` path

These will follow when the repo is renamed.

## Changed (displayed name only)
- `README.md` — title heading
- `.zenodo.json` — record title (expanded acronym once for citation discoverability)
- `docs/index.md` — homepage hero name
- `docs/.vitepress/config.js` — site/tab title
- `docs/architecture.svg` — diagram heading + client box label
- `docs/guide/configuration.md`, `deployment.md`, `quickstart.md` — prose + scaffold comments
- `CONTRIBUTING.md` — intro line
- `app/chat-ui.js` — app-title fallback, transcript heading/title, exported transcript filename slug (`glen-chat-*.html`)

## Testing
No tests reference these strings; changes are display-string only. CI runs the suite on this PR.