### PR TITLE
perf(boot): parallelize independent boot I/O + drop redundant MCP probes (#130)

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -57,12 +57,24 @@ async function main() {
     /* ── 1b. Build UI chrome (layout-manager owns floating vs sidebar) ─── */
     const layoutRefs = buildLayout(appConfig);
 
-    /* ── 2. Build dataset catalog from STAC ────────────────────────────── */
-    const catalog = new DatasetCatalog();
-    await catalog.load(appConfig);
-    console.log(`[main] Catalog loaded: ${catalog.datasets.size} collections`);
+    /* ── 1c. Kick off independent network I/O so it overlaps ──────────────
+     * MCP cold-start, the STAC catalog walk, the map style, and the static
+     * system-prompt fetch are mutually independent. Fire the slow ones now and
+     * await them together below, instead of serializing each round trip. */
+    const mcpUrl = appConfig.mcp_url || 'https://duckdb-mcp.nrp-nautilus.io/mcp';
+    const mcpHeaders = {};
+    if (appConfig.mcp_auth_token) {
+        mcpHeaders['Authorization'] = `Bearer ${appConfig.mcp_auth_token}`;
+    }
+    console.log('[main] MCP URL:', mcpUrl, 'auth token present:', !!appConfig.mcp_auth_token);
+    const mcp = new MCPClient(mcpUrl, mcpHeaders);
+    // Connect eagerly but don't block boot — overlaps catalog + map load below.
+    mcp.connect().catch(err => console.warn('[main] Initial MCP connect failed (will retry):', err.message));
+    // Static system-prompt fetch (awaited at step 6) — independent of everything.
+    const basePromptP = fetchText('system-prompt.md');
 
-    /* ── 3. Initialise map ────────────────────────────────────────────── */
+    /* ── 2+3. Build dataset catalog + map, loaded in parallel ──────────── */
+    const catalog = new DatasetCatalog();
     const mapManager = new MapManager('map', {
         center: appConfig.view?.center || [-119.4, 36.8],
         zoom: appConfig.view?.zoom || 6,
@@ -74,7 +86,10 @@ async function main() {
         defaultBasemap: appConfig.default_basemap || 'natgeo',
         customBasemap: appConfig.custom_basemap || null,
     });
-    await mapManager.ready;                        // wait for style to load
+    // STAC walk and map-style load run concurrently (the MapManager constructor
+    // already kicked off the style fetch); wait for both before wiring layers.
+    await Promise.all([catalog.load(appConfig), mapManager.ready]);
+    console.log(`[main] Catalog loaded: ${catalog.datasets.size} collections`);
     // Sidebar resize: reflow the MapLibre canvas during drag (rAF-gated by
     // layout-manager) and one final time on drag-end / window-resize.
     sidebarHooks.onResizeTick = () => mapManager.map.resize();
@@ -170,17 +185,6 @@ async function main() {
             console.warn('[main] Failed to add geolocate control:', err.message);
         }
     }
-
-    /* ── 4. Set up MCP client ─────────────────────────────────────────── */
-    const mcpUrl = appConfig.mcp_url || 'https://duckdb-mcp.nrp-nautilus.io/mcp';
-    const mcpHeaders = {};
-    if (appConfig.mcp_auth_token) {
-        mcpHeaders['Authorization'] = `Bearer ${appConfig.mcp_auth_token}`;
-    }
-    console.log('[main] MCP URL:', mcpUrl, 'auth token present:', !!appConfig.mcp_auth_token);
-    const mcp = new MCPClient(mcpUrl, mcpHeaders);
-    // Connect eagerly but don't block boot
-    mcp.connect().catch(err => console.warn('[main] Initial MCP connect failed (will retry):', err.message));
 
     /* ── 5. Build tool registry ───────────────────────────────────────── */
     const toolRegistry = new ToolRegistry();
@@ -285,11 +289,15 @@ async function main() {
         let lastErr;
         for (let i = 0; i < attempts; i++) {
             try {
-                return await mcp.listTools();
+                // connect() dedupes with the eager connect fired at boot and
+                // caches the tool list internally, so getTools() avoids the
+                // extra listTools() round trip the old path incurred.
+                await mcp.connect();
+                return mcp.getTools();
             } catch (err) {
                 lastErr = err;
                 const delay = Math.min(2000 * Math.pow(2, i), 8000);
-                console.warn(`[main] listTools attempt ${i + 1}/${attempts} failed: ${err.message}`);
+                console.warn(`[main] MCP connect attempt ${i + 1}/${attempts} failed: ${err.message}`);
                 if (i < attempts - 1) await new Promise(r => setTimeout(r, delay));
             }
         }
@@ -327,7 +335,7 @@ async function main() {
     }
 
     /* ── 6. Build system prompt ────────────────────────────────────────── */
-    const basePrompt = await fetchText('system-prompt.md');
+    const basePrompt = await basePromptP;   // fetch was kicked off at step 1c
     const catalogText = catalog.generatePromptCatalog();
     let systemPrompt = basePrompt + '\n\n' + catalogText;
 

--- a/app/mcp-client.js
+++ b/app/mcp-client.js
@@ -86,16 +86,13 @@ export class MCPClient {
      * Called lazily before any operation.
      */
     async ensureConnected() {
-        if (this.connected && this.client) {
-            try {
-                // Lightweight health check
-                await this.client.listTools();
-                return;
-            } catch {
-                console.warn('[MCP] Connection stale, reconnecting...');
-                this.connected = false;
-            }
-        }
+        // Trust the `connected` flag rather than probing with a listTools()
+        // round trip on every operation — that probe added a full request to
+        // each callTool/listPrompts/getPrompt, multiplying boot latency. A
+        // genuinely stale connection is caught by callTool's reconnect-and-retry
+        // branch (the only frequent, long-lived op); boot-time prompt reads run
+        // right after a fresh connect, so they're never stale.
+        if (this.connected && this.client) return;
         await this.reconnect();
     }
 

--- a/test/mcp-client.test.js
+++ b/test/mcp-client.test.js
@@ -80,20 +80,25 @@ describe('MCPClient connect', () => {
 });
 
 describe('MCPClient ensureConnected and reconnect', () => {
-    it('listTools health check passes when connection is alive — no reconnect', async () => {
+    it('on a live connection returns immediately — no probe round trip, no reconnect', async () => {
         const c = new MCPClient('https://mcp/');
         await c.connect();
-        const before = clientInstances.length;
+        const clientsBefore = clientInstances.length;
+        const probesBefore = lastClient().listTools.mock.calls.length;
         await c.ensureConnected();
-        expect(clientInstances.length).toBe(before);
+        // No new client (no reconnect) and no extra listTools() health-check call.
+        expect(clientInstances.length).toBe(clientsBefore);
+        expect(lastClient().listTools.mock.calls.length).toBe(probesBefore);
     });
 
-    it('on stale connection (listTools throws), reconnects', async () => {
+    it('reconnects when the connection has been marked down', async () => {
         vi.useFakeTimers();
         try {
             const c = new MCPClient('https://mcp/');
             await c.connect();
-            lastClient().listTools.mockRejectedValueOnce(new Error('stale'));
+            // Simulate callTool catching a connection error and marking the
+            // transport down — ensureConnected should then rebuild it.
+            c.connected = false;
 
             const promise = c.ensureConnected();
             await vi.advanceTimersByTimeAsync(1000);
@@ -233,8 +238,7 @@ describe('MCPClient onReconnect', () => {
             const cb = vi.fn();
             c.setOnReconnect(cb);
 
-            // Health check throws → forces reconnect → fresh client returns 2 tools
-            lastClient().listTools.mockRejectedValueOnce(new Error('stale'));
+            // A reconnect builds a fresh client that lists 2 tools.
             Client.mockImplementationOnce(() => {
                 const instance = buildClientInstance();
                 instance.listTools = vi.fn(async () => ({
@@ -244,7 +248,7 @@ describe('MCPClient onReconnect', () => {
                 return instance;
             });
 
-            const promise = c.ensureConnected();
+            const promise = c.reconnect();
             await vi.advanceTimersByTimeAsync(1000);
             await promise;
 
@@ -269,9 +273,8 @@ describe('MCPClient onReconnect', () => {
             const c = new MCPClient('https://mcp/');
             await c.connect();
             c.setOnReconnect(() => { throw new Error('registry boom'); });
-            lastClient().listTools.mockRejectedValueOnce(new Error('stale'));
 
-            const promise = c.ensureConnected();
+            const promise = c.reconnect();
             await vi.advanceTimersByTimeAsync(1000);
             await expect(promise).resolves.toBeUndefined();
             expect(c.isConnected).toBe(true);


### PR DESCRIPTION
Addresses **Findings 1–3** of #130. **Finding 4** (render the welcome screen early via an `ui.setAgent()` setter) is deferred to a focused follow-up — it's a browser-bound UX refactor of `ChatUI.init()` that needs visual verification, and I didn't want to bundle a boot-path regression risk with these safe wins.

## Changes

**1. Drop the `listTools()` health check in `MCPClient.ensureConnected()`.**
It ran a full round trip before *every* `callTool` / `listPrompts` / `getPrompt`. Now it trusts the `connected` flag; `callTool`'s existing reconnect-and-retry branch is the real safety net for the only frequent, long-lived op, and boot-time prompt reads happen right after a fresh connect (never stale).

**2. `listMcpToolsWithRetry` uses the connect cache.**
Was `await mcp.listTools()` (ensureConnected probe + a second list round trip) even though `connect()` already cached the tools. Now `await mcp.connect(); return mcp.getTools()` — dedupes with the eager boot connect, no extra round trip.

**3. Parallelize independent boot I/O.**
`mcp.connect()` and the `system-prompt.md` fetch now fire at the top of `main()`, and the STAC catalog walk + map-style load run via `Promise.all` instead of two serial `await`s. The MCP cold-start overlaps catalog + map + prompt I/O (previously connect fired only *after* both were awaited, so it never overlapped).

Net: removes per-call probe round trips and collapses several serialized boot I/Os into one overlapping wait.

## Tests
`test/mcp-client.test.js` updated for the new no-probe contract: `ensureConnected` on a live connection makes no client and no extra `listTools` call; staleness now surfaces via `callTool` / explicit `reconnect()`; the two `onReconnect` specs drive `reconnect()` directly. Full suite green (**334**).

## Verification
`app/main.js` is browser-bootstrap (0% harness). Per the issue's validation plan, verify with a **cold-load network waterfall** on padus/template (disable cache, throttle): confirm total time-to-ready is unchanged-or-better and the MCP connect now overlaps the catalog/map fetches. The MCP-client change is covered by unit tests.

## Deferred
**Finding 4** (early welcome render): split `ChatUI.init()` into agent-independent chrome + an `setAgent()` that wires callbacks/model-selector and enables the input. Worth its own PR with jsdom tests + a browser pass, since it changes boot ordering of the UI.