### PR TITLE
fix(set_filter): stop reporting off-screen (0-in-view) matches as a failed filter (#246)

### DIFF
--- a/app/map-manager.js
+++ b/app/map-manager.js
@@ -665,9 +665,14 @@ export class MapManager {
         if (state.outlineLayerId) this.map.setFilter(state.outlineLayerId, filter);
         state.filter = filter;
 
-        // Count features in view
+        // featuresInView is a viewport metric, NOT a global match count:
+        // queryRenderedFeatures only sees currently-rendered tiles in the visible
+        // area. A valid filter whose matches are off-screen legitimately returns 0,
+        // so we deliberately do NOT flag 0 as a failure — that wrongly told users a
+        // correct filter had matched nothing (the human just needs to zoom out, and
+        // the filtered tiles redraw automatically as the view changes).
         const features = this.map.queryRenderedFeatures({ layers: [state.mapLayerId] });
-        const result = {
+        return {
             success: true,
             layer: layerId,
             displayName: state.displayName,
@@ -675,12 +680,6 @@ export class MapManager {
             filterDescription: filter ? this.describeFilter(filter) : 'No filter (showing all)',
             featuresInView: features.length,
         };
-
-        if (features.length === 0 && filter) {
-            result.warning = 'No features match this filter in the current view. The filter may be too restrictive or property values may not match. Use the query tool to check actual data values.';
-        }
-
-        return result;
     }
 
     /**

--- a/app/map-tools.js
+++ b/app/map-tools.js
@@ -102,8 +102,6 @@ ${formatLayerList(allLayers())}`,
 
 IMPORTANT: Never guess categorical values used in filters. Check the dataset catalog in your system prompt for documented coded values, or call get_stac_details for full column details. Only use SELECT DISTINCT via SQL if the metadata doesn't cover it.
 
-IMPORTANT: After filtering, check 'featuresInView' in the result. If 0, the filter may be wrong.
-
 Filter syntax (use MapLibre expressions — NOT legacy filter arrays):
 - Equality: ["==", ["get", "property"], "value"]
 - Inequality: ["!=", ["get", "property"], "value"]

--- a/test/map-manager.filter.test.js
+++ b/test/map-manager.filter.test.js
@@ -5,11 +5,11 @@ import { MapManager } from '../app/map-manager.js';
  * Bare MapManager mock exposing only the surface setFilter touches:
  * a single registered vector layer and a map that records setFilter calls.
  */
-function createManager() {
+function createManager(featuresInView = 3) {
     const setFilterCalls = [];
     const map = {
         setFilter: (id, f) => setFilterCalls.push({ id, f }),
-        queryRenderedFeatures: () => [{}, {}, {}], // 3 features in view
+        queryRenderedFeatures: () => Array.from({ length: featuresInView }, () => ({})),
     };
     const mm = Object.create(MapManager.prototype);
     mm.map = map;
@@ -45,5 +45,23 @@ describe('MapManager.setFilter empty-filter guard (#243)', () => {
         const r = mm.setFilter('vec', null);
         expect(r.success).toBe(true);
         expect(mm._setFilterCalls[0].f).toBe(null);
+    });
+});
+
+describe('MapManager.setFilter 0-features-in-view', () => {
+    it('reports plain success with no failure signal when 0 features are in the viewport', () => {
+        // queryRenderedFeatures is viewport-scoped: a valid filter whose matches are
+        // off-screen returns 0 here. The result must NOT flag that as a problem — a
+        // warning here was being relayed to users as "filter matched nothing / is
+        // wrong". featuresInView is plain data; 0 just means none in the current view.
+        const mm = createManager(0);
+        const expr = ['==', ['get', 'admin_agency'], 'NPS'];
+        const r = mm.setFilter('vec', expr);
+
+        expect(r.success).toBe(true);
+        expect(r.featuresInView).toBe(0);
+        // No warning / error / "no match" failure signal — the filter applied fine.
+        expect(r.warning).toBeUndefined();
+        expect(r.error).toBeUndefined();
     });
 });


### PR DESCRIPTION
Fixes #246.

## Problem
After #243, models emit correct filters again — but `set_filter` sometimes reported a working filter as a failure. A valid filter (`admin_agency = NPS`) returned `featuresInView: 0` with a warning saying the filter "may be too restrictive or property values may not match," which the agent relayed to the user as "0 matched."

`featuresInView` is from `queryRenderedFeatures` — viewport-scoped. The user was zoomed into LA; nationwide NPS trails weren't loaded (that's how vector tiling works), so 0 is *correct*, not a failure. There's no cheap client-side global match count, and we don't want to defeat tiling to get one.

## Evidence (proxy logs, all history)
140 non-empty filters → 106 returned >0, 34 returned 0-in-view. The 0 cases are overwhelmingly **valid filters with off-screen matches** (`STATEFP=48` (Texas) ~7×, GAP status, EEZ IDs, …). Genuine faults are rare and already covered by existing schema/syntax guidance. Zoom is the real caveat — and the user zooms instinctively, after which the filtered tiles redraw automatically.

## Fix (minimal, no added model-facing prose — cf. #225)
- **Delete** the harmful "If 0, the filter may be wrong" line from the `set_filter` description (net context *reduction* for the small local models).
- **Drop** the 0-in-view warning entirely; `featuresInView` is returned as plain, self-describing data.
- No field rename, no metric change, no extra computation.

## Tests
Updated `test/map-manager.filter.test.js`: a 0-in-view valid filter now returns plain `success: true` with `featuresInView: 0` and **no warning/error** failure signal.

Distinct from #243 (the empty-`[]` loop). 

🤖 Generated with [Claude Code](https://claude.com/claude-code)