### PR TITLE
feat(geocode): geocoding tool + optional search box (#238)

### DIFF
--- a/app/geocoder.js
+++ b/app/geocoder.js
@@ -11,10 +11,8 @@
  *   - photon              — OSM (Komoot), free, no key. Returns extents.
  *   - maptiler            — high quality, requires an API key.
  *
- * Census (US addresses) is intentionally NOT a browser provider: it sends no
- * CORS headers, so a static app can only reach it via JSONP (a script-injection
- * sink we will not reintroduce) or a server-side proxy. It can be added later
- * as an `endpoint`-backed proxy provider.
+ * A custom `endpoint` lets an app point a provider at a self-hosted instance
+ * (e.g. a private Nominatim) without changing the parsing.
  *
  * Every provider normalizes to the same shape so both consumers — and any
  * future provider — are interchangeable:

--- a/app/geocoder.js
+++ b/app/geocoder.js
@@ -1,0 +1,266 @@
+/**
+ * Geocoder — pluggable place-name / address → coordinate resolution.
+ *
+ * One backend, two consumers:
+ *   1. the `geocode` agent tool (map-tools.js) — so the LLM resolves real,
+ *      traceable coordinates instead of inventing lat/lng from memory, and
+ *   2. the optional maplibre-gl-geocoder search box (map-geocoder.js).
+ *
+ * All providers are global and CORS-clean from a static browser app:
+ *   - nominatim (default) — OSM, free, no key. Rich confidence signals.
+ *   - photon              — OSM (Komoot), free, no key. Returns extents.
+ *   - maptiler            — high quality, requires an API key.
+ *
+ * Census (US addresses) is intentionally NOT a browser provider: it sends no
+ * CORS headers, so a static app can only reach it via JSONP (a script-injection
+ * sink we will not reintroduce) or a server-side proxy. It can be added later
+ * as an `endpoint`-backed proxy provider.
+ *
+ * Every provider normalizes to the same shape so both consumers — and any
+ * future provider — are interchangeable:
+ *
+ * @typedef {Object} GeocodeResult
+ * @property {number} lat
+ * @property {number} lon
+ * @property {[number, number, number, number]|null} bbox  // [west, south, east, north]
+ * @property {string} display_name  // normalized, matched location — echo to the user
+ * @property {'high'|'medium'|'low'} match_quality
+ * @property {string} source         // provider id
+ */
+
+const NOMINATIM_BASE = 'https://nominatim.openstreetmap.org';
+const PHOTON_BASE = 'https://photon.komoot.io';
+const MAPTILER_BASE = 'https://api.maptiler.com/geocoding';
+
+/** Coerce a value to a finite number, or return null. */
+function num(v) {
+    const n = typeof v === 'number' ? v : parseFloat(v);
+    return Number.isFinite(n) ? n : null;
+}
+
+/**
+ * Map a 0..1 score (Nominatim importance, MapTiler relevance) to a coarse
+ * quality bucket. Callers also use result count for disambiguation.
+ */
+function bucket(score) {
+    if (score == null) return 'medium';
+    if (score >= 0.5) return 'high';
+    if (score >= 0.2) return 'medium';
+    return 'low';
+}
+
+/* ── Provider: Nominatim ──────────────────────────────────────────────── */
+
+function nominatimUrl(base, query, limit, email) {
+    const p = new URLSearchParams({
+        q: query,
+        format: 'jsonv2',
+        limit: String(limit),
+        addressdetails: '1',
+    });
+    if (email) p.set('email', email);   // contact per OSM usage policy
+    return `${base}/search?${p}`;
+}
+
+function nominatimReverseUrl(base, lat, lon, email) {
+    const p = new URLSearchParams({
+        lat: String(lat),
+        lon: String(lon),
+        format: 'jsonv2',
+    });
+    if (email) p.set('email', email);
+    return `${base}/reverse?${p}`;
+}
+
+/** Parse a Nominatim search array (or a single reverse object) → results. */
+function parseNominatim(json) {
+    const rows = Array.isArray(json) ? json : (json ? [json] : []);
+    return rows.map((r) => {
+        // boundingbox is [south, north, west, east] (strings) → [w, s, e, n]
+        let bbox = null;
+        const bb = r.boundingbox;
+        if (Array.isArray(bb) && bb.length === 4) {
+            const [s, n, w, e] = bb.map(num);
+            if ([s, n, w, e].every((v) => v != null)) bbox = [w, s, e, n];
+        }
+        return {
+            lat: num(r.lat),
+            lon: num(r.lon),
+            bbox,
+            display_name: r.display_name || r.name || '',
+            match_quality: bucket(num(r.importance)),
+            source: 'nominatim',
+        };
+    }).filter((r) => r.lat != null && r.lon != null);
+}
+
+/* ── Provider: Photon ─────────────────────────────────────────────────── */
+
+function photonUrl(base, query, limit) {
+    const p = new URLSearchParams({ q: query, limit: String(limit) });
+    return `${base}/api/?${p}`;
+}
+
+function photonReverseUrl(base, lat, lon) {
+    const p = new URLSearchParams({ lat: String(lat), lon: String(lon) });
+    return `${base}/reverse?${p}`;
+}
+
+/** Build the human label Photon omits (it returns address parts, not a string). */
+function photonLabel(props) {
+    const parts = [
+        props.name,
+        props.street && props.housenumber ? `${props.housenumber} ${props.street}` : props.street,
+        props.city || props.district,
+        props.state,
+        props.postcode,
+        props.country,
+    ];
+    return parts.filter(Boolean).join(', ');
+}
+
+/** Parse a Photon GeoJSON FeatureCollection → results. */
+function parsePhoton(json) {
+    const feats = json?.features || [];
+    return feats.map((f) => {
+        const [lon, lat] = f.geometry?.coordinates || [];
+        // Photon extent is [minLon, maxLat, maxLon, minLat] → [w, s, e, n]
+        let bbox = null;
+        const ext = f.properties?.extent;
+        if (Array.isArray(ext) && ext.length === 4) {
+            const [w, n, e, s] = ext.map(num);
+            if ([w, n, e, s].every((v) => v != null)) bbox = [w, s, e, n];
+        }
+        return {
+            lat: num(lat),
+            lon: num(lon),
+            bbox,
+            display_name: photonLabel(f.properties || {}),
+            // Photon has no per-result score; rank reflects ordering only.
+            match_quality: 'medium',
+            source: 'photon',
+        };
+    }).filter((r) => r.lat != null && r.lon != null);
+}
+
+/* ── Provider: MapTiler ───────────────────────────────────────────────── */
+
+function maptilerUrl(base, query, limit, key) {
+    const p = new URLSearchParams({ key, limit: String(limit) });
+    return `${base}/${encodeURIComponent(query)}.json?${p}`;
+}
+
+function maptilerReverseUrl(base, lat, lon, key) {
+    const p = new URLSearchParams({ key });
+    return `${base}/${lon},${lat}.json?${p}`;
+}
+
+/** Parse a MapTiler geocoding GeoJSON FeatureCollection → results. */
+function parseMaptiler(json) {
+    const feats = json?.features || [];
+    return feats.map((f) => {
+        const [lon, lat] = f.center || f.geometry?.coordinates || [];
+        // MapTiler features carry a standard GeoJSON bbox: [w, s, e, n]
+        let bbox = null;
+        if (Array.isArray(f.bbox) && f.bbox.length === 4) {
+            const b = f.bbox.map(num);
+            if (b.every((v) => v != null)) bbox = b;
+        }
+        return {
+            lat: num(lat),
+            lon: num(lon),
+            bbox,
+            display_name: f.place_name || f.text || '',
+            match_quality: bucket(num(f.relevance)),
+            source: 'maptiler',
+        };
+    }).filter((r) => r.lat != null && r.lon != null);
+}
+
+/* ── Factory ──────────────────────────────────────────────────────────── */
+
+/**
+ * Build a geocoder for the configured provider.
+ *
+ * @param {Object} [config]
+ * @param {'nominatim'|'photon'|'maptiler'} [config.provider='nominatim']
+ * @param {string} [config.endpoint]      // base URL override (e.g. self-hosted Nominatim)
+ * @param {string} [config.maptiler_key]  // required for the maptiler provider
+ * @param {string} [config.email]         // contact passed to Nominatim per usage policy
+ * @param {typeof fetch} [config.fetchImpl=fetch]  // injectable for tests
+ * @returns {{ provider: string, forwardGeocode: Function, reverseGeocode: Function }}
+ */
+export function createGeocoder(config = {}) {
+    const provider = config.provider || 'nominatim';
+    const fetchImpl = config.fetchImpl || ((...a) => fetch(...a));
+
+    const bases = {
+        nominatim: config.endpoint || NOMINATIM_BASE,
+        photon: config.endpoint || PHOTON_BASE,
+        maptiler: config.endpoint || MAPTILER_BASE,
+    };
+
+    if (provider === 'maptiler' && !config.maptiler_key) {
+        throw new Error('geocoder provider "maptiler" requires config.maptiler_key');
+    }
+    if (!bases[provider]) {
+        throw new Error(`Unknown geocoder provider "${provider}". Use nominatim, photon, or maptiler.`);
+    }
+
+    async function get(url, signal) {
+        const res = await fetchImpl(url, { signal, headers: { Accept: 'application/json' } });
+        if (!res.ok) throw new Error(`geocoder HTTP ${res.status}`);
+        return res.json();
+    }
+
+    /**
+     * Resolve free text → ranked candidates.
+     * @param {string} query
+     * @param {{ limit?: number, signal?: AbortSignal }} [opts]
+     * @returns {Promise<GeocodeResult[]>}
+     */
+    async function forwardGeocode(query, opts = {}) {
+        const q = (query || '').trim();
+        if (!q) return [];
+        const limit = Math.max(1, Math.min(opts.limit || 5, 10));
+        const base = bases[provider];
+        let url;
+        if (provider === 'nominatim') url = nominatimUrl(base, q, limit, config.email);
+        else if (provider === 'photon') url = photonUrl(base, q, limit);
+        else url = maptilerUrl(base, q, limit, config.maptiler_key);
+
+        const json = await get(url, opts.signal);
+        if (provider === 'nominatim') return parseNominatim(json);
+        if (provider === 'photon') return parsePhoton(json);
+        return parseMaptiler(json);
+    }
+
+    /**
+     * Resolve coordinates → the place at that point (best single match).
+     * @param {number} lat
+     * @param {number} lon
+     * @param {{ signal?: AbortSignal }} [opts]
+     * @returns {Promise<GeocodeResult|null>}
+     */
+    async function reverseGeocode(lat, lon, opts = {}) {
+        const la = num(lat), lo = num(lon);
+        if (la == null || lo == null) return null;
+        const base = bases[provider];
+        let url;
+        if (provider === 'nominatim') url = nominatimReverseUrl(base, la, lo, config.email);
+        else if (provider === 'photon') url = photonReverseUrl(base, la, lo);
+        else url = maptilerReverseUrl(base, la, lo, config.maptiler_key);
+
+        const json = await get(url, opts.signal);
+        let results;
+        if (provider === 'nominatim') results = parseNominatim(json);
+        else if (provider === 'photon') results = parsePhoton(json);
+        else results = parseMaptiler(json);
+        return results[0] || null;
+    }
+
+    return { provider, forwardGeocode, reverseGeocode };
+}
+
+// Exported for unit tests — not part of the public surface.
+export const _internal = { parseNominatim, parsePhoton, parseMaptiler, bucket };

--- a/app/main.js
+++ b/app/main.js
@@ -10,6 +10,7 @@ import { DatasetCatalog } from './dataset-catalog.js';
 import { MapManager } from './map-manager.js';
 import { ToolRegistry } from './tool-registry.js';
 import { createMapTools } from './map-tools.js';
+import { createGeocoder } from './geocoder.js';
 import { Agent } from './agent.js';
 import { ChatUI } from './chat-ui.js';
 import { buildLayout, sidebarHooks } from './layout-manager.js';
@@ -155,8 +156,38 @@ async function main() {
     /* ── 5. Build tool registry ───────────────────────────────────────── */
     const toolRegistry = new ToolRegistry();
 
+    // Geocoder backend (shared by the `geocode` tool and the optional search
+    // box). Enabled by default; set geocoder.enabled=false to disable. The
+    // MapTiler key, when present, falls back to the basemap key.
+    const geoCfg = appConfig.geocoder || {};
+    let geocoder = null;
+    if (geoCfg.enabled !== false) {
+        try {
+            geocoder = createGeocoder({
+                ...geoCfg,
+                maptiler_key: geoCfg.maptiler_key || runtimeConfig?.maptiler_key,
+            });
+        } catch (err) {
+            console.warn('[main] Geocoder disabled — invalid config:', err.message);
+        }
+    }
+
+    // Optional on-map search box, sharing the same geocoder backend.
+    if (geocoder && geoCfg.search_box) {
+        try {
+            const { addSearchBox } = await import('./map-geocoder.js');
+            await addSearchBox(mapManager.map, geocoder, {
+                position: geoCfg.search_box_position,
+                placeholder: geoCfg.search_box_placeholder,
+            });
+            console.log('[main] Search box ready');
+        } catch (err) {
+            console.warn('[main] Failed to load search box:', err.message);
+        }
+    }
+
     // Register local map tools
-    for (const tool of createMapTools(mapManager, catalog, mcp)) {
+    for (const tool of createMapTools(mapManager, catalog, mcp, geocoder)) {
         toolRegistry.registerLocal(tool);
     }
 

--- a/app/map-geocoder.js
+++ b/app/map-geocoder.js
@@ -1,0 +1,131 @@
+/**
+ * MapGeocoder — optional on-map search box.
+ *
+ * A thin adapter that drives the @maplibre/maplibre-gl-geocoder UI control with
+ * the SAME backend the `geocode` agent tool uses (geocoder.js). Lazy-loads the
+ * library from CDN only when `geocoder.search_box` is enabled — mirrors
+ * map-draw.js (opt-in, SRI-pinned). Never loaded otherwise.
+ */
+
+const GEOCODER_JS = 'https://cdn.jsdelivr.net/npm/@maplibre/maplibre-gl-geocoder@1.9.4/dist/maplibre-gl-geocoder.min.js';
+const GEOCODER_JS_SRI = 'sha384-RGV5vfoJd7alk8HE+71IyVfu19ciH1FKA15+AuXs6OeBM2npXrmTPFqG23yMiHXi';
+const GEOCODER_CSS = 'https://cdn.jsdelivr.net/npm/@maplibre/maplibre-gl-geocoder@1.9.4/dist/maplibre-gl-geocoder.css';
+const GEOCODER_CSS_SRI = 'sha384-UkDpPApjTpHJHpcJiSNAmbobh30W0/dmt0DoKm4V8CWYRYvQ/Jhd/ijFz0tFdVnH';
+
+/** Load a JS script by URL, resolves when loaded. */
+function loadScript(url, integrity) {
+    return new Promise((resolve, reject) => {
+        const s = document.createElement('script');
+        s.src = url;
+        if (integrity) {
+            s.integrity = integrity;
+            s.crossOrigin = 'anonymous';
+        }
+        s.onload = resolve;
+        s.onerror = () => reject(new Error(`Failed to load ${url}`));
+        document.head.appendChild(s);
+    });
+}
+
+/** Load a CSS stylesheet by URL. */
+function loadCSS(url, integrity) {
+    const link = document.createElement('link');
+    link.rel = 'stylesheet';
+    link.href = url;
+    if (integrity) {
+        link.integrity = integrity;
+        link.crossOrigin = 'anonymous';
+    }
+    document.head.appendChild(link);
+}
+
+/**
+ * Convert a normalized GeocodeResult (geocoder.js) into the Carmen GeoJSON
+ * feature shape maplibre-gl-geocoder expects. Pure — exported for tests.
+ *
+ * @param {import('./geocoder.js').GeocodeResult} r
+ * @returns {Object} Carmen GeoJSON Feature
+ */
+export function toCarmenFeature(r) {
+    const center = [r.lon, r.lat];
+    const feature = {
+        type: 'Feature',
+        geometry: { type: 'Point', coordinates: center },
+        properties: { match_quality: r.match_quality, source: r.source },
+        place_name: r.display_name,
+        place_type: ['place'],
+        center,
+        text: r.display_name,
+    };
+    if (r.bbox) feature.bbox = r.bbox;
+    return feature;
+}
+
+/**
+ * Build the maplibre-gl-geocoder API object backed by our geocoder. Pure
+ * (no DOM) — exported for tests. The control passes `{ query, limit }` for
+ * forward lookups and `{ query: [lon, lat] }` for reverse.
+ *
+ * @param {{ forwardGeocode: Function, reverseGeocode: Function }} geocoder
+ */
+export function buildGeocoderApi(geocoder) {
+    return {
+        forwardGeocode: async (config) => {
+            try {
+                const results = await geocoder.forwardGeocode(config.query, { limit: config.limit || 5 });
+                return { features: results.map(toCarmenFeature) };
+            } catch {
+                return { features: [] };
+            }
+        },
+        reverseGeocode: async (config) => {
+            try {
+                const [lon, lat] = config.query || [];
+                const r = await geocoder.reverseGeocode(lat, lon);
+                return { features: r ? [toCarmenFeature(r)] : [] };
+            } catch {
+                return { features: [] };
+            }
+        },
+    };
+}
+
+/**
+ * Add the search box to the map.
+ *
+ * @param {maplibregl.Map} map
+ * @param {{ forwardGeocode: Function, reverseGeocode: Function }} geocoder
+ * @param {Object} [options]
+ * @param {string} [options.position='top-left']
+ * @param {string} [options.placeholder='Search address or place…']
+ * @returns {Promise<Object>} the MaplibreGeocoder control instance
+ */
+export async function addSearchBox(map, geocoder, options = {}) {
+    loadCSS(GEOCODER_CSS, GEOCODER_CSS_SRI);
+    await loadScript(GEOCODER_JS, GEOCODER_JS_SRI);
+
+    /* global MaplibreGeocoder */
+    const ctrl = new MaplibreGeocoder(buildGeocoderApi(geocoder), {
+        maplibregl: window.maplibregl,
+        marker: !!window.maplibregl,            // markers need the maplibregl module
+        showResultsWhileTyping: true,
+        minLength: 3,
+        placeholder: options.placeholder || 'Search address or place…',
+        // Forward bbox-framing / fly handled below so it works without markers.
+        flyTo: false,
+    });
+
+    map.addControl(ctrl, options.position || 'top-left');
+
+    // Frame the result: fit its bbox when present, else fly to the point.
+    ctrl.on('result', (e) => {
+        const r = e.result || {};
+        if (Array.isArray(r.bbox) && r.bbox.length === 4) {
+            map.fitBounds([[r.bbox[0], r.bbox[1]], [r.bbox[2], r.bbox[3]]], { padding: 48, maxZoom: 16 });
+        } else if (Array.isArray(r.center)) {
+            map.flyTo({ center: r.center, zoom: 14 });
+        }
+    });
+
+    return ctrl;
+}

--- a/app/map-tools.js
+++ b/app/map-tools.js
@@ -41,9 +41,10 @@ export function extractJsonArray(text) {
  * @param {import('./map-manager.js').MapManager} mapManager
  * @param {import('./dataset-catalog.js').DatasetCatalog} catalog
  * @param {import('./mcp-client.js').MCPClient} [mcpClient]
+ * @param {{ forwardGeocode: Function }} [geocoder] - optional geocoder backend (see geocoder.js)
  * @returns {Array<Object>} Tool definitions
  */
-export function createMapTools(mapManager, catalog, mcpClient) {
+export function createMapTools(mapManager, catalog, mcpClient, geocoder) {
     const allLayers = () => mapManager.getLayerSummaries();
     const vectorLayers = () => mapManager.getLayerSummaries().filter(l => l.type === 'vector');
 
@@ -288,6 +289,49 @@ ${formatLayerList(allLayers())}`,
             },
             execute: (args) => JSON.stringify(mapManager.flyTo(args)),
         },
+
+        // ---- Geocoding ----
+        ...(geocoder ? [{
+            name: 'geocode',
+            description: `Resolve a free-text place reference — street address, city, landmark, or named region — to real coordinates. Use this WHENEVER the user names a place rather than giving coordinates: "what watershed is 3109 6th Ave, LA in?", "show me Yosemite", "fly to Chicago", "which district contains downtown Fresno".
+
+NEVER invent, recall, or estimate coordinates from your own memory — always call this tool so the coordinate is traceable to a geocoder.
+
+Returns up to \`limit\` ranked candidates. Each candidate has:
+  - lat, lon          — pass to fly_to as center [lon, lat] (lon first!), or into point-in-hex SQL lookups
+  - bbox [w,s,e,n]    — for framing/fit-bounds; null for precise point addresses
+  - display_name      — the normalized, matched location
+  - match_quality     — "high" | "medium" | "low"
+
+How to use the result:
+  - Echo the resolved \`display_name\` back to the user so they can confirm the location is the one they meant.
+  - If more than one candidate is returned, or the top match_quality is "low" (e.g. "Springfield"), ASK the user which one they mean — do NOT silently pick the first.
+  - Then act: fly_to the coordinate, or use it in a containing-polygon / nearest-feature query.`,
+            inputSchema: {
+                type: 'object',
+                properties: {
+                    query: { type: 'string', description: 'Free-text place reference: address, city, landmark, or region name.' },
+                    limit: { type: 'number', description: 'Max candidates to return (1–10, default 5). Use a small limit unless disambiguating.' },
+                },
+                required: ['query'],
+            },
+            execute: async (args) => {
+                try {
+                    const results = await geocoder.forwardGeocode(args.query, { limit: args.limit ?? 5 });
+                    if (!results.length) {
+                        return JSON.stringify({
+                            success: true,
+                            count: 0,
+                            results: [],
+                            message: `No location found for "${args.query}". Ask the user to add detail (city, state, or a more specific address).`,
+                        });
+                    }
+                    return JSON.stringify({ success: true, count: results.length, source: results[0].source, results });
+                } catch (err) {
+                    return JSON.stringify({ success: false, error: `Geocoding failed: ${err.message}` });
+                }
+            },
+        }] : []),
 
         // ---- Dynamic Hex Tile Layers ----
         {

--- a/app/style.css
+++ b/app/style.css
@@ -648,3 +648,39 @@ details.layer-group:not([open]) .layer-group-title::before {
     background: rgba(255, 255, 255, 0.15);
     color: #fff;
 }
+
+/* ── Navigation control (zoom +/- and compass) ───────────────────────────
+   Same glass treatment as the search box so the on-map controls match.
+   The zoom/compass glyphs are dark SVGs baked into background-images (not
+   recolorable via fill), so invert them to read on the glass and add a
+   drop-shadow for legibility over light basemaps. */
+.maplibregl-ctrl-group,
+.mapboxgl-ctrl-group {
+    background: rgba(255, 255, 255, 0.08) !important;
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    border: 1px solid rgba(255, 255, 255, 0.25);
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
+    border-radius: 10px;
+    overflow: hidden;
+}
+
+.maplibregl-ctrl-group button,
+.mapboxgl-ctrl-group button {
+    background: transparent !important;
+}
+
+.maplibregl-ctrl-group button + button,
+.mapboxgl-ctrl-group button + button {
+    border-top: 1px solid rgba(255, 255, 255, 0.18);
+}
+
+.maplibregl-ctrl-group button:hover,
+.mapboxgl-ctrl-group button:hover {
+    background: rgba(255, 255, 255, 0.15) !important;
+}
+
+.maplibregl-ctrl-group button .maplibregl-ctrl-icon,
+.mapboxgl-ctrl-group button .mapboxgl-ctrl-icon {
+    filter: invert(1) drop-shadow(0 1px 1px rgba(0, 0, 0, 0.4));
+}

--- a/app/style.css
+++ b/app/style.css
@@ -591,3 +591,60 @@ details.layer-group:not([open]) .layer-group-title::before {
     background: #fff;
     font-size: 12px;
 }
+
+/* ── Geocoder search box (maplibre-gl-geocoder) ──────────────────────────
+   Translucent glass to match the app's chat panel / map controls instead of
+   the library's solid white. The geocoder's CDN stylesheet is appended to
+   <head> at runtime (after this file), so !important pins the surface colors
+   against the later, equal-specificity library rules. Covers both the
+   maplibregl- and mapboxgl- class prefixes the control emits. */
+.maplibregl-ctrl-geocoder,
+.mapboxgl-ctrl-geocoder {
+    background: rgba(255, 255, 255, 0.08) !important;
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    border: 1px solid rgba(255, 255, 255, 0.25);
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
+    border-radius: 10px;
+}
+
+.maplibregl-ctrl-geocoder input,
+.mapboxgl-ctrl-geocoder input {
+    color: #f5f5f5;
+    text-shadow: 0 1px 2px rgba(0, 0, 0, 0.4);
+}
+
+.maplibregl-ctrl-geocoder input::placeholder,
+.mapboxgl-ctrl-geocoder input::placeholder {
+    color: rgba(255, 255, 255, 0.7);
+}
+
+/* Search / loading / close icons */
+.maplibregl-ctrl-geocoder--icon,
+.mapboxgl-ctrl-geocoder--icon {
+    fill: rgba(255, 255, 255, 0.85);
+}
+
+/* Suggestions dropdown — darker glass so the list stays legible over any basemap */
+.maplibregl-ctrl-geocoder .suggestions,
+.mapboxgl-ctrl-geocoder .suggestions {
+    background: rgba(28, 28, 30, 0.6) !important;
+    backdrop-filter: blur(14px);
+    -webkit-backdrop-filter: blur(14px);
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    border-radius: 10px;
+    overflow: hidden;
+}
+
+.maplibregl-ctrl-geocoder .suggestions > li > a,
+.mapboxgl-ctrl-geocoder .suggestions > li > a {
+    color: #f0f0f0;
+}
+
+.maplibregl-ctrl-geocoder .suggestions > .active > a,
+.maplibregl-ctrl-geocoder .suggestions > li > a:hover,
+.mapboxgl-ctrl-geocoder .suggestions > .active > a,
+.mapboxgl-ctrl-geocoder .suggestions > li > a:hover {
+    background: rgba(255, 255, 255, 0.15);
+    color: #fff;
+}

--- a/app/style.css
+++ b/app/style.css
@@ -593,74 +593,74 @@ details.layer-group:not([open]) .layer-group-title::before {
 }
 
 /* ── Geocoder search box (maplibre-gl-geocoder) ──────────────────────────
-   Translucent glass to match the app's chat panel / map controls instead of
-   the library's solid white. The geocoder's CDN stylesheet is appended to
+   Frosted-glass surface to match the app's other map controls (#menu,
+   .version-select) instead of the library's solid white — light tint +
+   backdrop blur with DARK text, the way the rest of the map chrome reads
+   over the (light) basemaps. The geocoder's CDN stylesheet is appended to
    <head> at runtime (after this file), so !important pins the surface colors
    against the later, equal-specificity library rules. Covers both the
    maplibregl- and mapboxgl- class prefixes the control emits. */
 .maplibregl-ctrl-geocoder,
 .mapboxgl-ctrl-geocoder {
-    background: rgba(255, 255, 255, 0.08) !important;
+    background: rgba(255, 255, 255, 0.15) !important;
     backdrop-filter: blur(12px);
     -webkit-backdrop-filter: blur(12px);
-    border: 1px solid rgba(255, 255, 255, 0.25);
-    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
+    border: 1px solid rgba(0, 0, 0, 0.18);
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
     border-radius: 10px;
 }
 
 .maplibregl-ctrl-geocoder input,
 .mapboxgl-ctrl-geocoder input {
-    color: #f5f5f5;
-    text-shadow: 0 1px 2px rgba(0, 0, 0, 0.4);
+    color: #2b2b2b;
 }
 
 .maplibregl-ctrl-geocoder input::placeholder,
 .mapboxgl-ctrl-geocoder input::placeholder {
-    color: rgba(255, 255, 255, 0.7);
+    color: rgba(0, 0, 0, 0.5);
 }
 
 /* Search / loading / close icons */
 .maplibregl-ctrl-geocoder--icon,
 .mapboxgl-ctrl-geocoder--icon {
-    fill: rgba(255, 255, 255, 0.85);
+    fill: rgba(0, 0, 0, 0.55);
 }
 
-/* Suggestions dropdown — darker glass so the list stays legible over any basemap */
+/* Suggestions dropdown — lighter, more opaque frosted glass for list legibility */
 .maplibregl-ctrl-geocoder .suggestions,
 .mapboxgl-ctrl-geocoder .suggestions {
-    background: rgba(28, 28, 30, 0.6) !important;
+    background: rgba(255, 255, 255, 0.85) !important;
     backdrop-filter: blur(14px);
     -webkit-backdrop-filter: blur(14px);
-    border: 1px solid rgba(255, 255, 255, 0.2);
+    border: 1px solid rgba(0, 0, 0, 0.15);
     border-radius: 10px;
     overflow: hidden;
 }
 
 .maplibregl-ctrl-geocoder .suggestions > li > a,
 .mapboxgl-ctrl-geocoder .suggestions > li > a {
-    color: #f0f0f0;
+    color: #333;
 }
 
 .maplibregl-ctrl-geocoder .suggestions > .active > a,
 .maplibregl-ctrl-geocoder .suggestions > li > a:hover,
 .mapboxgl-ctrl-geocoder .suggestions > .active > a,
 .mapboxgl-ctrl-geocoder .suggestions > li > a:hover {
-    background: rgba(255, 255, 255, 0.15);
-    color: #fff;
+    background: rgba(0, 0, 0, 0.07);
+    color: #000;
 }
 
 /* ── Navigation control (zoom +/- and compass) ───────────────────────────
-   Same glass treatment as the search box so the on-map controls match.
-   The zoom/compass glyphs are dark SVGs baked into background-images (not
-   recolorable via fill), so invert them to read on the glass and add a
-   drop-shadow for legibility over light basemaps. */
+   Same frosted-glass surface as the search box so the on-map controls match.
+   The zoom/compass glyphs keep their natural dark fill — they read well on
+   the light glass and stay crisp (no invert / shadow blurring). */
 .maplibregl-ctrl-group,
 .mapboxgl-ctrl-group {
-    background: rgba(255, 255, 255, 0.08) !important;
+    background: rgba(255, 255, 255, 0.15) !important;
     backdrop-filter: blur(12px);
     -webkit-backdrop-filter: blur(12px);
-    border: 1px solid rgba(255, 255, 255, 0.25);
-    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
+    border: 1px solid rgba(0, 0, 0, 0.18);
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
     border-radius: 10px;
     overflow: hidden;
 }
@@ -672,15 +672,10 @@ details.layer-group:not([open]) .layer-group-title::before {
 
 .maplibregl-ctrl-group button + button,
 .mapboxgl-ctrl-group button + button {
-    border-top: 1px solid rgba(255, 255, 255, 0.18);
+    border-top: 1px solid rgba(0, 0, 0, 0.12);
 }
 
 .maplibregl-ctrl-group button:hover,
 .mapboxgl-ctrl-group button:hover {
-    background: rgba(255, 255, 255, 0.15) !important;
-}
-
-.maplibregl-ctrl-group button .maplibregl-ctrl-icon,
-.mapboxgl-ctrl-group button .mapboxgl-ctrl-icon {
-    filter: invert(1) drop-shadow(0 1px 1px rgba(0, 0, 0, 0.4));
+    background: rgba(0, 0, 0, 0.06) !important;
 }

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -440,7 +440,7 @@ Geocoding is **on by default** using Nominatim (OpenStreetMap) — no API key re
 | `geocoder.provider` | string | `"nominatim"` | Backend: `"nominatim"`, `"photon"`, or `"maptiler"`. All are global. |
 | `geocoder.maptiler_key` | string | — | Required for the `maptiler` provider. Falls back to the basemap `maptiler_key` if not set here. |
 | `geocoder.email` | string | — | Contact email sent to Nominatim per its [usage policy](https://operations.osmfoundation.org/policies/nominatim/). Recommended for production apps. |
-| `geocoder.endpoint` | string | — | Base-URL override (e.g. a self-hosted Nominatim instance, or a proxy in front of a CORS-restricted backend). |
+| `geocoder.endpoint` | string | — | Base-URL override (e.g. a self-hosted Nominatim instance). |
 | `geocoder.search_box` | boolean | `false` | Show the on-map search box. Lazy-loads the geocoder library from CDN only when enabled. |
 | `geocoder.search_box_position` | string | `"top-left"` | MapLibre control position for the search box. |
 | `geocoder.search_box_placeholder` | string | `"Search address or place…"` | Placeholder text in the search box. |
@@ -455,7 +455,7 @@ Geocoding is **on by default** using Nominatim (OpenStreetMap) — no API key re
 }
 ```
 
-**Provider notes.** `nominatim` and `photon` are both free OpenStreetMap-based services with no key — Nominatim returns richer confidence signals, Photon is more lenient on request volume. `maptiler` is higher quality but needs an API key. The US Census geocoder is *not* offered as a browser provider: it sends no CORS headers, so a static app can only reach it via a server-side proxy (point `geocoder.endpoint` at one if you need authoritative US-address matching).
+**Provider notes.** `nominatim` and `photon` are both free OpenStreetMap-based services with no key — Nominatim returns richer confidence signals, Photon is more lenient on request volume. `maptiler` is higher quality but needs an API key. All three are global (not US-only) and work directly from a static browser app.
 
 ## Tool call auto-approve
 

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -425,6 +425,38 @@ When enabled, a pentagon icon button appears in the top-left map controls (below
 
 The agent receives a `get_drawn_region` tool that returns the polygon as WKT along with a suggested H3 resolution scaled to the region size. This prevents expensive high-resolution hexing of large areas.
 
+## Geocoding (optional)
+
+Geocoding turns a free-text place reference — a street address, city, landmark, or named region — into real coordinates. It powers two things from one shared backend:
+
+1. A **`geocode` agent tool**, so the LLM resolves a *traceable* coordinate instead of inventing lat/lng from memory. The model is instructed to echo the matched location back and to ask for clarification on ambiguous queries (e.g. "Springfield").
+2. An optional **on-map search box** (the [maplibre-gl-geocoder](https://maplibre.org/maplibre-gl-geocoder/) control), enabled per-app.
+
+Geocoding is **on by default** using Nominatim (OpenStreetMap) — no API key required. Set `geocoder.enabled: false` to turn it off entirely (the `geocode` tool is then not registered).
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `geocoder.enabled` | boolean | `true` | Register the `geocode` tool and (if configured) the search box. Set `false` to disable. |
+| `geocoder.provider` | string | `"nominatim"` | Backend: `"nominatim"`, `"photon"`, or `"maptiler"`. All are global. |
+| `geocoder.maptiler_key` | string | — | Required for the `maptiler` provider. Falls back to the basemap `maptiler_key` if not set here. |
+| `geocoder.email` | string | — | Contact email sent to Nominatim per its [usage policy](https://operations.osmfoundation.org/policies/nominatim/). Recommended for production apps. |
+| `geocoder.endpoint` | string | — | Base-URL override (e.g. a self-hosted Nominatim instance, or a proxy in front of a CORS-restricted backend). |
+| `geocoder.search_box` | boolean | `false` | Show the on-map search box. Lazy-loads the geocoder library from CDN only when enabled. |
+| `geocoder.search_box_position` | string | `"top-left"` | MapLibre control position for the search box. |
+| `geocoder.search_box_placeholder` | string | `"Search address or place…"` | Placeholder text in the search box. |
+
+```json
+{
+  "geocoder": {
+    "provider": "nominatim",
+    "email": "ops@example.org",
+    "search_box": true
+  }
+}
+```
+
+**Provider notes.** `nominatim` and `photon` are both free OpenStreetMap-based services with no key — Nominatim returns richer confidence signals, Photon is more lenient on request volume. `maptiler` is higher quality but needs an API key. The US Census geocoder is *not* offered as a browser provider: it sends no CORS headers, so a static app can only reach it via a server-side proxy (point `geocoder.endpoint` at one if you need authoritative US-address matching).
+
 ## Tool call auto-approve
 
 By default, the agent executes remote tool calls (SQL queries via the MCP server) immediately. Local tools — map controls like `show_layer`, `fly_to`, `set_filter` — also run without confirmation.

--- a/test/geocoder.test.js
+++ b/test/geocoder.test.js
@@ -1,0 +1,185 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createGeocoder, _internal } from '../app/geocoder.js';
+
+const okJson = (body) => ({ ok: true, json: async () => body });
+const errJson = (status) => ({ ok: false, status, json: async () => ({}) });
+
+// Real response fixtures (trimmed) captured from the live APIs.
+const NOMINATIM_YOSEMITE = [{
+    lat: '37.8393004',
+    lon: '-119.5164635',
+    importance: 0.5857662850918021,
+    boundingbox: ['37.4921493', '38.1863499', '-119.8861599', '-119.1995075'],
+    display_name: 'Yosemite National Park, California, United States',
+}];
+
+const NOMINATIM_ADDRESS = [{
+    lat: '34.0266169',
+    lon: '-118.3241943',
+    importance: 8.738155184248139e-05,
+    display_name: 'Sixth Avenue Elementary School, 3109, 6th Avenue, Los Angeles, California, 90018, United States',
+}];
+
+const PHOTON_YOSEMITE = {
+    features: [{
+        geometry: { coordinates: [-119.5164635, 37.8393004] },
+        properties: {
+            name: 'Yosemite National Park',
+            state: 'California',
+            country: 'United States',
+            extent: [-119.8861599, 38.1863499, -119.1995075, 37.4921493],
+        },
+    }],
+};
+
+const MAPTILER_YOSEMITE = {
+    features: [{
+        place_name: 'Yosemite National Park, California, United States',
+        center: [-119.5164635, 37.8393004],
+        bbox: [-119.8861599, 37.4921493, -119.1995075, 38.1863499],
+        relevance: 0.9,
+    }],
+};
+
+describe('createGeocoder factory', () => {
+    it('defaults to the nominatim provider', () => {
+        expect(createGeocoder().provider).toBe('nominatim');
+    });
+
+    it('throws when maptiler is selected without a key', () => {
+        expect(() => createGeocoder({ provider: 'maptiler' })).toThrow(/maptiler_key/);
+    });
+
+    it('throws on an unknown provider', () => {
+        expect(() => createGeocoder({ provider: 'bogus' })).toThrow(/Unknown geocoder provider/);
+    });
+});
+
+describe('forwardGeocode — nominatim (default)', () => {
+    it('normalizes lat/lon/bbox/display_name and reorders bbox to [w,s,e,n]', async () => {
+        const fetchImpl = vi.fn(async () => okJson(NOMINATIM_YOSEMITE));
+        const g = createGeocoder({ fetchImpl });
+        const [r] = await g.forwardGeocode('Yosemite National Park');
+
+        expect(r.lat).toBeCloseTo(37.8393, 3);
+        expect(r.lon).toBeCloseTo(-119.5165, 3);
+        // boundingbox [s, n, w, e] → bbox [w, s, e, n]
+        expect(r.bbox).toEqual([-119.8861599, 37.4921493, -119.1995075, 38.1863499]);
+        expect(r.display_name).toMatch(/Yosemite National Park/);
+        expect(r.match_quality).toBe('high');   // importance 0.58
+        expect(r.source).toBe('nominatim');
+    });
+
+    it('marks a low-importance address match as low quality and tolerates a missing bbox', async () => {
+        const g = createGeocoder({ fetchImpl: async () => okJson(NOMINATIM_ADDRESS) });
+        const [r] = await g.forwardGeocode('3109 6th Ave, Los Angeles 90018');
+        expect(r.lat).toBeCloseTo(34.0266, 3);
+        expect(r.bbox).toBeNull();
+        expect(r.match_quality).toBe('low');
+    });
+
+    it('builds the search URL with query, limit, and the contact email', async () => {
+        const fetchImpl = vi.fn(async () => okJson([]));
+        const g = createGeocoder({ fetchImpl, email: 'ops@example.org' });
+        await g.forwardGeocode('Chicago', { limit: 3 });
+        const url = fetchImpl.mock.calls[0][0];
+        expect(url).toContain('nominatim.openstreetmap.org/search');
+        expect(url).toContain('q=Chicago');
+        expect(url).toContain('limit=3');
+        expect(url).toContain('email=ops%40example.org');
+    });
+
+    it('clamps limit to [1,10]', async () => {
+        const fetchImpl = vi.fn(async () => okJson([]));
+        const g = createGeocoder({ fetchImpl });
+        await g.forwardGeocode('x', { limit: 99 });
+        expect(fetchImpl.mock.calls[0][0]).toContain('limit=10');
+    });
+
+    it('returns [] for blank input without calling fetch', async () => {
+        const fetchImpl = vi.fn(async () => okJson([]));
+        const g = createGeocoder({ fetchImpl });
+        expect(await g.forwardGeocode('   ')).toEqual([]);
+        expect(fetchImpl).not.toHaveBeenCalled();
+    });
+
+    it('throws including the HTTP status on a non-OK response', async () => {
+        const g = createGeocoder({ fetchImpl: async () => errJson(429) });
+        await expect(g.forwardGeocode('x')).rejects.toThrow(/429/);
+    });
+
+    it('forwards an AbortSignal to fetch', async () => {
+        const fetchImpl = vi.fn(async () => okJson([]));
+        const g = createGeocoder({ fetchImpl });
+        const ctrl = new AbortController();
+        await g.forwardGeocode('x', { signal: ctrl.signal });
+        expect(fetchImpl.mock.calls[0][1].signal).toBe(ctrl.signal);
+    });
+
+    it('honors an endpoint override (e.g. self-hosted Nominatim)', async () => {
+        const fetchImpl = vi.fn(async () => okJson([]));
+        const g = createGeocoder({ fetchImpl, endpoint: 'https://geo.internal' });
+        await g.forwardGeocode('x');
+        expect(fetchImpl.mock.calls[0][0]).toContain('https://geo.internal/search');
+    });
+});
+
+describe('forwardGeocode — photon', () => {
+    it('normalizes coordinates, builds a label, and reorders the extent to [w,s,e,n]', async () => {
+        const g = createGeocoder({ provider: 'photon', fetchImpl: async () => okJson(PHOTON_YOSEMITE) });
+        const [r] = await g.forwardGeocode('Yosemite');
+        expect(r.lat).toBeCloseTo(37.8393, 3);
+        expect(r.lon).toBeCloseTo(-119.5165, 3);
+        // extent [w, n, e, s] → bbox [w, s, e, n]
+        expect(r.bbox).toEqual([-119.8861599, 37.4921493, -119.1995075, 38.1863499]);
+        expect(r.display_name).toBe('Yosemite National Park, California, United States');
+        expect(r.source).toBe('photon');
+    });
+
+    it('targets the photon endpoint', async () => {
+        const fetchImpl = vi.fn(async () => okJson({ features: [] }));
+        const g = createGeocoder({ provider: 'photon', fetchImpl });
+        await g.forwardGeocode('x');
+        expect(fetchImpl.mock.calls[0][0]).toContain('photon.komoot.io/api/');
+    });
+});
+
+describe('forwardGeocode — maptiler', () => {
+    it('normalizes center/bbox/place_name and maps relevance to quality', async () => {
+        const fetchImpl = vi.fn(async () => okJson(MAPTILER_YOSEMITE));
+        const g = createGeocoder({ provider: 'maptiler', maptiler_key: 'KEY', fetchImpl });
+        const [r] = await g.forwardGeocode('Yosemite');
+        expect(r.lat).toBeCloseTo(37.8393, 3);
+        expect(r.bbox).toEqual([-119.8861599, 37.4921493, -119.1995075, 38.1863499]);
+        expect(r.match_quality).toBe('high');
+        expect(r.source).toBe('maptiler');
+        const url = fetchImpl.mock.calls[0][0];
+        expect(url).toContain('api.maptiler.com/geocoding/Yosemite.json');
+        expect(url).toContain('key=KEY');
+    });
+});
+
+describe('reverseGeocode', () => {
+    it('returns the best single match for coordinates (nominatim)', async () => {
+        const g = createGeocoder({ fetchImpl: async () => okJson(NOMINATIM_YOSEMITE[0]) });
+        const r = await g.reverseGeocode(37.8393, -119.5165);
+        expect(r.display_name).toMatch(/Yosemite/);
+        expect(r.source).toBe('nominatim');
+    });
+
+    it('returns null for invalid coordinates without calling fetch', async () => {
+        const fetchImpl = vi.fn();
+        const g = createGeocoder({ fetchImpl });
+        expect(await g.reverseGeocode('nope', null)).toBeNull();
+        expect(fetchImpl).not.toHaveBeenCalled();
+    });
+});
+
+describe('_internal.bucket', () => {
+    it('maps scores to quality buckets and defaults null to medium', () => {
+        expect(_internal.bucket(0.9)).toBe('high');
+        expect(_internal.bucket(0.3)).toBe('medium');
+        expect(_internal.bucket(0.01)).toBe('low');
+        expect(_internal.bucket(null)).toBe('medium');
+    });
+});

--- a/test/map-geocoder.test.js
+++ b/test/map-geocoder.test.js
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi } from 'vitest';
+import { toCarmenFeature, buildGeocoderApi } from '../app/map-geocoder.js';
+
+// Only the pure adapter helpers are tested here. addSearchBox() loads the
+// maplibre-gl-geocoder library and touches the DOM/map — verified manually in
+// a deployed app (consistent with the project's browser-bound coverage policy).
+
+const RESULT = {
+    lat: 37.8393, lon: -119.5165,
+    bbox: [-119.886, 37.492, -119.199, 38.186],
+    display_name: 'Yosemite National Park, California, United States',
+    match_quality: 'high', source: 'nominatim',
+};
+
+describe('toCarmenFeature', () => {
+    it('maps a GeocodeResult to a Carmen GeoJSON Point feature', () => {
+        const f = toCarmenFeature(RESULT);
+        expect(f.type).toBe('Feature');
+        expect(f.geometry).toEqual({ type: 'Point', coordinates: [-119.5165, 37.8393] });
+        expect(f.center).toEqual([-119.5165, 37.8393]);
+        expect(f.place_name).toBe(RESULT.display_name);
+        expect(f.text).toBe(RESULT.display_name);
+        expect(f.bbox).toEqual(RESULT.bbox);
+        expect(f.properties).toMatchObject({ match_quality: 'high', source: 'nominatim' });
+    });
+
+    it('omits bbox when the result has none', () => {
+        const f = toCarmenFeature({ ...RESULT, bbox: null });
+        expect('bbox' in f).toBe(false);
+    });
+});
+
+describe('buildGeocoderApi', () => {
+    it('forwardGeocode passes query+limit through and wraps results as features', async () => {
+        const forwardGeocode = vi.fn(async () => [RESULT]);
+        const api = buildGeocoderApi({ forwardGeocode });
+        const out = await api.forwardGeocode({ query: 'Yosemite', limit: 4 });
+        expect(forwardGeocode).toHaveBeenCalledWith('Yosemite', { limit: 4 });
+        expect(out.features).toHaveLength(1);
+        expect(out.features[0].place_name).toBe(RESULT.display_name);
+    });
+
+    it('forwardGeocode returns no features when the backend throws', async () => {
+        const api = buildGeocoderApi({ forwardGeocode: async () => { throw new Error('boom'); } });
+        expect(await api.forwardGeocode({ query: 'x' })).toEqual({ features: [] });
+    });
+
+    it('reverseGeocode unpacks [lon,lat] and returns the single match', async () => {
+        const reverseGeocode = vi.fn(async () => RESULT);
+        const api = buildGeocoderApi({ reverseGeocode });
+        const out = await api.reverseGeocode({ query: [-119.5165, 37.8393] });
+        expect(reverseGeocode).toHaveBeenCalledWith(37.8393, -119.5165);
+        expect(out.features).toHaveLength(1);
+    });
+
+    it('reverseGeocode returns no features when there is no match', async () => {
+        const api = buildGeocoderApi({ reverseGeocode: async () => null });
+        expect(await api.reverseGeocode({ query: [0, 0] })).toEqual({ features: [] });
+    });
+});

--- a/test/map-tools.test.js
+++ b/test/map-tools.test.js
@@ -289,6 +289,46 @@ describe('set_tooltip / reset_tooltip', () => {
     });
 });
 
+describe('geocode tool', () => {
+    const stubMap = { getLayerSummaries: () => [] };
+    const stubCatalog = { records: new Map() };
+    const getTool = (geocoder) =>
+        createMapTools(stubMap, stubCatalog, null, geocoder).find(t => t.name === 'geocode');
+
+    it('is only registered when a geocoder is provided', () => {
+        expect(getTool(undefined)).toBeUndefined();
+        expect(getTool({ forwardGeocode: vi.fn() })).toBeDefined();
+    });
+
+    it('returns ranked candidates and the source on success', async () => {
+        const results = [{ lat: 37.8, lon: -119.5, bbox: null, display_name: 'Yosemite', match_quality: 'high', source: 'nominatim' }];
+        const forwardGeocode = vi.fn(async () => results);
+        const out = JSON.parse(await getTool({ forwardGeocode }).execute({ query: 'Yosemite' }));
+        expect(out).toMatchObject({ success: true, count: 1, source: 'nominatim', results });
+        // default limit applied
+        expect(forwardGeocode).toHaveBeenCalledWith('Yosemite', { limit: 5 });
+    });
+
+    it('passes a custom limit through', async () => {
+        const forwardGeocode = vi.fn(async () => []);
+        await getTool({ forwardGeocode }).execute({ query: 'x', limit: 3 });
+        expect(forwardGeocode).toHaveBeenCalledWith('x', { limit: 3 });
+    });
+
+    it('returns a no-match message (success:true, count:0) when nothing is found', async () => {
+        const out = JSON.parse(await getTool({ forwardGeocode: async () => [] }).execute({ query: 'asdfqwer' }));
+        expect(out).toMatchObject({ success: true, count: 0, results: [] });
+        expect(out.message).toMatch(/No location found/);
+    });
+
+    it('surfaces backend failures as success:false with the error message', async () => {
+        const forwardGeocode = async () => { throw new Error('HTTP 429'); };
+        const out = JSON.parse(await getTool({ forwardGeocode }).execute({ query: 'x' }));
+        expect(out).toMatchObject({ success: false });
+        expect(out.error).toMatch(/429/);
+    });
+});
+
 describe('createMapTools smoke test', () => {
     const stubMapManager = {
         getLayerSummaries: () => [],


### PR DESCRIPTION
Closes #238.

## Problem
The framework had no way to turn a place reference (address, city, landmark) into coordinates. In a TPL demo (boettiger-lab/tpl-ca#26) a user asked *"What watershed is 3109 6th Ave, Los Angeles 90018 in?"* and the model **hardcoded an approximate lat/lng from its own memory** — unreliable and unverifiable, with no signal to the user that the location was fabricated.

## Solution
A pluggable geocoder shared by two consumers:

1. **`geocode` agent tool** — resolves a *traceable* coordinate and is prompted to echo the normalized match back and to ask for clarification on ambiguous queries.
2. **Optional on-map search box** (`maplibre-gl-geocoder`) — enabled per-app via `geocoder.search_box`, driven by the same backend.

### Backend choice
Verified the candidate backends against the live APIs before building. All three are global (not US-only) and work directly from a static browser app:

| Backend | Default | Key | Notes |
|---|---|---|---|
| **Nominatim** | ✅ | no | OSM. Resolves the issue's exact address to within ~100 m; rich confidence signals. |
| Photon | | no | OSM (Komoot); lenient on volume; returns extents. |
| MapTiler | | yes | High quality; key falls back to the basemap key. |

A custom `geocoder.endpoint` points a provider at a self-hosted instance (e.g. a private Nominatim) without changing parsing.

## Changes
- `app/geocoder.js` (new) — pluggable backend, normalized result shape `{ lat, lon, bbox:[w,s,e,n], display_name, match_quality, source }`, forward + reverse, injectable fetch.
- `app/map-tools.js` — `geocode` tool (gated on a configured geocoder) + threaded through `createMapTools`.
- `app/map-geocoder.js` (new) — opt-in search box, CDN-pinned + SRI (mirrors `map-draw.js`).
- `app/main.js` — construct geocoder from config; lazy-load the search box behind the flag.
- `docs/guide/configuration.md` — geocoder config reference.

## Tests
28 new tests (provider normalization, bbox reordering, match-quality buckets, error/abort paths, tool execute paths, Carmen adapter). **Full suite: 267 passing.** The search box's DOM/library-loading path is browser-bound — verify manually in a deployed app (per the project's coverage policy); its pure adapters are unit-tested.

## Manual verification still needed
- Search box renders and frames results in a deployed app (`geocoder.search_box: true`).
- End-to-end: agent calls `geocode` on an address question, echoes the match, and feeds it into `fly_to` / a containing-polygon query.

🤖 Generated with [Claude Code](https://claude.com/claude-code)