### PR TITLE
fix(set_style): repoint hex paint to the layer's real value column (#259)

### DIFF
--- a/app/hex-layer-helpers.js
+++ b/app/hex-layer-helpers.js
@@ -83,6 +83,46 @@ export function buildFillColorExpression(valueColumn, valueStats, palette) {
 }
 
 /**
+ * Rewrite the `["get", <prop>]` value references in a MapLibre expression to
+ * target a hex layer's actual value column.
+ *
+ * The agent constructs `set_style` paint expressions without a reliable signal
+ * of a dynamic hex layer's value column, so it defaults to `["get", "count"]`
+ * (only correct for `agg="COUNT"` tilesets). On a layer whose property is e.g.
+ * `species_richness`, that `get` resolves to null on every feature and the ramp
+ * yields no color — a silent no-op (see issue #259). This pure walker repoints
+ * any value-bearing `get` to `valueColumn` so the recolor takes effect.
+ *
+ * `res` is left untouched: it's the per-feature resolution key the per-res
+ * `match` branches on (see {@link buildFillColorExpression}), not a value.
+ *
+ * @param {*} expr - A MapLibre paint value (expression array, literal, etc.).
+ * @param {string} valueColumn - The layer's real value property.
+ * @returns {{ value: *, replaced: string[] }} The rewritten value and the
+ *   distinct original property names that were repointed (empty if none).
+ */
+export function rewriteValueColumn(expr, valueColumn) {
+    const replaced = new Set();
+
+    const walk = (node) => {
+        if (!Array.isArray(node)) return node;
+        // ["get", "<prop>"] — the only form we repoint. Longer get forms
+        // (e.g. ["get", key, obj]) and other operators recurse normally.
+        if (node.length === 2 && node[0] === 'get' && typeof node[1] === 'string') {
+            const prop = node[1];
+            if (prop !== valueColumn && prop !== 'res') {
+                replaced.add(prop);
+                return ['get', valueColumn];
+            }
+            return node;
+        }
+        return node.map(walk);
+    };
+
+    return { value: walk(expr), replaced: [...replaced] };
+}
+
+/**
  * Build a *flat* `fill-color` expression for a single-resolution hex layer.
  *
  * GeoJSON hex tilesets (server `format: "geojson"`) are materialized at one H3

--- a/app/map-manager.js
+++ b/app/map-manager.js
@@ -12,7 +12,7 @@
  * No knowledge of LLMs, tools, or chat — pure map operations.
  */
 
-import { extractHashFromUrl, buildFillColorExpression, buildFlatFillColorExpression } from './hex-layer-helpers.js';
+import { extractHashFromUrl, buildFillColorExpression, buildFlatFillColorExpression, rewriteValueColumn } from './hex-layer-helpers.js';
 
 const BASEMAPS = {
     natgeo: {
@@ -595,6 +595,7 @@ export class MapManager {
             displayName,
             type: 'vector',
             sourceLayer,
+            valueColumn,
             columns: [],
             visible: true,
             filter: null,
@@ -765,8 +766,20 @@ export class MapManager {
         const state = this.layers.get(layerId);
         if (!state) return { success: false, error: `Unknown layer: ${layerId}` };
 
+        // Hex layers carry a single dynamic value column (e.g. "species_richness").
+        // The agent often emits a data-driven expression against a guessed
+        // property name — typically ["get","count"] — which resolves to null on
+        // every feature and silently fails to recolor (issue #259). Repoint any
+        // value-bearing `get` to the layer's real column before applying.
+        const corrected = new Set();
         const results = [];
-        for (const [prop, value] of Object.entries(paintProps)) {
+        for (const [prop, rawValue] of Object.entries(paintProps)) {
+            let value = rawValue;
+            if (state.valueColumn) {
+                const { value: rewritten, replaced } = rewriteValueColumn(rawValue, state.valueColumn);
+                value = rewritten;
+                replaced.forEach(p => corrected.add(p));
+            }
             try {
                 this.map.setPaintProperty(state.mapLayerId, prop, value);
                 results.push({ property: prop, success: true });
@@ -782,6 +795,9 @@ export class MapManager {
             layer: layerId,
             displayName: state.displayName,
             updates: results,
+            ...(corrected.size > 0 && {
+                note: `Repointed value reference(s) ${[...corrected].map(p => `"${p}"`).join(', ')} to this layer's actual value column "${state.valueColumn}".`,
+            }),
             ...(failed.length > 0 && {
                 error: `${failed.length}/${results.length} property update(s) failed: ${failed.join(', ')}. Layer type is "${layerType}" — use ${layerType}-prefixed paint properties (see set_style tool description for the supported set).`,
             }),
@@ -820,6 +836,9 @@ export class MapManager {
                 filterDescription: state.filter ? this.describeFilter(state.filter) : null,
                 hasDefaultFilter: state.defaultFilter !== null,
                 defaultFilterDescription: state.defaultFilter ? this.describeFilter(state.defaultFilter) : null,
+                // Hex layers color by a single dynamic column; expose it so the
+                // agent styles against the real property, not a guess (#259).
+                ...(state.valueColumn && { valueColumn: state.valueColumn }),
             };
         }
         return { success: true, layers };

--- a/app/map-tools.js
+++ b/app/map-tools.js
@@ -247,6 +247,8 @@ Examples:
   Data-driven gradient: { "fill-color": ["interpolate", ["linear"], ["get", "PROP"], 0, "#low", 100, "#high"] }
   Stepped: { "fill-color": ["step", ["get", "PROP"], "#c1", 10, "#c2", 50, "#c3"] }
 
+For dynamic hex layers (\`hex-…\` ids from add_hex_tile_layer), \`PROP\` is the layer's value column (the \`value_column\` you passed to add_hex_tile_layer, e.g. "species_richness") — NOT "count" unless that is literally the column. If unsure, call get_map_state to read the layer's \`valueColumn\`.
+
 ${pickLayerNudge}
 
 Available layers:

--- a/test/hex-layer-helpers.test.js
+++ b/test/hex-layer-helpers.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { extractHashFromUrl } from '../app/hex-layer-helpers.js';
+import { extractHashFromUrl, rewriteValueColumn } from '../app/hex-layer-helpers.js';
 
 describe('extractHashFromUrl', () => {
   it('extracts hash from a valid MCP tile URL template', () => {
@@ -145,5 +145,49 @@ describe('buildFlatFillColorExpression', () => {
   it('throws when stats lack numeric min/max', () => {
     expect(() => buildFlatFillColorExpression('v', null, 'viridis')).toThrow(/min and max/);
     expect(() => buildFlatFillColorExpression('v', { min: 0 }, 'viridis')).toThrow(/min and max/);
+  });
+});
+
+describe('rewriteValueColumn', () => {
+  it('repoints a guessed ["get","count"] to the real value column', () => {
+    const expr = ['interpolate', ['linear'], ['get', 'count'], 1, '#440154', 125, '#FDE725'];
+    const { value, replaced } = rewriteValueColumn(expr, 'species_richness');
+    expect(value).toEqual(
+      ['interpolate', ['linear'], ['get', 'species_richness'], 1, '#440154', 125, '#FDE725']);
+    expect(replaced).toEqual(['count']);
+  });
+
+  it('leaves an expression that already targets the value column untouched', () => {
+    const expr = ['interpolate', ['linear'], ['get', 'species_richness'], 0, '#000', 10, '#fff'];
+    const { value, replaced } = rewriteValueColumn(expr, 'species_richness');
+    expect(value).toEqual(expr);
+    expect(replaced).toEqual([]);
+  });
+
+  it('does not touch the per-resolution `res` key', () => {
+    const expr = ['case', ['==', ['get', 'count'], null], 'rgba(0,0,0,0)',
+      ['match', ['get', 'res'], 3, ['get', 'count'], 'rgba(0,0,0,0)']];
+    const { value, replaced } = rewriteValueColumn(expr, 'pop');
+    expect(value).toEqual(['case', ['==', ['get', 'pop'], null], 'rgba(0,0,0,0)',
+      ['match', ['get', 'res'], 3, ['get', 'pop'], 'rgba(0,0,0,0)']]);
+    expect(replaced).toEqual(['count']);
+  });
+
+  it('reports each distinct replaced property once', () => {
+    const expr = ['+', ['get', 'count'], ['get', 'foo'], ['get', 'count']];
+    const { replaced } = rewriteValueColumn(expr, 'val');
+    expect(replaced.sort()).toEqual(['count', 'foo']);
+  });
+
+  it('passes through literals and non-expression values', () => {
+    expect(rewriteValueColumn('red', 'val')).toEqual({ value: 'red', replaced: [] });
+    expect(rewriteValueColumn(0.7, 'val')).toEqual({ value: 0.7, replaced: [] });
+  });
+
+  it('leaves longer get forms (["get", key, obj]) alone', () => {
+    const expr = ['get', 'count', ['properties']];
+    const { value, replaced } = rewriteValueColumn(expr, 'val');
+    expect(value).toEqual(expr);
+    expect(replaced).toEqual([]);
   });
 });

--- a/test/map-manager.style.test.js
+++ b/test/map-manager.style.test.js
@@ -59,3 +59,54 @@ describe('MapManager.setStyle', () => {
         expect(r.error).toMatch(/Unknown layer/);
     });
 });
+
+describe('MapManager.setStyle — hex value-column rewrite (#259)', () => {
+    function createHexManager(valueColumn) {
+        const applied = {};
+        const map = {
+            getLayer: () => ({ id: 'hex-layer', type: 'fill' }),
+            setPaintProperty(id, prop, value) { applied[prop] = value; },
+        };
+        const mm = Object.create(MapManager.prototype);
+        mm.map = map;
+        mm.layers = new Map([[
+            'hex-abc',
+            { mapLayerId: 'hex-layer', displayName: 'Richness', valueColumn },
+        ]]);
+        return { mm, applied };
+    }
+
+    it('repoints a guessed ["get","count"] to the layer value column and applies the corrected paint', () => {
+        const { mm, applied } = createHexManager('species_richness');
+        const r = mm.setStyle('hex-abc', {
+            'fill-color': ['interpolate', ['log'], ['get', 'count'], 1, '#440154', 125, '#FDE725'],
+            'fill-opacity': 0.7,
+        });
+        expect(r.success).toBe(true);
+        expect(applied['fill-color']).toEqual(
+            ['interpolate', ['log'], ['get', 'species_richness'], 1, '#440154', 125, '#FDE725']);
+        expect(r.note).toMatch(/"count".*"species_richness"/);
+    });
+
+    it('leaves an already-correct expression unchanged and emits no note', () => {
+        const { mm, applied } = createHexManager('species_richness');
+        const r = mm.setStyle('hex-abc', {
+            'fill-color': ['interpolate', ['linear'], ['get', 'species_richness'], 0, '#000', 10, '#fff'],
+        });
+        expect(r.success).toBe(true);
+        expect(applied['fill-color']).toEqual(
+            ['interpolate', ['linear'], ['get', 'species_richness'], 0, '#000', 10, '#fff']);
+        expect(r.note).toBeUndefined();
+    });
+
+    it('does not rewrite for non-hex layers (no valueColumn in state)', () => {
+        const { mm, applied } = createHexManager(undefined);
+        const r = mm.setStyle('hex-abc', {
+            'fill-color': ['interpolate', ['linear'], ['get', 'count'], 0, '#000', 10, '#fff'],
+        });
+        expect(r.success).toBe(true);
+        expect(applied['fill-color']).toEqual(
+            ['interpolate', ['linear'], ['get', 'count'], 0, '#000', 10, '#fff']);
+        expect(r.note).toBeUndefined();
+    });
+});


### PR DESCRIPTION
Fixes #259.

## Problem
When a user asks to recolor a dynamic hex layer, the agent calls `set_style` with a plausible data-driven expression — but hardcodes the value property as `["get","count"]`. `count` is only the real column for `agg="COUNT"` tilesets. On a layer whose property is e.g. `species_richness`, `["get","count"]` resolves to **null on every feature**, the `interpolate` yields no color, and the recolor is a **silent no-op**.

Observed in padus logs (2026-06-20 ~05:16): "show san diego county gbif richness as hex" → "change the colormap" produced `set_style` against `["get","count"]` while the tileset property was `species_richness`.

## Fix (client-side, deterministic)
- Store `valueColumn` on the hex layer's state at `addHexTileLayer`.
- New pure helper `rewriteValueColumn(expr, valueColumn)` in `hex-layer-helpers.js` recursively repoints any value-bearing `["get", X]` to the real column. It leaves the per-resolution `res` key and already-correct expressions untouched, and reports which properties it repointed.
- `setStyle` applies the rewrite for hex layers (those carrying `valueColumn`) and returns a transparent `note` so the correction isn't silent.
- `get_map_state` now exposes `valueColumn` for hex layers so the agent can discover the right column.
- `set_style` tool description gains a short note that for `hex-…` layers the value column is the one passed to `add_hex_tile_layer`, not `count`.

Non-hex layers are unaffected (no `valueColumn` in state → no rewrite).

## Tests
- `rewriteValueColumn`: repoint, no-op on correct column, `res` left alone, distinct-replacement reporting, literal pass-through, longer `get` forms left alone.
- `setStyle`: hex rewrite applies corrected paint + emits note; correct expression unchanged; non-hex layer not rewritten.

Full suite green (312 tests).