### PR TITLE
fix(set_filter): declare items schema + cap local-only loops (#243)

### DIFF
--- a/app/agent.js
+++ b/app/agent.js
@@ -149,11 +149,23 @@ export class Agent {
         }
 
         let iterations = 0;
+        // Consecutive local-only tool rounds. Local map tools never increment
+        // `iterations` (they're cheap and never gated), so a model stuck
+        // re-issuing a local tool — e.g. set_filter failing — would loop forever
+        // with no checkpoint to stop it (#243). This counter bounds that.
+        let localOnlyStreak = 0;
 
         try {
         while (true) {
             const threshold = this.activeThreshold();
             if (threshold && iterations >= threshold) {
+                return await this._checkpoint(endpoint, modelConfig, turnMessages, sqlQueries, iterations);
+            }
+            // Runaway guard: a turn that does `threshold` local-only rounds in a row
+            // (with no remote round and no final answer) is stuck looping, not making
+            // progress. Checkpoint it like any other cap. A remote round resets the
+            // streak, so legitimately tool-heavy turns are unaffected.
+            if (threshold && localOnlyStreak >= threshold) {
                 return await this._checkpoint(endpoint, modelConfig, turnMessages, sqlQueries, iterations);
             }
             this.onThinkingStart();
@@ -185,8 +197,15 @@ export class Agent {
                 const allLocal = calls.every(tc => this.toolRegistry.isLocal(tc.function.name));
 
                 // Only remote (MCP/SQL) rounds count toward the checkpoint
-                // threshold — local map tools are cheap and never gated.
-                if (!allLocal) iterations++;
+                // threshold — local map tools are cheap and never gated. But a
+                // remote round breaks a local-only streak, while a local-only
+                // round extends it (the runaway guard above).
+                if (!allLocal) {
+                    iterations++;
+                    localOnlyStreak = 0;
+                } else {
+                    localOnlyStreak++;
+                }
 
                 // Strip embedded <tool_call> tags from content before displaying to user
                 const displayContent = message.content

--- a/app/map-manager.js
+++ b/app/map-manager.js
@@ -635,6 +635,17 @@ export class MapManager {
      * @returns {Object} Result with feature count
      */
     setFilter(layerId, filter) {
+        // An empty array is never a meaningful predicate. MapLibre applies it as a
+        // silent no-op (clearing any filter), so a model that emits `[]` — e.g. when
+        // grammar-constrained decoding collapses the filter argument — sees
+        // success + no visible change and retries forever (#243). Reject it
+        // explicitly; clear_filter / reset_filter are the ways to show all features.
+        if (Array.isArray(filter) && filter.length === 0) {
+            return {
+                success: false,
+                error: 'filter was empty ([]) — no predicate applied. Provide a MapLibre expression like ["==", ["get", "NO_TAKE"], "All"], or call clear_filter to show all features.',
+            };
+        }
         const state = this.layers.get(layerId);
         if (!state) return { success: false, error: `Unknown layer: ${layerId}` };
         if (state.type === 'animation') {

--- a/app/map-tools.js
+++ b/app/map-tools.js
@@ -124,6 +124,11 @@ ${formatLayerList(vectorLayers())}`,
                     layer_id: { type: 'string', description: 'Vector layer ID to filter' },
                     filter: {
                         type: 'array',
+                        // `items: {}` (any JSON value, including nested arrays) is
+                        // REQUIRED: under grammar-constrained tool decoding, an array
+                        // schema with no `items` compiles to a grammar that can only
+                        // emit `[]`, silently collapsing every filter to empty (#243).
+                        items: {},
                         description: 'MapLibre filter expression array'
                     }
                 },

--- a/test/agent-checkpoint.test.js
+++ b/test/agent-checkpoint.test.js
@@ -67,13 +67,60 @@ describe('Agent remote-round counting', () => {
             .mockResolvedValueOnce(okToolCall('local_tool'))
             .mockResolvedValueOnce(okText('all done'));
         const agent = new Agent(
-            baseConfig({ max_tool_calls: 1 }),    // tiny threshold
+            baseConfig({ max_tool_calls: 3 }),     // threshold above the single round
             stubRegistry({ isLocal: () => true }), // every call is local
         );
         agent.autoApprove = true;
         const { response } = await agent.processMessage('hi');
         expect(response).toBe('all done');
         expect(agent.suspendedTurn).toBe(null);
+    });
+
+    // Regression guard for #243: local tool rounds don't increment the remote
+    // checkpoint counter, so a model stuck re-issuing a local tool (e.g.
+    // set_filter failing) would loop FOREVER — no cap ever fired. The
+    // consecutive-local-streak guard must bound it.
+    it('bounds a runaway local-only tool loop instead of looping forever (#243)', async () => {
+        // The model NEVER returns a final answer — it re-issues a local tool
+        // every round. Without the streak guard this never terminates.
+        global.fetch = vi.fn().mockResolvedValue(okToolCall('set_filter'));
+        const agent = new Agent(
+            baseConfig({ max_tool_calls: 3 }),
+            stubRegistry({ isLocal: () => true }),
+        );
+        agent.autoApprove = true;
+        const onCheckpoint = vi.fn();
+        agent.onCheckpoint = onCheckpoint;
+
+        const { checkpoint } = await agent.processMessage('filter it');
+
+        expect(checkpoint).toBe(true);
+        expect(onCheckpoint).toHaveBeenCalledOnce();
+        // 3 local rounds, then the streak guard trips and makes 1 summary call.
+        // The key assertion is that it terminated at all (bounded, not infinite).
+        expect(global.fetch.mock.calls.length).toBe(4);
+    });
+
+    it('a remote round resets the local-only streak, so interleaved turns are not cut short (#243)', async () => {
+        // local, local, REMOTE, local, local, final — the remote round resets the
+        // streak, so with threshold 3 the 2-local / 1-remote / 2-local pattern
+        // never reaches 3 consecutive local rounds and the turn completes normally.
+        const isLocal = vi.fn((name) => name !== 'remote_tool');
+        global.fetch = vi.fn()
+            .mockResolvedValueOnce(okToolCall('set_filter'))   // local streak 1
+            .mockResolvedValueOnce(okToolCall('set_filter'))   // local streak 2
+            .mockResolvedValueOnce(okToolCall('remote_tool'))  // remote → streak reset, iterations 1
+            .mockResolvedValueOnce(okToolCall('set_filter'))   // local streak 1
+            .mockResolvedValueOnce(okToolCall('set_filter'))   // local streak 2
+            .mockResolvedValueOnce(okText('done'));
+        const agent = new Agent(
+            baseConfig({ max_tool_calls: 3 }),
+            stubRegistry({ isLocal }),
+        );
+        agent.autoApprove = true;
+        const { response, checkpoint } = await agent.processMessage('do stuff');
+        expect(checkpoint).toBeFalsy();
+        expect(response).toBe('done');
     });
 });
 

--- a/test/map-manager.filter.test.js
+++ b/test/map-manager.filter.test.js
@@ -1,0 +1,49 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { MapManager } from '../app/map-manager.js';
+
+/**
+ * Bare MapManager mock exposing only the surface setFilter touches:
+ * a single registered vector layer and a map that records setFilter calls.
+ */
+function createManager() {
+    const setFilterCalls = [];
+    const map = {
+        setFilter: (id, f) => setFilterCalls.push({ id, f }),
+        queryRenderedFeatures: () => [{}, {}, {}], // 3 features in view
+    };
+    const mm = Object.create(MapManager.prototype);
+    mm.map = map;
+    mm.layers = new Map([
+        ['vec', { type: 'vector', mapLayerId: 'layer-vec', displayName: 'Vec' }],
+    ]);
+    mm._setFilterCalls = setFilterCalls;
+    return mm;
+}
+
+describe('MapManager.setFilter empty-filter guard (#243)', () => {
+    let mm;
+    beforeEach(() => { mm = createManager(); });
+
+    it('rejects an empty array [] with an error instead of silent success', () => {
+        const r = mm.setFilter('vec', []);
+        expect(r.success).toBe(false);
+        expect(r.error).toMatch(/empty/i);
+        // The no-op filter never reaches the map (would otherwise clear it silently).
+        expect(mm._setFilterCalls.length).toBe(0);
+    });
+
+    it('applies a valid (non-empty) filter expression', () => {
+        const expr = ['==', ['get', 'NO_TAKE'], 'All'];
+        const r = mm.setFilter('vec', expr);
+        expect(r.success).toBe(true);
+        expect(r.filter).toEqual(expr);
+        expect(r.featuresInView).toBe(3);
+        expect(mm._setFilterCalls[0].f).toEqual(expr);
+    });
+
+    it('still allows null to clear — clearFilter passes null, not [] (the guard must not block it)', () => {
+        const r = mm.setFilter('vec', null);
+        expect(r.success).toBe(true);
+        expect(mm._setFilterCalls[0].f).toBe(null);
+    });
+});

--- a/test/map-tools.test.js
+++ b/test/map-tools.test.js
@@ -371,4 +371,28 @@ describe('createMapTools smoke test', () => {
             expect(typeof tool.execute).toBe('function');
         }
     });
+
+    // Regression guard for #243: an array-typed param with no `items` compiles,
+    // under grammar-constrained tool decoding, to a grammar that can only emit
+    // `[]` — which silently collapsed every set_filter call to an empty filter.
+    // Every array param MUST declare `items` (even `{}`) so the grammar permits
+    // content. This invariant catches the bug for set_filter and any future tool.
+    it('every array-typed tool param declares items (constrained-decoding safety, #243)', () => {
+        const tools = createMapTools(stubMapManager, stubCatalog, { callTool: () => null });
+        for (const tool of tools) {
+            const props = tool.inputSchema?.properties || {};
+            for (const [name, schema] of Object.entries(props)) {
+                if (schema.type === 'array') {
+                    expect(schema.items, `${tool.name}.${name} must declare 'items'`).toBeDefined();
+                }
+            }
+        }
+    });
+
+    it('set_filter.filter declares items so it is not grammar-collapsed to [] (#243)', () => {
+        const tools = createMapTools(stubMapManager, stubCatalog);
+        const setFilter = tools.find(t => t.name === 'set_filter');
+        expect(setFilter.inputSchema.properties.filter.type).toBe('array');
+        expect(setFilter.inputSchema.properties.filter.items).toBeDefined();
+    });
 });


### PR DESCRIPTION
Fixes #243.

## Root cause (from open-llm-proxy logs)

`set_filter` looped forever — models emit `filter: []`, MapLibre applies it as a silent no-op, the model sees no change and retries endlessly. Two independent problems:

**1. The `filter` param had no `items` schema, and the servers started enforcing it.** It was `{type:'array'}` with no `items` — the only array param in the tool set missing it. On **2026-06-14** the NRP vLLM servers began grammar-constraining tool-call arguments to the JSON schema; an array with no `items` compiles to a grammar that can only emit `[]`. Logs show a clean overnight cliff:

```
Apr 02 → Jun 13:  empty filters = 0/day   (hundreds working, ALL models)
Jun 14 onward:    empty = 100%            ← every self-hosted model
```

Not a weak-model issue — they worked for two months. claude-sonnet unaffected (different decoder).

**2. v3.9 dropped the local-loop cap.** Commit `2f2ec56` changed `iterations++` to `if (!allLocal) iterations++`. `set_filter` is local, so a local-only loop never hits the checkpoint and spins forever.

## Fix (all framework-side, no new tool)

- **`map-tools.js`** — `filter` declares `items: {}` (root cause). MapLibre filters are heterogeneous/recursive, so "any element" is the honest schema.
- **`agent.js`** — bound consecutive local-only rounds; a remote round resets the streak, so tool-heavy turns are unaffected.
- **`map-manager.js`** — `setFilter` rejects empty `[]` with an explicit error instead of silent success.

## Tests
- Invariant: **every** array-typed tool param must declare `items` (would have caught this).
- `set_filter.filter` declares items.
- Empty-`[]` guard rejects, valid filter applies, `null` (clear) still works.
- Runaway local-only loop is bounded; a remote round resets the streak.

All 274 tests pass.

## ⚠️ Needs live verification before merge
`items: {}` should let grammar-constrained decoding emit nested filters again — this needs confirming against the live NRP `minimax-m2` server. If it still collapses, the fallback is a string-typed `filter` we parse. The guard + cap make it fail loudly (not infinitely) either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)