### PR TITLE
feat(legend): continuous/graduated legends for vector layers (#258)

### DIFF
--- a/app/dataset-catalog.js
+++ b/app/dataset-catalog.js
@@ -366,6 +366,8 @@ export class DatasetCatalog {
                         legendLabel: config.legend_label || null,
                         legendType: config.legend_type || null,
                         legendClasses: normalizeLegendClasses(config.legend_classes),
+                        legendRange: config.legend_range || null,
+                        legendGradient: config.legend_gradient || null,
                         // Versioned metadata
                         versions,
                         defaultVersionIndex: defaultIndex,
@@ -398,6 +400,8 @@ export class DatasetCatalog {
                         legendLabel: config.legend_label || null,
                         legendType: config.legend_type || null,
                         legendClasses: normalizeLegendClasses(config.legend_classes),
+                        legendRange: config.legend_range || null,
+                        legendGradient: config.legend_gradient || null,
                     });
                 } else if (type.includes('geotiff') || type.includes('tiff')) {
                     const band0 = asset['raster:bands']?.[0];
@@ -448,6 +452,8 @@ export class DatasetCatalog {
                         legendLabel: config.legend_label || null,
                         legendType: config.legend_type || null,
                         legendClasses: normalizeLegendClasses(config.legend_classes),
+                        legendRange: config.legend_range || null,
+                        legendGradient: config.legend_gradient || null,
                         animation,
                     });
                 }
@@ -784,6 +790,8 @@ export class DatasetCatalog {
                         legendLabel: ml.legendLabel || null,
                         legendType: ml.legendType || null,
                         legendClasses: ml.legendClasses || null,
+                        legendRange: ml.legendRange || null,
+                        legendGradient: ml.legendGradient || null,
                         // Versioned metadata
                         versions: versionConfigs,
                         defaultVersionIndex: ml.defaultVersionIndex,
@@ -819,6 +827,8 @@ export class DatasetCatalog {
                         legendLabel: ml.legendLabel || null,
                         legendType: ml.legendType || null,
                         legendClasses: ml.legendClasses || null,
+                        legendRange: ml.legendRange || null,
+                        legendGradient: ml.legendGradient || null,
                         animation: ml.animation || null,
                         tracksUrl: isGeoJson ? ml.url : null,
                     };

--- a/app/legend-helpers.js
+++ b/app/legend-helpers.js
@@ -1,0 +1,77 @@
+/**
+ * Pure helpers for building vector-layer legends.
+ *
+ * No DOM / MapLibre dependencies, so they're unit-testable without a browser.
+ * Consumed by map-manager.js (the continuous-vector legend branch, #258).
+ */
+
+/**
+ * The paint keys that carry a layer's primary data-driven color, in priority
+ * order. A fill layer colors via `fill-color`, a line via `line-color`, a
+ * circle via `circle-color`.
+ */
+const COLOR_PAINT_KEYS = ['fill-color', 'line-color', 'circle-color'];
+
+/**
+ * Derive a continuous legend (gradient + value range) from a vector layer's
+ * paint, by parsing a data-driven `interpolate` or `step` color expression.
+ *
+ * Rasters get their colorbar from TiTiler `colormap` + `rescale`; vector layers
+ * have neither, but a graduated choropleth already encodes the same information
+ * in its paint expression — e.g.
+ *   ["interpolate", ["linear"], ["get", "species"], 0, "#edf8e9", 242, "#005a32"]
+ * This reads the numeric stops (value axis) and their colors (gradient) back out
+ * so the legend can mirror the map without duplicate config.
+ *
+ * @param {Object} paint - A MapLibre paint object (e.g. layer state `defaultPaint`).
+ * @returns {{ gradient: string[], range: [number, number] } | null}
+ *   `gradient` is ≥2 CSS color strings low→high; `range` is [min, max] of the
+ *   numeric stops. Returns null when no parseable continuous color expression
+ *   is present (e.g. a flat color, a `match`/categorical expression, or no paint).
+ */
+export function deriveContinuousLegend(paint) {
+    if (!paint || typeof paint !== 'object') return null;
+
+    let expr = null;
+    for (const key of COLOR_PAINT_KEYS) {
+        if (Array.isArray(paint[key])) { expr = paint[key]; break; }
+    }
+    if (!expr) return null;
+
+    const op = expr[0];
+    const stops = [];   // { value, color }
+
+    if (op === 'interpolate' || op === 'interpolate-hcl' || op === 'interpolate-lab') {
+        // ["interpolate", <interpolation>, <input>, v0, c0, v1, c1, ...]
+        for (let i = 3; i + 1 < expr.length; i += 2) {
+            const value = expr[i];
+            const color = expr[i + 1];
+            if (typeof value === 'number' && typeof color === 'string') {
+                stops.push({ value, color });
+            }
+        }
+    } else if (op === 'step') {
+        // ["step", <input>, c0, v1, c1, v2, c2, ...]
+        // c0 is the color below the first threshold; subsequent pairs are
+        // (threshold, color). Use the thresholds as the value axis.
+        if (typeof expr[2] === 'string') stops.push({ value: null, color: expr[2] });
+        for (let i = 3; i + 1 < expr.length; i += 2) {
+            const value = expr[i];
+            const color = expr[i + 1];
+            if (typeof value === 'number' && typeof color === 'string') {
+                stops.push({ value, color });
+            }
+        }
+    } else {
+        return null;
+    }
+
+    const colors = stops.map(s => s.color);
+    const values = stops.map(s => s.value).filter(v => typeof v === 'number');
+    if (colors.length < 2 || values.length < 1) return null;
+
+    return {
+        gradient: colors,
+        range: [Math.min(...values), Math.max(...values)],
+    };
+}

--- a/app/map-manager.js
+++ b/app/map-manager.js
@@ -13,6 +13,7 @@
  */
 
 import { extractHashFromUrl, buildFillColorExpression, buildFlatFillColorExpression } from './hex-layer-helpers.js';
+import { deriveContinuousLegend } from './legend-helpers.js';
 
 const BASEMAPS = {
     natgeo: {
@@ -159,7 +160,7 @@ export class MapManager {
      * Register a single layer on the map.
      */
     registerLayer(config) {
-        const { layerId, datasetId, group, groupCollapsed, displayName, type, paint, outlinePaint, renderType, columns, tooltipFields, defaultVisible, defaultFilter, colormap, rescale, legendLabel, legendType, legendClasses } = config;
+        const { layerId, datasetId, group, groupCollapsed, displayName, type, paint, outlinePaint, renderType, columns, tooltipFields, defaultVisible, defaultFilter, colormap, rescale, legendLabel, legendType, legendClasses, legendRange, legendGradient } = config;
 
         // ── Animated layer: delegate to TrajectoryAnimation ──
         if (config.animation && config.animation.type === 'trajectory') {
@@ -269,6 +270,8 @@ export class MapManager {
                 legendLabel: legendLabel || null,
                 legendType: legendType || null,
                 legendClasses: legendClasses || null,
+                legendRange: legendRange || null,
+                legendGradient: legendGradient || null,
                 // Version tracking
                 versions: versionStates,
                 activeVersionIndex: config.defaultVersionIndex,
@@ -366,6 +369,8 @@ export class MapManager {
             legendLabel: legendLabel || null,
             legendType: legendType || null,
             legendClasses: legendClasses || null,
+            legendRange: legendRange || null,
+            legendGradient: legendGradient || null,
         });
 
         // Wire tooltip handler on every vector layer (even those without
@@ -1267,12 +1272,36 @@ export class MapManager {
     // ---- Legend ----
 
     /**
-     * Whether a layer contributes a legend entry: continuous rasters (colorbar)
-     * and any layer — raster or vector — with a categorical class list.
+     * Whether a layer contributes a legend entry: continuous rasters (colorbar),
+     * any layer with a categorical class list, and continuous vector layers
+     * (graduated choropleths) whose colorbar can be sourced from config or
+     * derived from their paint expression (#258).
      */
     _hasLegend(state) {
         return state.type === 'raster'
-            || (state.legendType === 'categorical' && state.legendClasses?.length > 0);
+            || (state.legendType === 'categorical' && state.legendClasses?.length > 0)
+            || (state.legendType === 'continuous' && !!this._continuousVectorLegend(state));
+    }
+
+    /**
+     * Resolve a continuous vector layer's colorbar — explicit `legendGradient` /
+     * `legendRange` config wins, otherwise derive both from the layer's paint
+     * `interpolate`/`step` color expression. Returns null when neither is
+     * available (so the layer simply contributes no legend).
+     *
+     * @returns {{ colors: string[], range: [number, number] } | null}
+     */
+    _continuousVectorLegend(state) {
+        if (state.type !== 'vector') return null;
+        const derived = deriveContinuousLegend(state.defaultPaint);
+        const colors = (Array.isArray(state.legendGradient) && state.legendGradient.length >= 2)
+            ? state.legendGradient
+            : derived?.gradient;
+        const range = (Array.isArray(state.legendRange) && state.legendRange.length === 2)
+            ? state.legendRange
+            : derived?.range;
+        if (!colors || colors.length < 2 || !range) return null;
+        return { colors, range };
     }
 
     /**
@@ -1347,6 +1376,10 @@ export class MapManager {
         heading.textContent = state.displayName;
         item.appendChild(heading);
 
+        const continuousVector = state.legendType === 'continuous'
+            ? this._continuousVectorLegend(state)
+            : null;
+
         if (state.legendType === 'categorical' && state.legendClasses?.length) {
             for (const cls of state.legendClasses) {
                 const row = document.createElement('div');
@@ -1357,6 +1390,27 @@ export class MapManager {
                 row.appendChild(document.createTextNode(cls.name || `Class ${cls.value}`));
                 item.appendChild(row);
             }
+        } else if (continuousVector) {
+            // Continuous vector (graduated choropleth): build the gradient from
+            // the layer's own color stops — no TiTiler colormap/rescale (#258).
+            const safe = continuousVector.colors.map(c => this._safeColorHint(c)).filter(Boolean);
+            const gradient = safe.length >= 2
+                ? `linear-gradient(to right, ${safe.join(', ')})`
+                : 'linear-gradient(to right, #eee, #333)';
+            const [minVal, maxVal] = continuousVector.range;
+            const unit = state.legendLabel ? ` ${state.legendLabel}` : '';
+            const bar = document.createElement('div');
+            bar.className = 'legend-colorbar';
+            bar.style.background = gradient;
+            const labels = document.createElement('div');
+            labels.className = 'legend-labels';
+            for (const v of [minVal, maxVal]) {
+                const span = document.createElement('span');
+                span.textContent = `${v}${unit}`;
+                labels.appendChild(span);
+            }
+            item.appendChild(bar);
+            item.appendChild(labels);
         } else {
             const gradient = await this._getColormapGradient(state.colormap || 'reds');
             const [minVal, maxVal] = (state.rescale || '0,1').split(',');

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -77,8 +77,31 @@ Each entry in `assets` may be a **bare string** (the STAC asset key, loaded with
 | `default_filter` | array | MapLibre filter expression applied at load time. |
 | `tooltip_fields` | array | Feature property names shown in the hover tooltip. |
 | `group` | string | Overrides the collection-level `group` for this specific layer. |
-| `legend_type` | string | `"categorical"` to show a discrete swatch legend (see `legend_classes`). |
+| `legend_type` | string | `"categorical"` for a discrete swatch legend (see `legend_classes`), or `"continuous"` for a graduated colorbar (see below). |
 | `legend_classes` | array | `{ label, color }` entries describing the discrete legend swatches. Required when `legend_type` is `"categorical"` on a vector layer — vectors have no STAC `classification:classes` to derive from. |
+| `legend_label` | string | Unit/axis label shown next to the colorbar end values (e.g. `"species"`). Applies to `"continuous"` legends. |
+| `legend_range` | `[min, max]` | Override the colorbar's value-axis labels. Optional — derived from the `default_style` color stops when omitted. |
+| `legend_gradient` | array | Override the colorbar colors, low→high (e.g. `["#edf8e9", "#005a32"]`). Optional — derived from the `default_style` color stops when omitted. |
+
+### Continuous (graduated) vector legends
+
+A vector layer styled with a graduated `default_style` — an `interpolate` or `step` color expression — can show the same colorbar a raster does. Set `legend_type: "continuous"`; the colorbar's gradient and value range are **derived automatically from the `default_style` color stops**, so no extra config is required:
+
+```json
+{
+  "id": "ace-amphibian-richness-pmtiles",
+  "display_name": "ACE Amphibian Richness",
+  "legend_type": "continuous",
+  "legend_label": "species",
+  "default_style": {
+    "fill-color": ["interpolate", ["linear"], ["get", "species"],
+      0, "#edf8e9", 242, "#005a32"],
+    "fill-opacity": 0.7
+  }
+}
+```
+
+Use `legend_range` and/or `legend_gradient` only to override the derived values (e.g. when the paint expression doesn't cleanly map to the labels you want, or the color stops aren't plain hex). If neither config nor a parseable color expression is present, the layer shows no legend.
 
 ## Asset config — raster (COG)
 

--- a/test/legend-helpers.test.js
+++ b/test/legend-helpers.test.js
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import { deriveContinuousLegend } from '../app/legend-helpers.js';
+
+describe('deriveContinuousLegend', () => {
+    it('derives gradient + range from an interpolate fill-color expression', () => {
+        const paint = {
+            'fill-color': ['interpolate', ['linear'], ['get', 'species'],
+                0, '#edf8e9', 121, '#74c476', 242, '#005a32'],
+            'fill-opacity': 0.7,
+        };
+        expect(deriveContinuousLegend(paint)).toEqual({
+            gradient: ['#edf8e9', '#74c476', '#005a32'],
+            range: [0, 242],
+        });
+    });
+
+    it('reads line-color when there is no fill-color', () => {
+        const paint = {
+            'line-color': ['interpolate', ['linear'], ['get', 'v'], 10, '#000', 20, '#fff'],
+        };
+        expect(deriveContinuousLegend(paint)).toEqual({
+            gradient: ['#000', '#fff'],
+            range: [10, 20],
+        });
+    });
+
+    it('reads circle-color too', () => {
+        const paint = {
+            'circle-color': ['interpolate', ['linear'], ['get', 'v'], 1, '#111', 5, '#999'],
+        };
+        expect(deriveContinuousLegend(paint).range).toEqual([1, 5]);
+    });
+
+    it('handles a step color expression (leading default color + thresholds)', () => {
+        const paint = {
+            'fill-color': ['step', ['get', 'v'], '#fee', 10, '#f88', 50, '#900'],
+        };
+        expect(deriveContinuousLegend(paint)).toEqual({
+            gradient: ['#fee', '#f88', '#900'],
+            range: [10, 50],
+        });
+    });
+
+    it('uses min/max of stops even if authored out of order', () => {
+        const paint = {
+            'fill-color': ['interpolate', ['linear'], ['get', 'v'], -5, '#000', 100, '#fff'],
+        };
+        expect(deriveContinuousLegend(paint).range).toEqual([-5, 100]);
+    });
+
+    it('returns null for a flat (non-expression) color', () => {
+        expect(deriveContinuousLegend({ 'fill-color': '#2E7D32', 'fill-opacity': 0.5 })).toBeNull();
+    });
+
+    it('returns null for a categorical match expression', () => {
+        const paint = {
+            'fill-color': ['match', ['get', 'gap'], '1', '#c1', '2', '#c2', '#999'],
+        };
+        expect(deriveContinuousLegend(paint)).toBeNull();
+    });
+
+    it('returns null for missing / empty paint', () => {
+        expect(deriveContinuousLegend(null)).toBeNull();
+        expect(deriveContinuousLegend({})).toBeNull();
+        expect(deriveContinuousLegend(undefined)).toBeNull();
+    });
+
+    it('returns null when fewer than two color stops are present', () => {
+        const paint = { 'fill-color': ['interpolate', ['linear'], ['get', 'v'], 0, '#000'] };
+        expect(deriveContinuousLegend(paint)).toBeNull();
+    });
+});

--- a/test/map-manager.tooltip-legend.test.js
+++ b/test/map-manager.tooltip-legend.test.js
@@ -153,6 +153,42 @@ describe('MapManager raster legend (SEC-3)', () => {
         expect(mm._legendContent.textContent).toContain('Seamounts');
         expect(mm._legendContent.textContent).toContain('Ridges');
     });
+
+    it('renders a continuous vector colorbar derived from the paint expression (issue #258)', async () => {
+        const mm = createLegendManager({
+            type: 'vector',
+            displayName: 'ACE Amphibian Richness',
+            legendType: 'continuous',
+            legendLabel: 'species',
+            defaultPaint: {
+                'fill-color': ['interpolate', ['linear'], ['get', 'species'],
+                    0, '#edf8e9', 242, '#005a32'],
+                'fill-opacity': 0.7,
+            },
+        });
+        await mm._showLegend('A');
+        const bar = mm._legendContent.querySelector('.legend-colorbar');
+        expect(bar.getAttribute('style')).toContain('linear-gradient');
+        expect(bar.getAttribute('style')).toContain('#edf8e9');
+        const labels = [...mm._legendContent.querySelectorAll('.legend-labels span')].map(s => s.textContent);
+        expect(labels).toEqual(['0 species', '242 species']);
+    });
+
+    it('continuous vector colorbar honors explicit legend_range / legend_gradient over the paint', async () => {
+        const mm = createLegendManager({
+            type: 'vector',
+            displayName: 'CalEnviroScreen',
+            legendType: 'continuous',
+            legendRange: [0, 100],
+            legendGradient: ['#ffffcc', '#800026'],
+            defaultPaint: { 'fill-color': '#2E7D32' },  // flat — nothing to derive
+        });
+        await mm._showLegend('A');
+        const bar = mm._legendContent.querySelector('.legend-colorbar');
+        expect(bar.getAttribute('style')).toContain('#ffffcc');
+        const labels = [...mm._legendContent.querySelectorAll('.legend-labels span')].map(s => s.textContent);
+        expect(labels).toEqual(['0', '100']);
+    });
 });
 
 describe('MapManager._hasLegend', () => {
@@ -175,6 +211,27 @@ describe('MapManager._hasLegend', () => {
 
     it('is false for a vector layer flagged categorical but with no classes', () => {
         expect(mm._hasLegend({ type: 'vector', legendType: 'categorical', legendClasses: [] })).toBeFalsy();
+    });
+
+    it('is true for a continuous vector layer whose colorbar derives from its paint (#258)', () => {
+        expect(mm._hasLegend({
+            type: 'vector', legendType: 'continuous',
+            defaultPaint: { 'fill-color': ['interpolate', ['linear'], ['get', 'v'], 0, '#000', 10, '#fff'] },
+        })).toBe(true);
+    });
+
+    it('is true for a continuous vector layer with explicit gradient + range', () => {
+        expect(mm._hasLegend({
+            type: 'vector', legendType: 'continuous',
+            legendGradient: ['#fff', '#000'], legendRange: [0, 5],
+        })).toBe(true);
+    });
+
+    it('is false for a continuous vector layer with nothing to source a colorbar from', () => {
+        expect(mm._hasLegend({
+            type: 'vector', legendType: 'continuous',
+            defaultPaint: { 'fill-color': '#2E7D32' },
+        })).toBeFalsy();
     });
 });
 


### PR DESCRIPTION
Fixes #258.

## Problem
Vector legends (PR #248, issue #118, v3.13.0) are **categorical-only**. A vector layer styled with a continuous `interpolate`/`step` ramp — a graduated choropleth — gets **no legend**, while a raster with the same kind of ramp gets a colorbar.

- `_hasLegend` admitted a vector only when `legendType === 'categorical' && legendClasses.length > 0`.
- `_showLegend`'s continuous branch sourced its gradient from `state.colormap` + `state.rescale` — TiTiler/raster-only concepts a vector layer doesn't have.

Real impact (ca-30x30): 12 ACE richness layers + CalEnviroScreen are `["interpolate",["linear"],["get",<col>],…]` ramps that render correctly but show no legend.

## Approach
The graduated paint expression already encodes the gradient and value range, so the **primary path auto-derives the legend from `default_style`** — set `legend_type: "continuous"` and nothing else is needed.

- **`app/legend-helpers.js`** (new, pure/tested): `deriveContinuousLegend(paint)` parses `fill`/`line`/`circle-color` `interpolate`/`step` expressions into `{ gradient, range }`. Returns null for flat colors, `match`/categorical, or unparseable paint.
- **`_hasLegend`** now accepts continuous vectors *when a colorbar is resolvable*; **`_continuousVectorLegend(state)`** resolves it — explicit `legend_gradient`/`legend_range` config wins, else derive from paint.
- **`_showLegend`** gains a continuous-vector branch that reuses the existing `.legend-colorbar`/`.legend-labels` DOM; colors are validated through `_safeColorHint` (same XSS guard as the categorical path).
- **`dataset-catalog.js`** plumbs the optional `legend_range` / `legend_gradient` overrides (vector + versioned + `getMapLayerConfigs`).
- **Docs**: continuous-legend config table rows + a "Continuous (graduated) vector legends" subsection covering auto-derivation.

Categorical vectors and raster colorbars are unchanged.

## Tests
- `deriveContinuousLegend`: interpolate/step parsing, fill/line/circle keys, out-of-order stops, null cases (flat, match, empty, single-stop).
- `_hasLegend`: continuous eligible via derived paint and via explicit config; not eligible with nothing to source from.
- `_showLegend`: renders a derived colorbar with `legend_label` axis labels; explicit `legend_range`/`legend_gradient` override the paint.

Full suite green (317 tests).

> Note: `app/map-manager.js`, `dataset-catalog.js`, and `chat-ui.js` are browser-bound per AGENTS.md, but the legend/catalog logic here is exercised by the jsdom-based `map-manager.tooltip-legend` and `dataset-catalog` suites. Visual confirmation on a ca-30x30-style app is still worth a manual check.