### PR TITLE
fix(mcp): close connect() race that registered zero MCP tools

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -293,7 +293,13 @@ async function main() {
                 // caches the tool list internally, so getTools() avoids the
                 // extra listTools() round trip the old path incurred.
                 await mcp.connect();
-                return mcp.getTools();
+                const tools = mcp.getTools();
+                // An empty list here means the connect resolved before its tool
+                // cache was populated — treat it as a failure so we retry, and
+                // fall back to the hardcoded `query` tool rather than silently
+                // registering zero MCP tools for the life of the session.
+                if (!tools.length) throw new Error('MCP connected but returned an empty tool list');
+                return tools;
             } catch (err) {
                 lastErr = err;
                 const delay = Math.min(2000 * Math.pow(2, i), 8000);

--- a/app/mcp-client.js
+++ b/app/mcp-client.js
@@ -66,12 +66,18 @@ export class MCPClient {
                 { capabilities: {} }
             );
             await this.client.connect(transport);
-            this.connected = true;
-            this.reconnectAttempts = 0;
 
-            // Cache available tools
+            // Cache available tools BEFORE flipping `connected`. The flag is the
+            // short-circuit for connect()/ensureConnected(); if it went true here
+            // (transport up) but the tool list were still empty, a concurrent
+            // connect() would short-circuit and a getTools() reader would see []
+            // — registering zero remote tools with no error, no fallback, and no
+            // reconnect to recover (the silent MCP-tools-missing boot). Populate
+            // the cache first so `connected === true` always implies tools ready.
             const response = await this.client.listTools();
             this.tools = response.tools || [];
+            this.connected = true;
+            this.reconnectAttempts = 0;
             console.log('[MCP] Connected. Tools:', this.tools.map(t => t.name));
         } catch (error) {
             this.connected = false;

--- a/test/mcp-client.test.js
+++ b/test/mcp-client.test.js
@@ -65,6 +65,35 @@ describe('MCPClient connect', () => {
         expect(clientInstances.length).toBe(1);
     });
 
+    it('never reports connected with an empty tool cache (listTools-race)', async () => {
+        // Regression for the silent MCP-tools-missing boot: connect() must not
+        // flip `connected` until the tool list is cached, or a concurrent
+        // connect() short-circuits and getTools() returns [] (zero remote tools,
+        // no error, no fallback) for the life of the session.
+        let resolveTools;
+        Client.mockImplementationOnce(() => {
+            const instance = buildClientInstance();
+            instance.listTools = vi.fn(() => new Promise(r => { resolveTools = r; }));
+            clientInstances.push(instance);
+            return instance;
+        });
+
+        const c = new MCPClient('https://mcp.example/mcp');
+        const connecting = c.connect();
+        // Let transport.connect() resolve; we are now parked awaiting listTools.
+        await Promise.resolve();
+        await Promise.resolve();
+        // The transport is up but the tool cache is not yet populated — the flag
+        // must stay false so no concurrent caller sees an empty list as "ready".
+        expect(c.isConnected).toBe(false);
+        expect(c.getTools()).toEqual([]);
+
+        resolveTools({ tools: [{ name: 'query' }, { name: 'register_hex_tiles' }] });
+        await connecting;
+        expect(c.isConnected).toBe(true);
+        expect(c.getTools().map(t => t.name)).toEqual(['query', 'register_hex_tiles']);
+    });
+
     it('on connect failure, marks disconnected and rethrows', async () => {
         Client.mockImplementationOnce(() => {
             const instance = buildClientInstance();


### PR DESCRIPTION
## Symptom

Apps report the hex-tile tools are gone — the agent says `register_hex_tiles` "isn't currently available in my function set" and `add_hex_tile_layer` can't be used. This is **not** a model hallucination: proxy logs show the affected sessions had `tools_count=18` (= 18 local tools + **0** MCP tools) instead of the healthy 24. All 6 remote MCP tools (`browse_stac_catalog`, `get_collection`, `get_stac_details`, `query`, `register_hex_tiles`, `get_hex_tile_status`) were missing for the whole session.

## Root cause — a latent race made reachable by #265 (v3.16.0)

`_doConnect()` set `this.connected = true` **before** populating `this.tools` via `listTools()`, with an `await` gap between them. `connect()` short-circuits on `if (this.connected && this.client) return`.

Since #265, the boot retry path trusts the tool cache (`await mcp.connect(); return mcp.getTools()`) instead of doing its own fresh `listTools()` round trip. When the eager boot connect had flipped `connected=true` but its `listTools()` hadn't resolved yet, `listMcpToolsWithRetry`'s `connect()` short-circuited and `getTools()` returned the still-empty `[]`:

- **0 remote tools registered**, with **no exception** — so the hardcoded-`query` fallback never fired
- no `onReconnect` recovery on *initial* connect → session stuck local-only for its whole life

Before #265 the retry path did its own `client.listTools()`, so it never read the unpopulated cache; the bug was latent.

## Evidence (open-llm-proxy logs)

- `tools_count=18` (silent-empty path) **never appears 6/14–6/27, first appears 6/28** as apps adopted v3.16/v3.17.
- global-30x30 today: 71 requests @ 24 (healthy), 4 @ 18 (degraded), 1 @ 0 — **intermittent**, the signature of a race.
- qwen3 sessions on padus + global-30x30 correctly reported the missing tool.

## Fix

1. `_doConnect()`: cache tools **before** flipping `connected`, so `connected === true` always implies tools ready (closes the window for every concurrent caller).
2. Defense-in-depth: `listMcpToolsWithRetry` treats an empty list as a failure → retry, then the `query` fallback (count 19, not silent 18).
3. Regression test: `connect()` never reports connected with an empty tool cache.

All 345 tests pass. Browser-bootstrap boot is unharnessed — recommend a cold-load check on padus/global-30x30 after release.