### PR TITLE
feat(chat): fold checkpoint resume into the input — Continue + abandon (#255)

### DIFF
--- a/app/chat-ui.js
+++ b/app/chat-ui.js
@@ -137,12 +137,32 @@ export class ChatUI {
     /* ------------------------------------------------------------------ */
 
     init() {
-        // Wire send button & enter key. Button doubles as Stop while busy;
-        // Enter simply no-ops while busy (handleSend guards).
+        // Default placeholder, restored by _syncInputControls when not paused.
+        this._defaultPlaceholder = this.inputEl.placeholder;
+
+        // The send button is a 3-state control:
+        //   idle           → "Send"      (click/Enter sends a new message)
+        //   busy           → "■" Stop    (click/Esc aborts the in-flight turn)
+        //   suspended+idle → "Continue"  (click/Enter resumes the paused turn;
+        //                                 typing a steer first resumes with it)
+        // While busy it aborts; otherwise it sends/resumes via handleSend.
         this.sendBtn.addEventListener('click', () => {
             if (this.busy) this.agent.abort();
             else this.handleSend();
         });
+
+        // Abandon control — shown only while a turn is suspended (and not busy).
+        // Discards the preserved work so the next message starts a fresh turn,
+        // instead of being folded into the old turn as a steer.
+        this.abandonBtn = document.createElement('button');
+        this.abandonBtn.id = 'chat-abandon';
+        this.abandonBtn.type = 'button';
+        this.abandonBtn.textContent = '✕';
+        this.abandonBtn.title = 'Discard the paused work and start fresh';
+        this.abandonBtn.hidden = true;
+        this.abandonBtn.addEventListener('click', () => this.abandonSuspendedTurn());
+        this.sendBtn.parentNode.insertBefore(this.abandonBtn, this.sendBtn);
+        this._syncInputControls();
         this.inputEl.addEventListener('keydown', e => {
             if (e.key === 'Enter' && !e.shiftKey) {
                 e.preventDefault();
@@ -578,9 +598,15 @@ export class ChatUI {
     }
 
     async handleSend() {
-        const text = this.inputEl.value.trim();
-        if (!text) return;
         if (this.busy) return;
+
+        // Empty input resumes a paused turn (Continue); otherwise there's
+        // nothing to send. A typed steer takes precedence over the canned resume.
+        let text = this.inputEl.value.trim();
+        if (!text) {
+            if (!this.agent.suspendedTurn) return;
+            text = 'continue';
+        }
 
         // In user-provided mode, check for API key before sending
         if (this.config._userProvidedMode && !localStorage.getItem('geo-agent-api-key')) {
@@ -589,9 +615,7 @@ export class ChatUI {
         }
 
         this.busy = true;
-        this.sendBtn.classList.add('stop');
-        this.sendBtn.textContent = '■';
-        this.sendBtn.title = 'Stop';
+        this._syncInputControls();
         this.inputEl.value = '';
         this._autoResizeInput();
 
@@ -616,13 +640,10 @@ export class ChatUI {
             } else {
                 this.endTurn('done');
             }
-
-            // If the turn paused with work preserved — a checkpoint, or Stop
-            // pressed during the checkpoint summary — offer a one-click resume.
-            // Typing any message also resumes (and can steer) the paused turn.
-            if (this.agent.suspendedTurn) {
-                this.renderContinueButton();
-            }
+            // If the turn paused with work preserved (a checkpoint, or Stop
+            // during the checkpoint summary), _syncInputControls() in finally
+            // relabels the send button to "Continue" and reveals the abandon
+            // control — the input area itself becomes the resume affordance.
         } catch (err) {
             console.error('[ChatUI] Error:', err);
             this.endTurn('error');
@@ -636,12 +657,47 @@ export class ChatUI {
                 : msg);
         } finally {
             this.busy = false;
-            this.sendBtn.classList.remove('stop');
-            this.sendBtn.textContent = 'Send';
-            this.sendBtn.title = '';
+            this._syncInputControls();
             document.removeEventListener('keydown', escHandler);
             this.inputEl.focus();
         }
+    }
+
+    /**
+     * Reflect the current (busy / suspended / idle) state onto the input
+     * controls. Single source of truth for the send button's three modes and
+     * the abandon button's visibility, so the wiring lives in one place.
+     */
+    _syncInputControls() {
+        const suspended = !this.busy && !!this.agent.suspendedTurn;
+        this.sendBtn.classList.toggle('stop', this.busy);
+        this.sendBtn.classList.toggle('continue', suspended);
+        if (this.busy) {
+            this.sendBtn.textContent = '■';
+            this.sendBtn.title = 'Stop';
+        } else if (suspended) {
+            this.sendBtn.textContent = 'Continue';
+            this.sendBtn.title = 'Resume where the agent paused — or type a steer first';
+        } else {
+            this.sendBtn.textContent = 'Send';
+            this.sendBtn.title = '';
+        }
+        this.abandonBtn.hidden = !suspended;
+        this.inputEl.placeholder = suspended
+            ? 'Press Continue, or type a steer / choice to resume…'
+            : this._defaultPlaceholder;
+    }
+
+    /**
+     * Discard a suspended turn so the next message starts fresh rather than
+     * being folded into the paused turn as a steer. Wired to the abandon (✕)
+     * button, which is only visible while a turn is suspended.
+     */
+    abandonSuspendedTurn() {
+        if (this.busy || !this.agent.suspendedTurn) return;
+        this.agent.suspendedTurn = null;
+        this._syncInputControls();
+        this.addMessage('system', 'Discarded the paused work. Your next message starts a new turn.');
     }
 
     /* ------------------------------------------------------------------ */
@@ -655,10 +711,6 @@ export class ChatUI {
      * assistant's final answer arrives.
      */
     startTurn() {
-        // A new turn supersedes any prior checkpoint prompt — drop stale
-        // Continue buttons so only the latest pause offers a resume.
-        this.messagesEl.querySelectorAll('.checkpoint-actions').forEach(el => el.remove());
-
         const container = document.createElement('details');
         container.className = 'agent-turn running';
         container.open = true;
@@ -1154,33 +1206,6 @@ body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-
             if (typeof hljs !== 'undefined') hljs.highlightElement(block);
         });
 
-        this.scrollToBottom();
-    }
-
-    /**
-     * Offer a one-click resume after the agent pauses at a checkpoint (or the
-     * user stopped during the checkpoint summary). The agent keeps the
-     * in-flight work in suspendedTurn; sending "continue" resumes it, while
-     * typing any other message resumes with that steer instead.
-     */
-    renderContinueButton() {
-        const wrap = document.createElement('div');
-        wrap.className = 'chat-message checkpoint-actions';
-
-        const btn = document.createElement('button');
-        btn.className = 'continue-btn';
-        btn.textContent = '▶ Continue';
-        btn.title = 'Resume where the agent paused';
-        btn.addEventListener('click', () => {
-            if (this.busy) return;
-            btn.disabled = true;
-            // Preserve a steer the user already typed; default to a plain resume.
-            if (!this.inputEl.value.trim()) this.inputEl.value = 'continue';
-            this.handleSend();
-        });
-
-        wrap.appendChild(btn);
-        this.messagesEl.appendChild(wrap);
         this.scrollToBottom();
     }
 

--- a/app/chat.css
+++ b/app/chat.css
@@ -372,29 +372,33 @@
     max-width: 95%;
 }
 
-/* Checkpoint "Continue" affordance, shown when the agent pauses mid-turn */
-.chat-message.checkpoint-actions {
-    align-self: flex-start;
-    padding: 0;
+/* Send button in "Continue" mode — shown when a turn is suspended at a
+   checkpoint. Green reads as resume/go, distinct from the blue Send and the
+   red Stop. Resume lives in the input row now, not an inline message button. */
+#chat-send.continue {
+    background: #2e9e5b;
 }
 
-.continue-btn {
-    padding: 6px 14px;
-    border: none;
-    border-radius: 8px;
-    background: rgba(0, 122, 255, 0.85);
+#chat-send.continue:hover {
+    background: #278a4f;
+}
+
+/* Abandon (✕) control — only visible while a turn is suspended; discards the
+   paused work so the next message starts fresh. Secondary, like the mic. */
+#chat-abandon {
+    padding: 9px 12px;
+    background: rgba(255, 255, 255, 0.08);
     color: #fff;
-    font-size: 13px;
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    border-radius: 6px;
     cursor: pointer;
+    font-size: 14px;
+    line-height: 1;
 }
 
-.continue-btn:hover {
-    background: rgba(0, 122, 255, 1);
-}
-
-.continue-btn:disabled {
-    opacity: 0.5;
-    cursor: default;
+#chat-abandon:hover {
+    background: rgba(220, 53, 69, 0.85);
+    border-color: rgba(220, 53, 69, 1);
 }
 
 /* Thinking indicator */

--- a/test/chat-ui-controls.test.js
+++ b/test/chat-ui-controls.test.js
@@ -1,0 +1,111 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest';
+import { ChatUI } from '../app/chat-ui.js';
+
+/**
+ * #255 — checkpoint resume folded into the chat input. These exercise the
+ * 3-state send button (Send / Stop / Continue), the abandon control, and the
+ * empty-input "Continue" resume, without standing up the full ChatUI (which
+ * wires voice, model selector, links, etc.). We drive the prototype methods on
+ * a minimal instance, mirroring the map-manager unit tests.
+ */
+function makeUI({ busy = false, suspendedTurn = null } = {}) {
+    const ui = Object.create(ChatUI.prototype);
+    ui.busy = busy;
+    ui.agent = { suspendedTurn };
+    ui.config = {};
+    ui.sendBtn = document.createElement('button');
+    ui.abandonBtn = document.createElement('button');
+    ui.inputEl = document.createElement('textarea');
+    ui._defaultPlaceholder = 'Ask about the data…';
+    ui.inputEl.placeholder = ui._defaultPlaceholder;
+    ui._messages = [];
+    ui.addMessage = (role, text) => ui._messages.push({ role, text });
+    return ui;
+}
+
+describe('ChatUI._syncInputControls (#255)', () => {
+    it('idle → Send, no abandon, default placeholder', () => {
+        const ui = makeUI();
+        ui._syncInputControls();
+        expect(ui.sendBtn.textContent).toBe('Send');
+        expect(ui.sendBtn.classList.contains('stop')).toBe(false);
+        expect(ui.sendBtn.classList.contains('continue')).toBe(false);
+        expect(ui.abandonBtn.hidden).toBe(true);
+        expect(ui.inputEl.placeholder).toBe('Ask about the data…');
+    });
+
+    it('busy → Stop, abandon stays hidden even if a turn is suspended', () => {
+        const ui = makeUI({ busy: true, suspendedTurn: { turnMessages: [] } });
+        ui._syncInputControls();
+        expect(ui.sendBtn.textContent).toBe('■');
+        expect(ui.sendBtn.classList.contains('stop')).toBe(true);
+        expect(ui.sendBtn.classList.contains('continue')).toBe(false);
+        expect(ui.abandonBtn.hidden).toBe(true);
+    });
+
+    it('suspended + idle → Continue, abandon visible, hint placeholder', () => {
+        const ui = makeUI({ suspendedTurn: { turnMessages: [] } });
+        ui._syncInputControls();
+        expect(ui.sendBtn.textContent).toBe('Continue');
+        expect(ui.sendBtn.classList.contains('continue')).toBe(true);
+        expect(ui.sendBtn.classList.contains('stop')).toBe(false);
+        expect(ui.abandonBtn.hidden).toBe(false);
+        expect(ui.inputEl.placeholder).toMatch(/Continue/);
+    });
+});
+
+describe('ChatUI.abandonSuspendedTurn (#255)', () => {
+    it('clears the suspended turn, resets to Send, and notes it', () => {
+        const ui = makeUI({ suspendedTurn: { turnMessages: [] } });
+        ui.abandonSuspendedTurn();
+        expect(ui.agent.suspendedTurn).toBeNull();
+        expect(ui.sendBtn.textContent).toBe('Send');
+        expect(ui.abandonBtn.hidden).toBe(true);
+        expect(ui._messages.at(-1)).toMatchObject({ role: 'system' });
+    });
+
+    it('is a no-op while busy', () => {
+        const ui = makeUI({ busy: true, suspendedTurn: { keep: 1 } });
+        ui.abandonSuspendedTurn();
+        expect(ui.agent.suspendedTurn).toEqual({ keep: 1 });
+        expect(ui._messages).toHaveLength(0);
+    });
+});
+
+describe('ChatUI.handleSend resume semantics (#255)', () => {
+    function wireTurnStubs(ui) {
+        const sent = [];
+        ui.agent.processMessage = async (t) => { sent.push(t); return { response: 'ok', cancelled: false }; };
+        ui._autoResizeInput = () => {};
+        ui.startTurn = () => {};
+        ui.endTurn = () => {};
+        ui.addMarkdown = () => {};
+        ui.scrollToBottom = () => {};
+        return sent;
+    }
+
+    it('empty input resumes a suspended turn with "continue"', async () => {
+        const ui = makeUI({ suspendedTurn: { turnMessages: [] } });
+        const sent = wireTurnStubs(ui);
+        ui.inputEl.value = '';
+        await ui.handleSend();
+        expect(sent).toEqual(['continue']);
+    });
+
+    it('empty input with no suspended turn does nothing', async () => {
+        const ui = makeUI();
+        const sent = wireTurnStubs(ui);
+        ui.inputEl.value = '   ';
+        await ui.handleSend();
+        expect(sent).toEqual([]);
+    });
+
+    it('a typed steer takes precedence over the canned continue', async () => {
+        const ui = makeUI({ suspendedTurn: { turnMessages: [] } });
+        const sent = wireTurnStubs(ui);
+        ui.inputEl.value = 'use the viridis palette';
+        await ui.handleSend();
+        expect(sent).toEqual(['use the viridis palette']);
+    });
+});


### PR DESCRIPTION
Fixes #255.

## Problem
When the agent pauses at a checkpoint, the UI rendered a standalone `▶ Continue` button *inside the message stream* — competing with the chat input even though sending **any** message already resumes the suspended turn (same code path). And once paused, there was **no way to abandon** the suspended work: any new message got folded into the old turn as a steer, with no escape short of reloading.

## Change
The resume affordance now lives in the input row:

- **3-state send button** via a single `_syncInputControls()`:
  - idle → **Send**
  - busy → **■ Stop** (abort, unchanged)
  - suspended + idle → **Continue** (green)
- **Continue / Enter on an empty input** resumes the paused turn (`"continue"`); **typing a steer first** resumes with that steer instead.
- **New ✕ abandon control**, visible *only* while suspended — clears `agent.suspendedTurn` so the next message starts a fresh turn.
- Placeholder hints the affordance while paused.
- Removed the standalone `renderContinueButton` / `.checkpoint-actions` block and its now-dead CSS.

State that was scattered through `handleSend` (the busy on/off button mutations) is now centralized in `_syncInputControls()`.

## Tests
`test/chat-ui-controls.test.js` (jsdom) drives the prototype methods on a minimal instance (mirroring the map-manager unit tests):
- `_syncInputControls`: idle→Send, busy→Stop (abandon hidden even if suspended), suspended→Continue+abandon+hint.
- `abandonSuspendedTurn`: clears the turn / resets to Send / notes it; no-op while busy.
- `handleSend`: empty input resumes with `"continue"`; empty + no suspended turn is a no-op; a typed steer wins over the canned resume.

Full suite green (334).

## Manual verification (browser-bound, per AGENTS.md)
On a downstream app with a low `max_tool_calls` (e.g. `3`) so a checkpoint triggers:
1. Ask a multi-step question → agent pauses → send button reads **Continue**, **✕** appears, placeholder hints resume.
2. Press **Continue** (empty input) → resumes. 
3. Repeat; this time type a steer first → resumes with the steer.
4. At a pause, press **✕** → system note, button returns to **Send**, next message starts a fresh turn.
5. While a turn is running, button is **■ Stop** and ✕ is hidden.