### PR TITLE
fix(hex): render GeoJSON hex tilesets instead of 404ing on .pbf (#252)

### DIFF
--- a/app/hex-layer-helpers.js
+++ b/app/hex-layer-helpers.js
@@ -81,3 +81,42 @@ export function buildFillColorExpression(valueColumn, valueStats, palette) {
         ['match', ['get', 'res'], ...branches, 'rgba(0,0,0,0)'],
     ];
 }
+
+/**
+ * Build a *flat* `fill-color` expression for a single-resolution hex layer.
+ *
+ * GeoJSON hex tilesets (server `format: "geojson"`) are materialized at one H3
+ * resolution (finest_res) and their features carry only the value columns — no
+ * `res` property — so the per-`res` `match` that {@link buildFillColorExpression}
+ * emits would render every feature transparent (match fallback). This helper
+ * interpolates directly over a single `{min, max}` instead.
+ *
+ * Null values render transparent; a collapsed range (min == max) renders a flat
+ * palette-midpoint color.
+ *
+ * @param {string} valueColumn - Feature property to color by.
+ * @param {{min: number, max: number}} stats - Single-resolution value range.
+ * @param {string} palette - One of the keys in PALETTES.
+ * @returns {Array} MapLibre expression.
+ */
+export function buildFlatFillColorExpression(valueColumn, stats, palette) {
+    if (!(palette in PALETTES)) {
+        throw new Error(`Unknown palette '${palette}'. Valid: ${Object.keys(PALETTES).join(', ')}`);
+    }
+    if (!stats || stats.min == null || stats.max == null) {
+        throw new Error('stats must contain numeric min and max');
+    }
+
+    const [c0, c1, c2] = PALETTES[palette];
+    const { min, max } = stats;
+    const branch = (min < max)
+        ? ['interpolate', ['linear'], ['get', valueColumn], min, c0, (min + max) / 2, c1, max, c2]
+        : c1;
+
+    return [
+        'case',
+        ['==', ['get', valueColumn], null],
+        'rgba(0,0,0,0)',
+        branch,
+    ];
+}

--- a/app/map-manager.js
+++ b/app/map-manager.js
@@ -12,7 +12,7 @@
  * No knowledge of LLMs, tools, or chat — pure map operations.
  */
 
-import { extractHashFromUrl, buildFillColorExpression } from './hex-layer-helpers.js';
+import { extractHashFromUrl, buildFillColorExpression, buildFlatFillColorExpression } from './hex-layer-helpers.js';
 
 const BASEMAPS = {
     natgeo: {
@@ -503,12 +503,19 @@ export class MapManager {
      * @returns {{success: boolean, layer_id?: string, error?: string}}
      */
     addHexTileLayer(opts) {
-        const { tileUrl, valueColumn, valueStats, bounds, palette, opacity, displayName, fitBounds, layerName, resolution } = opts;
-        const sourceLayer = layerName || 'layer';
+        const { tileUrl, valueColumn, valueStats, bounds, palette, opacity, displayName, fitBounds, layerName, resolution, format, geojsonUrl } = opts;
+        const isGeoJson = format === 'geojson';
+        const sourceLayer = isGeoJson ? null : (layerName || 'layer');
 
+        // The hash always comes from tile_url_template (returned by
+        // register_hex_tiles for both formats), never from geojson_url whose
+        // shape (.../hex/<hash>/data.geojson) extractHashFromUrl doesn't parse.
         const hash = extractHashFromUrl(tileUrl);
         if (!hash) {
             return { success: false, error: `Invalid tile_url — expected template from register_hex_tiles ending in /tiles/hex/<hash>/{z}/{x}/{y}.pbf` };
+        }
+        if (isGeoJson && !geojsonUrl) {
+            return { success: false, error: 'format "geojson" requires geojson_url from register_hex_tiles' };
         }
         const layerId = `hex-${hash}`;
 
@@ -536,7 +543,15 @@ export class MapManager {
 
         let fillColor;
         try {
-            fillColor = buildFillColorExpression(valueColumn, valueStats, palette);
+            if (isGeoJson) {
+                // Single-resolution: GeoJSON features carry no `res`, so the
+                // per-res `match` would render everything transparent. Paint a
+                // flat ramp over the finest (largest) resolution's stats.
+                const finestRes = availableRes[availableRes.length - 1];
+                fillColor = buildFlatFillColorExpression(valueColumn, valueStats.by_res[finestRes], palette);
+            } else {
+                fillColor = buildFillColorExpression(valueColumn, valueStats, palette);
+            }
         } catch (err) {
             return { success: false, error: err.message };
         }
@@ -554,12 +569,17 @@ export class MapManager {
         // render at most zoom levels. Let MapLibre render whatever the tile
         // contains; buildFillColorExpression's per-res `match` picks the
         // right branch for each tile's resolution.
-        this.map.addSource(layerId, { type: 'vector', tiles: [tileUrl], minzoom: 0, maxzoom: 14 });
+        if (isGeoJson) {
+            this.map.addSource(layerId, { type: 'geojson', data: geojsonUrl });
+        } else {
+            this.map.addSource(layerId, { type: 'vector', tiles: [tileUrl], minzoom: 0, maxzoom: 14 });
+        }
         this.map.addLayer({
             id: layerId,
             type: 'fill',
             source: layerId,
-            'source-layer': sourceLayer,
+            // GeoJSON sources have no source-layer; omit it for that branch.
+            ...(isGeoJson ? {} : { 'source-layer': sourceLayer }),
             layout: { visibility: 'visible' },
             paint,
         });

--- a/app/map-tools.js
+++ b/app/map-tools.js
@@ -401,10 +401,14 @@ Pass the following fields straight through from the register_hex_tiles return va
   - value_stats           ← value_stats[value_column]  (has { by_res: { "<res>": { min, max } } })
   - bounds                ← bounds
   - layer_name            ← layer_name (when present; defaults to "layer" otherwise)
+  - format                ← format ("geojson" or "vector"; defaults to "vector")
+  - geojson_url           ← geojson_url (REQUIRED when format="geojson"; ignored otherwise)
 
-Hexes get finer as the user zooms in: the tile server's pyramid serves the appropriate H3 resolution for each zoom level automatically. If the user wants a coarser overall view, re-run \`register_hex_tiles\` with the SQL projected to a coarser resolution by wrapping the first column in \`h3_cell_to_parent(<h3_col>, <target_res>)\` — the server auto-detects the H3 resolution from that column.
+ALWAYS pass \`format\` and (when present) \`geojson_url\` through. The server auto-selects GeoJSON for small/single-resolution tilesets and vector tiles otherwise; for GeoJSON the \`.pbf\` tile_url 404s, so the layer renders blank unless you also pass format="geojson" + geojson_url.
 
-IMPORTANT: The tile_url must be the exact tile_url_template returned by register_hex_tiles — the tool rejects other URLs.
+Hexes get finer as the user zooms in: the tile server's pyramid serves the appropriate H3 resolution for each zoom level automatically (vector format only). If the user wants a coarser overall view, re-run \`register_hex_tiles\` with the SQL projected to a coarser resolution by wrapping the first column in \`h3_cell_to_parent(<h3_col>, <target_res>)\` — the server auto-detects the H3 resolution from that column.
+
+IMPORTANT: tile_url must be the exact tile_url_template returned by register_hex_tiles — the tool rejects other URLs. It supplies the layer's content hash for both formats (the GeoJSON layer still keys off it).
 
 The returned layer_id can be used with show_layer / hide_layer / set_style / set_filter / get_map_state like any other vector layer, and with remove_hex_tile_layer to free the source.`,
             inputSchema: {
@@ -421,7 +425,13 @@ The returned layer_id can be used with show_layer / hide_layer / set_style / set
                         items: { type: 'number' },
                         description: '[w, s, e, n] from register_hex_tiles.bounds'
                     },
-                    layer_name: { type: 'string', description: 'MVT source-layer name from register_hex_tiles.layer_name (defaults to "layer" when omitted)' },
+                    layer_name: { type: 'string', description: 'MVT source-layer name from register_hex_tiles.layer_name (defaults to "layer" when omitted; ignored for format="geojson")' },
+                    format: {
+                        type: 'string',
+                        enum: ['vector', 'geojson'],
+                        description: 'Tileset format from register_hex_tiles.format. "vector" (default) reads MVT tiles from tile_url; "geojson" reads the whole FeatureCollection from geojson_url.'
+                    },
+                    geojson_url: { type: 'string', description: 'register_hex_tiles.geojson_url — REQUIRED when format="geojson"' },
                     display_name: { type: 'string', description: 'Optional human-readable layer name (default: "Hex: <value_column>")' },
                     palette: {
                         type: 'string',
@@ -445,6 +455,8 @@ The returned layer_id can be used with show_layer / hide_layer / set_style / set
                     displayName,
                     fitBounds: args.fit_bounds !== false,
                     layerName: args.layer_name,
+                    format: args.format,
+                    geojsonUrl: args.geojson_url,
                 });
                 return JSON.stringify(result);
             },

--- a/test/hex-layer-helpers.test.js
+++ b/test/hex-layer-helpers.test.js
@@ -25,7 +25,7 @@ describe('extractHashFromUrl', () => {
   });
 });
 
-import { PALETTES, buildFillColorExpression } from '../app/hex-layer-helpers.js';
+import { PALETTES, buildFillColorExpression, buildFlatFillColorExpression } from '../app/hex-layer-helpers.js';
 
 describe('PALETTES', () => {
   it('exposes three named 3-stop palettes', () => {
@@ -116,5 +116,34 @@ describe('buildFillColorExpression', () => {
         .toThrow(/by_res/);
     expect(() => buildFillColorExpression('v', null, 'viridis'))
         .toThrow(/by_res/);
+  });
+});
+
+describe('buildFlatFillColorExpression', () => {
+  it('builds a case-wrapped flat interpolate (no res match)', () => {
+    const expr = buildFlatFillColorExpression('count', { min: 1, max: 100 }, 'viridis');
+
+    expect(expr[0]).toBe('case');
+    expect(expr[1]).toEqual(['==', ['get', 'count'], null]);
+    expect(expr[2]).toBe('rgba(0,0,0,0)');
+
+    // No `match` / no `['get','res']` — interpolates directly over the value.
+    expect(expr[3]).toEqual(['interpolate', ['linear'], ['get', 'count'],
+      1, '#440154', 50.5, '#21918c', 100, '#fde725']);
+  });
+
+  it('collapses a min == max range to the palette midpoint color', () => {
+    const expr = buildFlatFillColorExpression('count', { min: 5, max: 5 }, 'viridis');
+    expect(expr[3]).toBe('#21918c');
+  });
+
+  it('throws on unknown palette', () => {
+    expect(() => buildFlatFillColorExpression('v', { min: 0, max: 1 }, 'nope'))
+        .toThrow(/Unknown palette/);
+  });
+
+  it('throws when stats lack numeric min/max', () => {
+    expect(() => buildFlatFillColorExpression('v', null, 'viridis')).toThrow(/min and max/);
+    expect(() => buildFlatFillColorExpression('v', { min: 0 }, 'viridis')).toThrow(/min and max/);
   });
 });

--- a/test/map-manager.hex.test.js
+++ b/test/map-manager.hex.test.js
@@ -230,6 +230,80 @@ describe('MapManager.addHexTileLayer', () => {
     });
 });
 
+describe('MapManager.addHexTileLayer (format: geojson)', () => {
+    let mm;
+    beforeEach(() => { mm = createManager(); });
+
+    const geojsonOpts = (overrides = {}) => ({
+        tileUrl: 'https://example.com/tiles/hex/gj123/{z}/{x}/{y}.pbf',
+        geojsonUrl: 'https://s3.example.com/hex/gj123/data.geojson',
+        format: 'geojson',
+        valueColumn: 'count',
+        valueStats: { by_res: { '9': { min: 1, max: 100 } } },
+        bounds: [-122, 38, -121, 39],
+        palette: 'viridis',
+        opacity: 0.7,
+        displayName: 'Carbon',
+        fitBounds: false,
+        ...overrides,
+    });
+
+    it('registers a GeoJSON source pointed at geojson_url (not the .pbf)', () => {
+        const result = mm.addHexTileLayer(geojsonOpts());
+        expect(result.success).toBe(true);
+        expect(result.layer_id).toBe('hex-gj123');
+
+        const src = mm.map._sources.get('hex-gj123');
+        expect(src).toEqual({ type: 'geojson', data: 'https://s3.example.com/hex/gj123/data.geojson' });
+    });
+
+    it('builds a fill layer with NO source-layer and a flat (non-res-match) paint', () => {
+        mm.addHexTileLayer(geojsonOpts());
+        const layer = mm.map._layers.get('hex-gj123');
+        expect(layer.type).toBe('fill');
+        expect(layer.source).toBe('hex-gj123');
+        expect('source-layer' in layer).toBe(false);
+
+        // Flat interpolate directly over the value — never branches on `res`,
+        // which GeoJSON features don't carry.
+        const expr = layer.paint['fill-color'];
+        const json = JSON.stringify(expr);
+        expect(json).not.toContain('match');
+        expect(json).not.toContain('"res"');
+        expect(expr[3][0]).toBe('interpolate');
+    });
+
+    it('derives the hash from tile_url, not geojson_url', () => {
+        const r = mm.addHexTileLayer(geojsonOpts());
+        // geojson_url shape (.../hex/<hash>/data.geojson) isn't parseable by
+        // extractHashFromUrl; the hash must come from the .pbf template.
+        expect(r.layer_id).toBe('hex-gj123');
+        expect(mm.layers.get('hex-gj123').sourceLayer).toBeNull();
+    });
+
+    it('uses the finest (largest) resolution stats for the flat ramp', () => {
+        mm.addHexTileLayer(geojsonOpts({
+            valueStats: { by_res: { '6': { min: 1, max: 9999 }, '9': { min: 2, max: 80 } } },
+        }));
+        const expr = mm.map._layers.get('hex-gj123').paint['fill-color'];
+        // finest res = 9 → domain min 2, max 80
+        expect(expr[3]).toEqual(['interpolate', ['linear'], ['get', 'count'],
+            2, '#440154', 41, '#21918c', 80, '#fde725']);
+    });
+
+    it('errors when format is geojson but geojson_url is missing', () => {
+        const r = mm.addHexTileLayer(geojsonOpts({ geojsonUrl: undefined }));
+        expect(r.success).toBe(false);
+        expect(r.error).toMatch(/geojson_url/);
+    });
+
+    it('still requires a valid tile_url for the hash', () => {
+        const r = mm.addHexTileLayer(geojsonOpts({ tileUrl: 'https://example.com/bad' }));
+        expect(r.success).toBe(false);
+        expect(r.error).toMatch(/Invalid tile_url/);
+    });
+});
+
 describe('MapManager.removeHexTileLayer', () => {
     let mm;
     beforeEach(() => { mm = createManager(); });


### PR DESCRIPTION
Fixes #252.

## Problem

`add_hex_tile_layer` only ever built a `{type:'vector'}` source pointed at the `.pbf` tile endpoint. Since mcp-data-server#181, `register_hex_tiles` auto-selects **GeoJSON** for small/single-resolution tilesets, whose `.pbf` endpoint deliberately 404s — so every GeoJSON hex render came up blank.

## A subtlety beyond "just add a geojson source"

Branching the source type alone isn't enough. Hex fill is painted by `buildFillColorExpression`, which does `['match', ['get','res'], …]` because the **vector** pyramid packs multiple H3 resolutions per tile. The GeoJSON export carries **only the value columns** as feature properties — no `res` — so reusing that paint would send every feature to the `match` fallback (`rgba(0,0,0,0)`), still blank.

So the GeoJSON branch needs a **flat** ramp over the finest-res stats.

## Changes

- **`addHexTileLayer`** branches on `format`:
  - `geojson` → `addSource({type:'geojson', data: geojson_url})` + fill layer with **no `source-layer`** and a flat ramp from new `buildFlatFillColorExpression` (built over `value_stats.by_res[finest_res]` + the chosen palette, so existing palette/opacity/legend wiring still applies).
  - `vector` → existing path, unchanged.
- Hash still derives from `tile_url_template` (returned for both formats); `geojson_url`'s shape (`…/hex/<hash>/data.geojson`) isn't parseable by `extractHashFromUrl`.
- Tool schema gains `format` + `geojson_url`; description/prompt updated to pass them through and stop steering toward `tile_url`-only.

## No conflict with existing GeoJSON rendering

The three other GeoJSON pipelines are isolated from the hex path and unchanged: curated catalog layers (`dataset-catalog.js` → generic `addLayer`, ids `<ds>/<asset>`), the `h3geo.js` cell overlay (fixed source id, interactive cell drawing), and `animation-manager.js` tracks. The hex path keeps its own `hex-<hash>` ids and shares no styling code, so there's no id collision or shared-state confusion.

## Tests

`npm test` → 303 passing. Added coverage in `test/hex-layer-helpers.test.js` (flat ramp: structure, min==max collapse, validation) and `test/map-manager.hex.test.js` (geojson source shape, no `source-layer`, flat non-`res` paint, hash from `tile_url`, finest-res selection, missing-`geojson_url` error).

Browser render verification (MapLibre) is manual per the coverage policy — recommend a quick check on the padus dev app against the Yolo County hash from the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
