### PR TITLE
feat(legend): discrete/categorical legends for vector layers (#118)

### DIFF
--- a/app/dataset-catalog.js
+++ b/app/dataset-catalog.js
@@ -12,6 +12,24 @@
  * and is injected into both the system prompt and the map layer setup.
  */
 
+/**
+ * Normalize a vector layer's `legend_classes` config into the internal
+ * categorical-legend shape (`{ name, 'color-hint' }`) the legend renderer
+ * expects. Accepts the documented `{ label, color }` form as well as the
+ * STAC-style `{ name | value, 'color-hint' }` form so either author style
+ * works. Rasters keep deriving their classes from STAC `classification:classes`.
+ * @param {Array<Object>} raw
+ * @returns {Array<Object>|null}
+ */
+function normalizeLegendClasses(raw) {
+    if (!Array.isArray(raw) || raw.length === 0) return null;
+    return raw.map(c => ({
+        name: c.name ?? c.label ?? (c.value != null ? `Class ${c.value}` : ''),
+        'color-hint': c['color-hint'] ?? c.color_hint ?? c.color ?? null,
+        ...(c.value != null ? { value: c.value } : {}),
+    }));
+}
+
 export class DatasetCatalog {
     constructor() {
         /** @type {Map<string, DatasetEntry>} keyed by collection ID */
@@ -310,6 +328,7 @@ export class DatasetCatalog {
                         paint: config.paint || null,
                         legendLabel: config.legend_label || null,
                         legendType: config.legend_type || null,
+                        legendClasses: normalizeLegendClasses(config.legend_classes),
                         // Versioned metadata
                         versions,
                         defaultVersionIndex: defaultIndex,
@@ -339,6 +358,9 @@ export class DatasetCatalog {
                         tooltipFields: config.tooltip_fields || null,
                         defaultVisible: config.visible === true,
                         defaultFilter: config.default_filter || null,
+                        legendLabel: config.legend_label || null,
+                        legendType: config.legend_type || null,
+                        legendClasses: normalizeLegendClasses(config.legend_classes),
                     });
                 } else if (type.includes('geotiff') || type.includes('tiff')) {
                     const band0 = asset['raster:bands']?.[0];
@@ -386,6 +408,9 @@ export class DatasetCatalog {
                         tooltipFields: config.tooltip_fields || null,
                         defaultVisible: config.visible === true,
                         defaultFilter: config.default_filter || null,
+                        legendLabel: config.legend_label || null,
+                        legendType: config.legend_type || null,
+                        legendClasses: normalizeLegendClasses(config.legend_classes),
                         animation,
                     });
                 }
@@ -721,6 +746,7 @@ export class DatasetCatalog {
                         rescale: ml.rescale || null,
                         legendLabel: ml.legendLabel || null,
                         legendType: ml.legendType || null,
+                        legendClasses: ml.legendClasses || null,
                         // Versioned metadata
                         versions: versionConfigs,
                         defaultVersionIndex: ml.defaultVersionIndex,
@@ -753,6 +779,9 @@ export class DatasetCatalog {
                         tooltipFields: ml.tooltipFields || null,
                         defaultVisible: ml.defaultVisible || false,
                         defaultFilter: ml.defaultFilter || null,
+                        legendLabel: ml.legendLabel || null,
+                        legendType: ml.legendType || null,
+                        legendClasses: ml.legendClasses || null,
                         animation: ml.animation || null,
                         tracksUrl: isGeoJson ? ml.url : null,
                     };

--- a/app/map-manager.js
+++ b/app/map-manager.js
@@ -273,6 +273,7 @@ export class MapManager {
                 versions: versionStates,
                 activeVersionIndex: config.defaultVersionIndex,
             });
+            this._showLegendIfVisible(layerId);
             return;
         }
 
@@ -373,6 +374,8 @@ export class MapManager {
         if (type === 'vector') {
             this._wireTooltip(mapLayerId, layerId);
         }
+
+        this._showLegendIfVisible(layerId);
     }
 
     /**
@@ -1250,6 +1253,16 @@ export class MapManager {
     _hasLegend(state) {
         return state.type === 'raster'
             || (state.legendType === 'categorical' && state.legendClasses?.length > 0);
+    }
+
+    /**
+     * Render the legend for a layer that loads visible, so default-on layers
+     * show their legend at boot (registerLayer sets visibility directly and
+     * never routes through showLayer).
+     */
+    _showLegendIfVisible(layerId) {
+        const state = this.layers.get(layerId);
+        if (state?.visible && this._hasLegend(state)) this._showLegend(layerId);
     }
 
     _ensureLegend() {

--- a/app/map-manager.js
+++ b/app/map-manager.js
@@ -446,7 +446,7 @@ export class MapManager {
         }
         this.map.setLayoutProperty(state.mapLayerId, 'visibility', 'visible');
         if (state.outlineLayerId) this.map.setLayoutProperty(state.outlineLayerId, 'visibility', 'visible');
-        if (state.type === 'raster') this._showRasterLegend(layerId);
+        if (this._hasLegend(state)) this._showLegend(layerId);
         return { success: true, layer: layerId, displayName: state.displayName, visible: true };
     }
 
@@ -466,7 +466,7 @@ export class MapManager {
         }
         this.map.setLayoutProperty(state.mapLayerId, 'visibility', 'none');
         if (state.outlineLayerId) this.map.setLayoutProperty(state.outlineLayerId, 'visibility', 'none');
-        if (state.type === 'raster') this._hideRasterLegend(layerId);
+        if (this._hasLegend(state)) this._hideLegend(layerId);
         return { success: true, layer: layerId, displayName: state.displayName, visible: false };
     }
 
@@ -1233,15 +1233,24 @@ export class MapManager {
 
         // Refresh raster legend if visible (tile URL changed)
         if (state.type === 'raster' && state.visible) {
-            this._hideRasterLegend(layerId);
+            this._hideLegend(layerId);
             this._legendItems.delete(layerId);   // force re-creation with new source
-            this._showRasterLegend(layerId);
+            this._showLegend(layerId);
         }
 
         return { success: true, layer: layerId, version: newV.label };
     }
 
-    // ---- Raster Legend ----
+    // ---- Legend ----
+
+    /**
+     * Whether a layer contributes a legend entry: continuous rasters (colorbar)
+     * and any layer — raster or vector — with a categorical class list.
+     */
+    _hasLegend(state) {
+        return state.type === 'raster'
+            || (state.legendType === 'categorical' && state.legendClasses?.length > 0);
+    }
 
     _ensureLegend() {
         if (this._legendEl) return;
@@ -1283,7 +1292,7 @@ export class MapManager {
         }
     }
 
-    async _showRasterLegend(layerId) {
+    async _showLegend(layerId) {
         const state = this.layers.get(layerId);
         if (!state) return;
 
@@ -1337,7 +1346,7 @@ export class MapManager {
         this._legendItems.set(layerId, item);
     }
 
-    _hideRasterLegend(layerId) {
+    _hideLegend(layerId) {
         const item = this._legendItems.get(layerId);
         if (item) item.style.display = 'none';
         // Hide the whole panel when nothing is visible

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -77,6 +77,8 @@ Each entry in `assets` may be a **bare string** (the STAC asset key, loaded with
 | `default_filter` | array | MapLibre filter expression applied at load time. |
 | `tooltip_fields` | array | Feature property names shown in the hover tooltip. |
 | `group` | string | Overrides the collection-level `group` for this specific layer. |
+| `legend_type` | string | `"categorical"` to show a discrete swatch legend (see `legend_classes`). |
+| `legend_classes` | array | `{ label, color }` entries describing the discrete legend swatches. Required when `legend_type` is `"categorical"` on a vector layer — vectors have no STAC `classification:classes` to derive from. |
 
 ## Asset config — raster (COG)
 
@@ -553,6 +555,33 @@ Open a collection → click the **Assets** tab. The keys listed there (e.g., `"p
   },
   "default_filter": ["match", ["get", "GAP_Sts"], ["1", "2"], true, false],
   "tooltip_fields": ["Unit_Nm", "GAP_Sts", "Mang_Type"]
+}
+```
+
+### Categorical legend on a vector layer
+
+When a vector layer is colored by category via a `match` expression, add a `legend_classes` list so the color scheme is explained in the legend panel. The labels and colors are authored to match the `match` arms (they are not derived automatically):
+
+```json
+{
+  "id": "seafloor-geomorphology-pmtiles",
+  "display_name": "Seafloor Geomorphology",
+  "visible": true,
+  "default_style": {
+    "fill-color": ["match", ["get", "feature_type"],
+      "Seamounts", "#F57F17",
+      "Ridges", "#BF360C",
+      "Trenches", "#311B92",
+      "#888888"
+    ],
+    "fill-opacity": 0.7
+  },
+  "legend_type": "categorical",
+  "legend_classes": [
+    { "label": "Seamounts", "color": "#F57F17" },
+    { "label": "Ridges", "color": "#BF360C" },
+    { "label": "Trenches", "color": "#311B92" }
+  ]
 }
 ```
 

--- a/test/dataset-catalog.test.js
+++ b/test/dataset-catalog.test.js
@@ -313,6 +313,36 @@ describe('DatasetCatalog.extractMapLayers', () => {
         expect(layers[0].sourceLayer).toBe('holdings_layer');
     });
 
+    it('normalizes legend_classes ({label,color}) for a categorical vector layer (issue #118)', () => {
+        const layers = cat.extractMapLayers(collectionWithAssets({
+            geo: { type: 'application/vnd.pmtiles', href: 'https://x/geo.pmtiles' },
+        }), {}, [{
+            key: 'geo', assetId: 'geo', config: {
+                legend_type: 'categorical',
+                legend_label: 'Type',
+                legend_classes: [
+                    { label: 'Seamounts', color: '#F57F17' },
+                    { label: 'Ridges', color: '#BF360C' },
+                ],
+            },
+        }]);
+
+        expect(layers[0].layerType).toBe('vector');
+        expect(layers[0].legendType).toBe('categorical');
+        expect(layers[0].legendLabel).toBe('Type');
+        expect(layers[0].legendClasses).toEqual([
+            { name: 'Seamounts', 'color-hint': '#F57F17' },
+            { name: 'Ridges', 'color-hint': '#BF360C' },
+        ]);
+    });
+
+    it('leaves legendClasses null for a vector layer without legend_classes', () => {
+        const layers = cat.extractMapLayers(collectionWithAssets({
+            geo: { type: 'application/vnd.pmtiles', href: 'https://x/geo.pmtiles' },
+        }), {}, [{ key: 'geo', assetId: 'geo', config: {} }]);
+        expect(layers[0].legendClasses).toBeNull();
+    });
+
     it('falls back to assetId for sourceLayer when vector:layers is absent', () => {
         const layers = cat.extractMapLayers(collectionWithAssets({
             tiles: { type: 'application/vnd.pmtiles', href: 'https://x/x.pmtiles' },
@@ -551,6 +581,22 @@ describe('DatasetCatalog.getMapLayerConfigs', () => {
         const [c] = cat.getMapLayerConfigs();
         expect(c.versions[0].type).toBe('raster');
         expect(c.versions[0].source.tiles[0]).toContain('colormap_name=viridis');
+    });
+
+    it('passes legendType/legendClasses through to a vector layer config (issue #118)', () => {
+        cat.datasets.set('sf', {
+            id: 'sf', title: 'Seafloor', columns: [],
+            mapLayers: [{
+                assetId: 'geo', layerType: 'vector', title: 'Seafloor Geomorphology',
+                url: 'https://x/geo.pmtiles', sourceLayer: 'geo',
+                legendType: 'categorical',
+                legendClasses: [{ name: 'Seamounts', 'color-hint': '#F57F17' }],
+            }],
+        });
+        const [c] = cat.getMapLayerConfigs();
+        expect(c.type).toBe('vector');
+        expect(c.legendType).toBe('categorical');
+        expect(c.legendClasses).toEqual([{ name: 'Seamounts', 'color-hint': '#F57F17' }]);
     });
 
     it('emits an inline colormap JSON for categorical raster layers from classification:classes', () => {

--- a/test/map-manager.hex.test.js
+++ b/test/map-manager.hex.test.js
@@ -51,8 +51,8 @@ function createManager() {
     mm.map = createMockMap();
     mm.layers = new Map();
     // Stub legend helpers the mutators might call.
-    mm._showRasterLegend = () => {};
-    mm._hideRasterLegend = () => {};
+    mm._showLegend = () => {};
+    mm._hideLegend = () => {};
     return mm;
 }
 

--- a/test/map-manager.tooltip-legend.test.js
+++ b/test/map-manager.tooltip-legend.test.js
@@ -82,7 +82,7 @@ describe('MapManager raster legend (SEC-3)', () => {
             legendType: 'categorical',
             legendClasses: [{ name: '<img src=x onerror=alert(1)>', 'color-hint': 'ff0000' }],
         });
-        await mm._showRasterLegend('A');
+        await mm._showLegend('A');
         expect(mm._legendContent.querySelector('img')).toBeNull();
         expect(mm._legendContent.textContent).toContain('<img');
     });
@@ -93,7 +93,7 @@ describe('MapManager raster legend (SEC-3)', () => {
             legendType: 'categorical',
             legendClasses: [{ name: 'Forest', 'color-hint': '00ff00' }],
         });
-        await mm._showRasterLegend('A');
+        await mm._showLegend('A');
         expect(mm._legendContent.querySelector('script')).toBeNull();
         expect(mm._legendContent.querySelector('h4').textContent).toContain('Cover');
     });
@@ -104,7 +104,7 @@ describe('MapManager raster legend (SEC-3)', () => {
             legendType: 'categorical',
             legendClasses: [{ name: 'Forest', 'color-hint': '00ff00' }],
         });
-        await mm._showRasterLegend('A');
+        await mm._showLegend('A');
         const swatch = mm._legendContent.querySelector('.legend-item span');
         expect(swatch.getAttribute('style')).toMatch(/00ff00|rgb\(0,\s*255,\s*0\)/i);
     });
@@ -115,7 +115,7 @@ describe('MapManager raster legend (SEC-3)', () => {
             legendType: 'categorical',
             legendClasses: [{ name: 'Evil', 'color-hint': 'red;"></span><img src=x onerror=alert(1)>' }],
         });
-        await mm._showRasterLegend('A');
+        await mm._showLegend('A');
         expect(mm._legendContent.querySelector('img')).toBeNull();
         const swatch = mm._legendContent.querySelector('.legend-item span');
         expect(swatch.getAttribute('style')).toMatch(/888888|rgb\(136,\s*136,\s*136\)/i);
@@ -129,11 +129,51 @@ describe('MapManager raster legend (SEC-3)', () => {
             legendLabel: 'tC/ha',
         });
         mm._getColormapGradient = async () => 'linear-gradient(to right, #fff, #000)';
-        await mm._showRasterLegend('A');
+        await mm._showLegend('A');
         expect(mm._legendContent.querySelector('i')).toBeNull();
         const labels = [...mm._legendContent.querySelectorAll('.legend-labels span')].map(s => s.textContent);
         expect(labels).toEqual(['0 tC/ha', '100 tC/ha']);
         const bar = mm._legendContent.querySelector('.legend-colorbar');
         expect(bar.getAttribute('style')).toContain('linear-gradient');
+    });
+
+    it('renders a categorical legend for a vector layer (issue #118)', async () => {
+        const mm = createLegendManager({
+            type: 'vector',
+            displayName: 'Seafloor Geomorphology',
+            legendType: 'categorical',
+            legendClasses: [
+                { name: 'Seamounts', 'color-hint': '#F57F17' },
+                { name: 'Ridges', 'color-hint': '#BF360C' },
+            ],
+        });
+        await mm._showLegend('A');
+        const rows = mm._legendContent.querySelectorAll('.legend-item');
+        expect(rows).toHaveLength(2);
+        expect(mm._legendContent.textContent).toContain('Seamounts');
+        expect(mm._legendContent.textContent).toContain('Ridges');
+    });
+});
+
+describe('MapManager._hasLegend', () => {
+    const mm = Object.create(MapManager.prototype);
+
+    it('is true for any raster layer (continuous colorbar)', () => {
+        expect(mm._hasLegend({ type: 'raster' })).toBe(true);
+    });
+
+    it('is true for a categorical vector layer with classes', () => {
+        expect(mm._hasLegend({
+            type: 'vector', legendType: 'categorical',
+            legendClasses: [{ name: 'A', 'color-hint': 'ff0000' }],
+        })).toBe(true);
+    });
+
+    it('is false for a plain vector layer', () => {
+        expect(mm._hasLegend({ type: 'vector' })).toBeFalsy();
+    });
+
+    it('is false for a vector layer flagged categorical but with no classes', () => {
+        expect(mm._hasLegend({ type: 'vector', legendType: 'categorical', legendClasses: [] })).toBeFalsy();
     });
 });

--- a/test/map-manager.tooltip-legend.test.js
+++ b/test/map-manager.tooltip-legend.test.js
@@ -177,3 +177,32 @@ describe('MapManager._hasLegend', () => {
         expect(mm._hasLegend({ type: 'vector', legendType: 'categorical', legendClasses: [] })).toBeFalsy();
     });
 });
+
+describe('MapManager._showLegendIfVisible (legend at boot for default-visible layers)', () => {
+    it('renders a default-visible categorical vector layer legend', async () => {
+        const mm = createLegendManager({
+            type: 'vector', visible: true, displayName: 'Trails',
+            legendType: 'categorical',
+            legendClasses: [{ name: 'USFS', 'color-hint': '#2E7D32' }],
+        });
+        await mm._showLegendIfVisible('A');
+        expect(mm._legendItems.has('A')).toBe(true);
+        expect(mm._legendContent.textContent).toContain('USFS');
+    });
+
+    it('does not render the legend for a hidden categorical layer', async () => {
+        const mm = createLegendManager({
+            type: 'vector', visible: false, displayName: 'Trails',
+            legendType: 'categorical',
+            legendClasses: [{ name: 'USFS', 'color-hint': '#2E7D32' }],
+        });
+        await mm._showLegendIfVisible('A');
+        expect(mm._legendItems.has('A')).toBe(false);
+    });
+
+    it('does not render a legend for a default-visible plain vector layer', async () => {
+        const mm = createLegendManager({ type: 'vector', visible: true, displayName: 'Boundaries' });
+        await mm._showLegendIfVisible('A');
+        expect(mm._legendItems.has('A')).toBe(false);
+    });
+});


### PR DESCRIPTION
Closes #118.

## What

Vector (PMTiles/GeoJSON) layers now support discrete/categorical legends. Previously the legend panel only appeared for raster layers, and `legendType`/`legendClasses` were never carried through the vector config paths — even though the categorical render branch already existed in the legend renderer.

The high-seas seafloor-geomorphology layer (24 `feature_type` values colored via a `match` expression) is the motivating case: it had no legend explaining the color scheme.

## Changes

- **`dataset-catalog.js`** — read `legend_type` + a new `legend_classes` config on vector layers (standard PMTiles, GeoJSON, and versioned). A `normalizeLegendClasses` helper converts the documented `{ label, color }` form into the internal `{ name, 'color-hint' }` shape the renderer already consumes (also accepts the STAC-style keys). Pass `legendType`/`legendClasses`/`legendLabel` through `getMapLayerConfigs`. Rasters are unchanged — they keep deriving classes from STAC `classification:classes`.
- **`map-manager.js`** — add a `_hasLegend(state)` predicate and gate show/hide on it, so any categorical layer (raster *or* vector) gets a legend. Renamed `_show/_hideRasterLegend` → `_show/_hideLegend` since they now serve both types.
- **docs** — document `legend_classes` and add a worked vector-categorical example.

## Why `legend_classes` (not auto-derived)

Vectors have no STAC `classification:classes` to read, and the fill colors live inside a MapLibre `match` expression that isn't reliably introspectable. So the labels/colors are authored explicitly to mirror the `match` arms — same division of labor as `default_style` itself.

## Tests

`npm test` — 283 passing (+8): config normalization, `getMapLayerConfigs` passthrough, vector legend render, and `_hasLegend`. Browser-bound legend DOM is exercised via the existing jsdom legend harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)