### PR TITLE
feat(catalog): soft-validate asset.id against STAC keys (#177)

### DIFF
--- a/app/dataset-catalog.js
+++ b/app/dataset-catalog.js
@@ -235,6 +235,40 @@ export class DatasetCatalog {
     }
 
     /**
+     * Soft-validate configured `asset.id`s against the STAC collection's asset keys (#177).
+     *
+     * Emits a single, informative `console.warn` per configured id that doesn't match a
+     * STAC asset key, naming the collection, the offending id, and the keys that *are*
+     * available. Warn-only by design: drift is tolerated because an asset may be added
+     * later, and the asset-id-as-source-layer fallback can still render a mismatched id —
+     * but that silent key-drift is exactly what's expensive to debug in the field, so we
+     * surface it in dev logs. The `versions` form validates each version's `asset_id`
+     * (the logical `id` of a versioned entry is not itself a STAC key, so it's skipped).
+     *
+     * @param {Object} collection - STAC collection (reads `.id` and `.assets`)
+     * @param {Array<{assetId: string, config: Object}>} assetConfigList
+     * @private
+     */
+    _validateAssetIds(collection, assetConfigList) {
+        const available = Object.keys(collection.assets || {});
+        const availableSet = new Set(available);
+        const warnMissing = (id) => console.warn(
+            `[Catalog] Asset id "${id}" configured for collection "${collection.id}" ` +
+            `does not match any STAC asset key. Available: ${available.join(', ') || '(none)'}`
+        );
+
+        for (const { assetId, config } of assetConfigList) {
+            if (config.versions && Array.isArray(config.versions)) {
+                for (const v of config.versions) {
+                    if (v.asset_id && !availableSet.has(v.asset_id)) warnMissing(v.asset_id);
+                }
+            } else if (!availableSet.has(assetId)) {
+                warnMissing(assetId);
+            }
+        }
+    }
+
+    /**
      * Extract map-displayable assets (PMTiles, GeoJSON, and COGs).
      * Each becomes a potential map layer.
      *
@@ -251,6 +285,9 @@ export class DatasetCatalog {
         const stacAssets = collection.assets || {};
 
         if (assetConfigList) {
+            // Soft-validate configured asset ids against STAC keys before building (#177)
+            this._validateAssetIds(collection, assetConfigList);
+
             // Filtered mode: iterate config entries so aliases and ordering are respected
             for (const { key, assetId, config } of assetConfigList) {
 

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -539,6 +539,10 @@ https://radiantearth.github.io/stac-browser/#/external/s3-west.nrp-nautilus.io/p
 
 Open a collection → click the **Assets** tab. The keys listed there (e.g., `"pmtiles"`, `"v2-total-2024-cog"`) are the `id` values to use. For PMTiles vector layers, the asset's `vector:layers` field gives the internal layer name used by MapLibre (the app reads this automatically).
 
+::: tip Mismatched asset IDs are flagged at startup
+If a configured `id` (or a `versions` entry's `asset_id`) doesn't match any key in the STAC collection, the app logs a `console.warn` at load naming the collection, the offending id, and the available keys. It's a warning, not an error — a mismatched id can still render via a source-layer fallback — but the warning surfaces the silent key-drift that's otherwise expensive to debug. Check the browser console if a layer behaves unexpectedly.
+:::
+
 ## Worked examples
 
 ### Point features as circles

--- a/test/dataset-catalog.test.js
+++ b/test/dataset-catalog.test.js
@@ -479,6 +479,50 @@ describe('DatasetCatalog.extractMapLayers', () => {
     });
 });
 
+describe('DatasetCatalog asset-id soft validation (issue #177)', () => {
+    const cat = new DatasetCatalog();
+    const collectionWithAssets = (assets) =>
+        stacCollection({ id: 'demo', title: 'Demo', assets });
+
+    let warnSpy;
+    beforeEach(() => { warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {}); });
+    afterEach(() => { warnSpy.mockRestore(); });
+
+    it('warns once, naming collection + bad id + available keys, when an asset id is not a STAC key', () => {
+        cat.extractMapLayers(collectionWithAssets({
+            'cd-pmtiles': { type: 'application/vnd.pmtiles', href: 'https://x/cd.pmtiles' },
+        }), {}, [{ key: 'cd', assetId: 'cd', config: {} }]);
+
+        expect(warnSpy).toHaveBeenCalledTimes(1);
+        const msg = warnSpy.mock.calls[0][0];
+        expect(msg).toContain('"cd"');
+        expect(msg).toContain('"demo"');
+        expect(msg).toContain('cd-pmtiles');
+    });
+
+    it('produces no warning when every configured id matches a STAC asset key', () => {
+        cat.extractMapLayers(collectionWithAssets({
+            holdings: { type: 'application/vnd.pmtiles', href: 'https://x/h.pmtiles' },
+        }), {}, [{ key: 'holdings', assetId: 'holdings', config: {} }]);
+        expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it('validates each asset_id in a versioned entry (not the logical id) and warns per offender', () => {
+        cat.extractMapLayers(collectionWithAssets({
+            l3: { type: 'application/vnd.pmtiles', href: 'https://x/l3.pmtiles' },
+        }), {}, [{
+            key: 'basins',
+            assetId: 'basins',  // logical id — not itself a STAC key, must not warn
+            config: { versions: [
+                { label: 'L3', asset_id: 'l3' },     // valid
+                { label: 'L4', asset_id: 'l4-typo' }, // invalid
+            ] },
+        }]);
+        expect(warnSpy).toHaveBeenCalledTimes(1);
+        expect(warnSpy.mock.calls[0][0]).toContain('l4-typo');
+    });
+});
+
 describe('DatasetCatalog.getMapLayerConfigs', () => {
     let cat;
     beforeEach(() => { cat = new DatasetCatalog(); });


### PR DESCRIPTION
Closes #177.

At startup, `extractMapLayers` now soft-validates each configured `asset.id` (and each `asset_id` inside a `versions` entry) against the STAC collection's asset keys. On drift it emits a single `console.warn` naming the collection, the offending id, and the available keys.

**Warn, not error** — per the issue. Drift is tolerated because an asset may be added later, and the asset-id-as-source-layer fallback can still render a mismatched id. This is observability only; valid configs produce no warning and behavior is unchanged.

This catches the silent key-drift class found in #175 (TPL had `id: "cd"` vs STAC key `cd-pmtiles`), which renders by accident but is expensive to debug downstream.

### Acceptance criteria
- [x] Mismatched id logs one informative warning per offending entry
- [x] Matching configs produce no warning
- [x] No behavior change for valid configs (observability only)
- [x] The `versions` form validates each `asset_id` in the list

### Tests
3 new tests in `test/dataset-catalog.test.js` (warn content, no-warn-on-match, per-version validation). Full suite: 293 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)