### PR TITLE
feat(map): geolocation (button + opt-in agent tool) #244 + decouple geocoder

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -35,6 +35,7 @@ async function main() {
         if (runtimeConfig.mcp_auth_token) appConfig.mcp_auth_token = runtimeConfig.mcp_auth_token;
         if (runtimeConfig.catalog_token) appConfig.catalog_token = runtimeConfig.catalog_token;
         if (runtimeConfig.draw_enabled != null) appConfig.draw_enabled = runtimeConfig.draw_enabled;
+        if (runtimeConfig.geolocate != null) appConfig.geolocate = runtimeConfig.geolocate;
         // != null (not truthiness) so 0 — which disables the checkpoint — survives.
         if (runtimeConfig.max_tool_calls != null) appConfig.max_tool_calls = runtimeConfig.max_tool_calls;
         if (runtimeConfig.max_tool_calls_manual != null) appConfig.max_tool_calls_manual = runtimeConfig.max_tool_calls_manual;
@@ -142,6 +143,25 @@ async function main() {
         }
     }
 
+    /* ── 3d. Geolocate control (optional — requires geolocate) ───────── */
+    // "Locate me" button using the device geolocation. Opt-in; off by default.
+    // GeolocateControl ships with MapLibre GL JS, so there's nothing to pin.
+    if (appConfig.geolocate) {
+        try {
+            mapManager.map.addControl(
+                new maplibregl.GeolocateControl({
+                    positionOptions: { enableHighAccuracy: true },
+                    trackUserLocation: true,
+                    showUserLocation: true,
+                }),
+                'top-left',
+            );
+            console.log('[main] Geolocate control ready');
+        } catch (err) {
+            console.warn('[main] Failed to add geolocate control:', err.message);
+        }
+    }
+
     /* ── 4. Set up MCP client ─────────────────────────────────────────── */
     const mcpUrl = appConfig.mcp_url || 'https://duckdb-mcp.nrp-nautilus.io/mcp';
     const mcpHeaders = {};
@@ -156,12 +176,13 @@ async function main() {
     /* ── 5. Build tool registry ───────────────────────────────────────── */
     const toolRegistry = new ToolRegistry();
 
-    // Geocoder backend (shared by the `geocode` tool and the optional search
-    // box). Enabled by default; set geocoder.enabled=false to disable. The
-    // MapTiler key, when present, falls back to the basemap key.
+    // Geocoder backend (powers the `geocode` tool and the optional search box).
+    // Opt-in: set geocoder.enabled=true for the agent tool, or geocoder.search_box=true
+    // (which implies the backend). Off otherwise. The MapTiler key, when present,
+    // falls back to the basemap key.
     const geoCfg = appConfig.geocoder || {};
     let geocoder = null;
-    if (geoCfg.enabled !== false) {
+    if (geoCfg.enabled === true || geoCfg.search_box) {
         try {
             geocoder = createGeocoder({
                 ...geoCfg,

--- a/app/main.js
+++ b/app/main.js
@@ -176,13 +176,15 @@ async function main() {
     /* ── 5. Build tool registry ───────────────────────────────────────── */
     const toolRegistry = new ToolRegistry();
 
-    // Geocoder backend (powers the `geocode` tool and the optional search box).
-    // Opt-in: set geocoder.enabled=true for the agent tool, or geocoder.search_box=true
-    // (which implies the backend). Off otherwise. The MapTiler key, when present,
-    // falls back to the basemap key.
+    // Geocoder backend, shared by two independently-toggled surfaces:
+    //   • the `geocode` agent tool — ON by default (opt-out: geocoder.enabled=false)
+    //   • the on-map search box — OFF by default (opt-in: geocoder.search_box=true)
+    // The backend is built when either surface needs it. The MapTiler key, when
+    // present, falls back to the basemap key.
     const geoCfg = appConfig.geocoder || {};
+    const geocodeToolEnabled = geoCfg.enabled !== false;
     let geocoder = null;
-    if (geoCfg.enabled === true || geoCfg.search_box) {
+    if (geocodeToolEnabled || geoCfg.search_box) {
         try {
             geocoder = createGeocoder({
                 ...geoCfg,
@@ -207,8 +209,9 @@ async function main() {
         }
     }
 
-    // Register local map tools
-    for (const tool of createMapTools(mapManager, catalog, mcp, geocoder)) {
+    // Register local map tools. The geocode tool is gated on geocodeToolEnabled
+    // (not merely on the backend existing), so search_box can run without it.
+    for (const tool of createMapTools(mapManager, catalog, mcp, geocodeToolEnabled ? geocoder : null)) {
         toolRegistry.registerLocal(tool);
     }
 

--- a/app/main.js
+++ b/app/main.js
@@ -143,10 +143,19 @@ async function main() {
         }
     }
 
-    /* ── 3d. Geolocate control (optional — requires geolocate) ───────── */
-    // "Locate me" button using the device geolocation. Opt-in; off by default.
+    /* ── 3d. Geolocation (optional — "where am I?") ──────────────────── */
+    // Two independently opt-in surfaces, both off by default:
+    //   • locate-me button (UI)        — geolocate.button
+    //   • get_user_location agent tool — geolocate.agent_tool (reaches device
+    //     GPS, so off by default even though it's invisible — see map-tools.js)
+    // `geolocate: true` is back-compat shorthand for { button: true }.
+    const geoLocCfg = appConfig.geolocate === true
+        ? { button: true }
+        : (appConfig.geolocate && typeof appConfig.geolocate === 'object')
+            ? appConfig.geolocate
+            : {};
     // GeolocateControl ships with MapLibre GL JS, so there's nothing to pin.
-    if (appConfig.geolocate) {
+    if (geoLocCfg.button) {
         try {
             mapManager.map.addControl(
                 new maplibregl.GeolocateControl({
@@ -211,7 +220,8 @@ async function main() {
 
     // Register local map tools. The geocode tool is gated on geocodeToolEnabled
     // (not merely on the backend existing), so search_box can run without it.
-    for (const tool of createMapTools(mapManager, catalog, mcp, geocodeToolEnabled ? geocoder : null)) {
+    // get_user_location is gated separately on the opt-in geolocate.agent_tool.
+    for (const tool of createMapTools(mapManager, catalog, mcp, geocodeToolEnabled ? geocoder : null, { geolocateTool: !!geoLocCfg.agent_tool })) {
         toolRegistry.registerLocal(tool);
     }
 

--- a/app/map-tools.js
+++ b/app/map-tools.js
@@ -36,15 +36,32 @@ export function extractJsonArray(text) {
 }
 
 /**
+ * Promisified `navigator.geolocation.getCurrentPosition`. Rejects (rather than
+ * hanging) when geolocation isn't available in the environment.
+ * @returns {Promise<GeolocationPosition>}
+ */
+export function getCurrentPositionAsync(options = { enableHighAccuracy: true, timeout: 10000 }) {
+    return new Promise((resolve, reject) => {
+        const geo = typeof navigator !== 'undefined' && navigator.geolocation;
+        if (!geo) {
+            reject(new Error('Geolocation is not available in this browser.'));
+            return;
+        }
+        geo.getCurrentPosition(resolve, reject, options);
+    });
+}
+
+/**
  * Generate all local tools given the app's MapManager and DatasetCatalog.
  *
  * @param {import('./map-manager.js').MapManager} mapManager
  * @param {import('./dataset-catalog.js').DatasetCatalog} catalog
  * @param {import('./mcp-client.js').MCPClient} [mcpClient]
  * @param {{ forwardGeocode: Function }} [geocoder] - optional geocoder backend (see geocoder.js)
+ * @param {{ geolocateTool?: boolean }} [options] - opt-in flags for privacy-sensitive tools
  * @returns {Array<Object>} Tool definitions
  */
-export function createMapTools(mapManager, catalog, mcpClient, geocoder) {
+export function createMapTools(mapManager, catalog, mcpClient, geocoder, options = {}) {
     const allLayers = () => mapManager.getLayerSummaries();
     const vectorLayers = () => mapManager.getLayerSummaries().filter(l => l.type === 'vector');
 
@@ -332,6 +349,34 @@ How to use the result:
                     return JSON.stringify({ success: true, count: results.length, source: results[0].source, results });
                 } catch (err) {
                     return JSON.stringify({ success: false, error: `Geocoding failed: ${err.message}` });
+                }
+            },
+        }] : []),
+
+        // ---- Geolocation (device location; opt-in) ----
+        ...(options.geolocateTool ? [{
+            name: 'get_user_location',
+            description: `Get the user's CURRENT PHYSICAL location from their device (GPS/network), returning { latitude, longitude, accuracy_m }. Use this when the relevant place is *where the user is* — "near me", "my area", "what county/district am I in", "carbon here". For a place the user NAMES (a city, address, landmark), use \`geocode\` instead.
+
+The browser asks the user for permission. If they deny it (success:false), tell them you couldn't access their location and offer to let them name a place instead (\`geocode\`).
+
+Returns a single point. This tool does NOT move the map — call \`fly_to\` yourself if you want to recenter. To answer "what's here", feed the coordinate into a containing-polygon / point-in-hex query.`,
+            inputSchema: { type: 'object', properties: {} },
+            execute: async () => {
+                try {
+                    const pos = await getCurrentPositionAsync();
+                    return JSON.stringify({
+                        success: true,
+                        latitude: pos.coords.latitude,
+                        longitude: pos.coords.longitude,
+                        accuracy_m: pos.coords.accuracy,
+                    });
+                } catch (err) {
+                    const reason = err?.code === 1 ? 'The user denied location permission.'
+                        : err?.code === 2 ? 'The location is currently unavailable.'
+                        : err?.code === 3 ? 'The location request timed out.'
+                        : (err?.message || 'Unknown error.');
+                    return JSON.stringify({ success: false, error: `Could not get the user's location: ${reason}` });
                 }
             },
         }] : []),

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -434,11 +434,11 @@ Geocoding turns a free-text place reference — a street address, city, landmark
 1. A **`geocode` agent tool**, so the LLM resolves a *traceable* coordinate instead of inventing lat/lng from memory. The model is instructed to echo the matched location back and to ask for clarification on ambiguous queries (e.g. "Springfield").
 2. An optional **on-map search box** (the [maplibre-gl-geocoder](https://maplibre.org/maplibre-gl-geocoder/) control), enabled per-app.
 
-Geocoding is **on by default** using Nominatim (OpenStreetMap) — no API key required. Set `geocoder.enabled: false` to turn it off entirely (the `geocode` tool is then not registered).
+Geocoding is **opt-in**. Enable it with `geocoder.enabled: true` (registers the `geocode` tool) or `geocoder.search_box: true` (shows the search box and implies the backend). When neither is set, the `geocode` tool is not registered and no geocoder library is loaded. The default provider is Nominatim (OpenStreetMap) — no API key required.
 
 | Field | Type | Default | Description |
 |---|---|---|---|
-| `geocoder.enabled` | boolean | `true` | Register the `geocode` tool and (if configured) the search box. Set `false` to disable. |
+| `geocoder.enabled` | boolean | `false` | Register the `geocode` agent tool. `geocoder.search_box: true` implies this even when unset. |
 | `geocoder.provider` | string | `"nominatim"` | Backend: `"nominatim"`, `"photon"`, or `"maptiler"`. All are global. |
 | `geocoder.maptiler_key` | string | — | Required for the `maptiler` provider. Falls back to the basemap `maptiler_key` if not set here. |
 | `geocoder.email` | string | — | Contact email sent to Nominatim per its [usage policy](https://operations.osmfoundation.org/policies/nominatim/). Recommended for production apps. |
@@ -456,6 +456,20 @@ Geocoding is **on by default** using Nominatim (OpenStreetMap) — no API key re
   }
 }
 ```
+
+## Geolocation (optional)
+
+A "locate me" button ([MapLibre `GeolocateControl`](https://maplibre.org/maplibre-gl-js/docs/API/classes/GeolocateControl/)) that uses the device's geolocation to drop a marker and recenter the map on the user's position. Opt-in; off by default. The control ships with MapLibre GL JS, so there's nothing extra to load or pin.
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `geolocate` | boolean | `false` | Add the geolocate ("locate me") button to the top-left map controls. |
+
+```json
+{ "geolocate": true }
+```
+
+Geolocation requires a secure context (HTTPS) and a browser permission prompt — both already true for deployed apps. Once the user locates themselves, the agent can answer "what's near me?" via `get_map_state` (the map is now centered on them); no dedicated location tool is added.
 
 **Provider notes.** `nominatim` and `photon` are both free OpenStreetMap-based services with no key — Nominatim returns richer confidence signals, Photon is more lenient on request volume. `maptiler` is higher quality but needs an API key. All three are global (not US-only) and work directly from a static browser app.
 

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -434,11 +434,16 @@ Geocoding turns a free-text place reference — a street address, city, landmark
 1. A **`geocode` agent tool**, so the LLM resolves a *traceable* coordinate instead of inventing lat/lng from memory. The model is instructed to echo the matched location back and to ask for clarification on ambiguous queries (e.g. "Springfield").
 2. An optional **on-map search box** (the [maplibre-gl-geocoder](https://maplibre.org/maplibre-gl-geocoder/) control), enabled per-app.
 
-Geocoding is **opt-in**. Enable it with `geocoder.enabled: true` (registers the `geocode` tool) or `geocoder.search_box: true` (shows the search box and implies the backend). When neither is set, the `geocode` tool is not registered and no geocoder library is loaded. The default provider is Nominatim (OpenStreetMap) — no API key required.
+The two surfaces toggle **independently**, sharing one backend:
+
+- The **`geocode` agent tool** is **on by default** (opt-out) — it's invisible and just lets the LLM resolve coordinates traceably. Set `geocoder.enabled: false` to turn it off.
+- The **on-map search box** is **off by default** (opt-in) — it's a visible UI change, so apps enable it deliberately with `geocoder.search_box: true`.
+
+So `search_box: true` alone gives you the box *and* the tool; `enabled: false` + `search_box: true` gives the box with no agent tool; the default (no geocoder config) gives the tool with no box. The default provider is Nominatim (OpenStreetMap) — no API key required.
 
 | Field | Type | Default | Description |
 |---|---|---|---|
-| `geocoder.enabled` | boolean | `false` | Register the `geocode` agent tool. `geocoder.search_box: true` implies this even when unset. |
+| `geocoder.enabled` | boolean | `true` | Register the `geocode` agent tool. Set `false` to disable it (the search box can still run independently). |
 | `geocoder.provider` | string | `"nominatim"` | Backend: `"nominatim"`, `"photon"`, or `"maptiler"`. All are global. |
 | `geocoder.maptiler_key` | string | — | Required for the `maptiler` provider. Falls back to the basemap `maptiler_key` if not set here. |
 | `geocoder.email` | string | — | Contact email sent to Nominatim per its [usage policy](https://operations.osmfoundation.org/policies/nominatim/). Recommended for production apps. |

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -462,21 +462,24 @@ So `search_box: true` alone gives you the box *and* the tool; `enabled: false` +
 }
 ```
 
+**Provider notes.** `nominatim` and `photon` are both free OpenStreetMap-based services with no key — Nominatim returns richer confidence signals, Photon is more lenient on request volume. `maptiler` is higher quality but needs an API key. All three are global (not US-only) and work directly from a static browser app.
+
 ## Geolocation (optional)
 
-A "locate me" button ([MapLibre `GeolocateControl`](https://maplibre.org/maplibre-gl-js/docs/API/classes/GeolocateControl/)) that uses the device's geolocation to drop a marker and recenter the map on the user's position. Opt-in; off by default. The control ships with MapLibre GL JS, so there's nothing extra to load or pin.
+Answers "where am *I*?" using the device's location. Two **independently opt-in** surfaces, both off by default:
 
 | Field | Type | Default | Description |
 |---|---|---|---|
-| `geolocate` | boolean | `false` | Add the geolocate ("locate me") button to the top-left map controls. |
+| `geolocate.button` | boolean | `false` | "Locate me" button ([MapLibre `GeolocateControl`](https://maplibre.org/maplibre-gl-js/docs/API/classes/GeolocateControl/)) in the top-left map controls; recenters the map on the user. Ships with MapLibre — nothing to pin. |
+| `geolocate.agent_tool` | boolean | `false` | Register the `get_user_location` agent tool, which reads the device's coordinate so the agent can answer "what county/district am I in?", "carbon near me", etc. |
 
 ```json
-{ "geolocate": true }
+{ "geolocate": { "button": true, "agent_tool": true } }
 ```
 
-Geolocation requires a secure context (HTTPS) and a browser permission prompt — both already true for deployed apps. Once the user locates themselves, the agent can answer "what's near me?" via `get_map_state` (the map is now centered on them); no dedicated location tool is added.
+The shorthand `"geolocate": true` is equivalent to `{ "button": true }`.
 
-**Provider notes.** `nominatim` and `photon` are both free OpenStreetMap-based services with no key — Nominatim returns richer confidence signals, Photon is more lenient on request volume. `maptiler` is higher quality but needs an API key. All three are global (not US-only) and work directly from a static browser app.
+Note the deliberate asymmetry with the [`geocode` tool](#geocoding-optional), which is **on** by default: `get_user_location` reaches into the user's *actual device location*, so it stays **off** unless an app opts in — even though, like `geocode`, it's an invisible agent tool. Both require a secure context (HTTPS) and a browser permission prompt. The `get_user_location` tool returns `{ latitude, longitude, accuracy_m }` only — it does not move the map; the agent calls `fly_to` itself if it wants to recenter.
 
 ## Tool call auto-approve
 

--- a/test/map-tools.test.js
+++ b/test/map-tools.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import { extractJsonArray, createMapTools } from '../app/map-tools.js';
 
 describe('extractJsonArray', () => {
@@ -326,6 +326,50 @@ describe('geocode tool', () => {
         const out = JSON.parse(await getTool({ forwardGeocode }).execute({ query: 'x' }));
         expect(out).toMatchObject({ success: false });
         expect(out.error).toMatch(/429/);
+    });
+});
+
+describe('get_user_location tool', () => {
+    const stubMap = { getLayerSummaries: () => [] };
+    const stubCatalog = { records: new Map() };
+    const getTool = (options) =>
+        createMapTools(stubMap, stubCatalog, null, null, options).find(t => t.name === 'get_user_location');
+
+    const origNavigator = globalThis.navigator;
+    afterEach(() => {
+        if (origNavigator === undefined) delete globalThis.navigator;
+        else Object.defineProperty(globalThis, 'navigator', { value: origNavigator, configurable: true });
+    });
+    const setGeolocation = (geo) => {
+        Object.defineProperty(globalThis, 'navigator', { value: { geolocation: geo }, configurable: true });
+    };
+
+    it('is only registered when geolocateTool is opted in', () => {
+        expect(getTool({})).toBeUndefined();
+        expect(getTool({ geolocateTool: false })).toBeUndefined();
+        expect(getTool({ geolocateTool: true })).toBeDefined();
+    });
+
+    it('returns the coordinate on success', async () => {
+        setGeolocation({
+            getCurrentPosition: (ok) => ok({ coords: { latitude: 37.87, longitude: -122.27, accuracy: 12 } }),
+        });
+        const out = JSON.parse(await getTool({ geolocateTool: true }).execute({}));
+        expect(out).toEqual({ success: true, latitude: 37.87, longitude: -122.27, accuracy_m: 12 });
+    });
+
+    it('reports a permission denial as success:false with a clear reason', async () => {
+        setGeolocation({ getCurrentPosition: (_ok, err) => err({ code: 1, message: 'User denied Geolocation' }) });
+        const out = JSON.parse(await getTool({ geolocateTool: true }).execute({}));
+        expect(out.success).toBe(false);
+        expect(out.error).toMatch(/denied/i);
+    });
+
+    it('reports gracefully when geolocation is unavailable', async () => {
+        setGeolocation(undefined);
+        const out = JSON.parse(await getTool({ geolocateTool: true }).execute({}));
+        expect(out.success).toBe(false);
+        expect(out.error).toMatch(/not available/i);
     });
 });
 


### PR DESCRIPTION
Closes #244.

## What

Optional, **independently opt-in** location features. Three config keys, three distinct things — none on unless asked for (except the harmless geocode tool, which stays default-on).

### 1. Geolocation — "where am *I*?" (`geolocate.*`)
Promoted from a flat boolean to an object with two independent surfaces:

| Surface | What it is | Config key | Default |
|---|---|---|---|
| locate-me button (#244) | [MapLibre `GeolocateControl`](https://maplibre.org/maplibre-gl-js/docs/API/classes/GeolocateControl/); recenters on the user | `geolocate.button` | off |
| `get_user_location` tool | agent reads device GPS → `{ latitude, longitude, accuracy_m }` | `geolocate.agent_tool` | off |

```json
{ "geolocate": { "button": true, "agent_tool": true } }
```

`geolocate: true` is back-compat shorthand for `{ "button": true }`. The `get_user_location` tool returns the coordinate only — it does **not** move the map; the agent calls `fly_to` itself. On permission denial / unavailability it returns `success:false` with a clear reason. This is the primitive for "carbon in my district": tool → lat/lng → existing H3/SQL flow does the rest.

### 2. Geocoding — "where is *that place*?" (`geocoder.*`), decoupled
The backend's two surfaces now toggle independently:

| Surface | Config key | Default |
|---|---|---|
| `geocode` agent tool | `geocoder.enabled` | **on** (opt-out) |
| on-map search box | `geocoder.search_box` | off (opt-in) |

Previously the tool was registered whenever the backend existed, so `search_box` pulled it in; now you can run the box with no agent tool.

## Default asymmetry (deliberate)

Both `geocode` and `get_user_location` are invisible agent tools, but opposite defaults: `geocode` is **on** (just resolves typed place names — harmless), `get_user_location` is **off** (reaches the user's real device location — privacy-sensitive, opt-in).

## Not breaking

The geocode tool stays on by default (matches today). The template's `geolocate: true` + `geocoder.search_box: true` keep working unchanged.

## Tests

`npm test` — 290 passing (+4 for `get_user_location`: opt-in gating, success, permission-denied, unavailable). The `app/main.js` wiring is browser-bound (0% harness coverage by design), verified on a deployed app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)