### PR TITLE
feat(map): reactive-parameter slider / temporal filter control (#147)

### DIFF
--- a/app/animation-manager.js
+++ b/app/animation-manager.js
@@ -208,8 +208,9 @@ export class TrajectoryAnimation {
                 <option value="4">4×</option>
             </select>
         `;
-        // Stack multiple panels vertically
-        const existing = document.querySelectorAll('.anim-controls').length;
+        // Stack multiple panels vertically — count reactive-control sliders too
+        // so the two panel types never render on top of each other.
+        const existing = document.querySelectorAll('.anim-controls, .reactive-controls').length;
         panel.style.bottom = (12 + existing * 44) + 'px';
         document.body.appendChild(panel);
 

--- a/app/dataset-catalog.js
+++ b/app/dataset-catalog.js
@@ -368,6 +368,7 @@ export class DatasetCatalog {
                         legendClasses: normalizeLegendClasses(config.legend_classes),
                         legendRange: config.legend_range || null,
                         legendGradient: config.legend_gradient || null,
+                        control: config.control || null,
                         // Versioned metadata
                         versions,
                         defaultVersionIndex: defaultIndex,
@@ -402,6 +403,7 @@ export class DatasetCatalog {
                         legendClasses: normalizeLegendClasses(config.legend_classes),
                         legendRange: config.legend_range || null,
                         legendGradient: config.legend_gradient || null,
+                        control: config.control || null,
                     });
                 } else if (type.includes('geotiff') || type.includes('tiff')) {
                     const band0 = asset['raster:bands']?.[0];
@@ -455,6 +457,7 @@ export class DatasetCatalog {
                         legendRange: config.legend_range || null,
                         legendGradient: config.legend_gradient || null,
                         animation,
+                        control: config.control || null,
                     });
                 }
             }
@@ -792,6 +795,7 @@ export class DatasetCatalog {
                         legendClasses: ml.legendClasses || null,
                         legendRange: ml.legendRange || null,
                         legendGradient: ml.legendGradient || null,
+                        control: ml.control || null,
                         // Versioned metadata
                         versions: versionConfigs,
                         defaultVersionIndex: ml.defaultVersionIndex,
@@ -830,6 +834,7 @@ export class DatasetCatalog {
                         legendRange: ml.legendRange || null,
                         legendGradient: ml.legendGradient || null,
                         animation: ml.animation || null,
+                        control: ml.control || null,
                         tracksUrl: isGeoJson ? ml.url : null,
                     };
                     if (!isGeoJson) layerConfig.sourceLayer = ml.sourceLayer;

--- a/app/map-manager.js
+++ b/app/map-manager.js
@@ -272,10 +272,12 @@ export class MapManager {
                 legendClasses: legendClasses || null,
                 legendRange: legendRange || null,
                 legendGradient: legendGradient || null,
+                control: null,   // filled in by _registerControl when config.control is set
                 // Version tracking
                 versions: versionStates,
                 activeVersionIndex: config.defaultVersionIndex,
             });
+            if (config.control) this._registerControl(layerId, config.control);
             this._showLegendIfVisible(layerId);
             return;
         }
@@ -371,7 +373,11 @@ export class MapManager {
             legendClasses: legendClasses || null,
             legendRange: legendRange || null,
             legendGradient: legendGradient || null,
+            control: null,   // filled in by _registerControl when config.control is set
         });
+
+        // Declarative reactive-parameter control (e.g. a temporal slider, #147).
+        if (config.control) this._registerControl(layerId, config.control);
 
         // Wire tooltip handler on every vector layer (even those without
         // declared fields) so set_tooltip can attach fields at runtime. The
@@ -436,6 +442,119 @@ export class MapManager {
         }
     }
 
+    /**
+     * Attach a reactive-parameter control (e.g. a temporal slider, #147) to an
+     * existing layer. The control owns its own DOM panel + (optional) autoplay
+     * loop and, on each change, calls back through _applyControlAction to
+     * rebind the layer — no LLM round-trip per tick. Replaces any prior control
+     * on the same layer. Async because the module is lazy-loaded.
+     *
+     * @param {string} layerId
+     * @param {Object} controlConfig — the `control` block (type/field/min/max/…)
+     * @returns {Promise<{success:boolean, error?:string}>}
+     */
+    async _registerControl(layerId, controlConfig) {
+        const state = this.layers.get(layerId);
+        if (!state) return { success: false, error: `Unknown layer: ${layerId}` };
+        try {
+            const { ReactiveControl } = await import('./reactive-control.js');
+            if (state.control) state.control.destroy();
+            // The slider rebinds the layer's filter; remember the layer's
+            // configured predicate so the slider composes with it rather than
+            // wiping it (a layer may ship a defaultFilter like severity=high).
+            state.controlBaseFilter = state.defaultFilter || null;
+            const ctrl = new ReactiveControl({
+                layerId,
+                displayName: state.displayName,
+                config: controlConfig,
+                apply: (action) => this._applyControlAction(layerId, action),
+            });
+            state.control = ctrl;
+            ctrl.setVisible(state.visible);
+            return { success: true };
+        } catch (err) {
+            console.error(`[Map] Failed to init reactive control for ${layerId}:`, err);
+            return { success: false, error: err.message };
+        }
+    }
+
+    /**
+     * Apply a ReactiveControl's filter directly to the layer. This runs on
+     * every slider input and up to ~60×/s during autoplay, so it deliberately
+     * bypasses the heavy setFilter() path (which calls queryRenderedFeatures +
+     * describeFilter to report a feature count). It also composes the slider
+     * predicate with the layer's base filter (`["all", base, sliderExpr]`) so a
+     * configured defaultFilter survives the slider.
+     */
+    _applyControlAction(layerId, action) {
+        if (!action || action.kind !== 'filter') return;
+        const state = this.layers.get(layerId);
+        if (!state || state.type !== 'vector' || !state.mapLayerId) return;
+        const base = state.controlBaseFilter;
+        const combined = base ? ['all', base, action.expr] : action.expr;
+        this.map.setFilter(state.mapLayerId, combined);
+        if (state.outlineLayerId) this.map.setFilter(state.outlineLayerId, combined);
+        state.filter = combined;
+    }
+
+    /**
+     * Create a slider that filters a vector layer by a numeric/temporal field,
+     * client-side, with no round-trip per step (#147). Used by the agent's
+     * `create_slider` tool. The slider is bound as a MapLibre filter:
+     * cumulative (`<=`) reveals everything up to the value; step (`==`) shows
+     * only the matching value.
+     *
+     * @param {Object} args
+     * @param {string} args.layer_id
+     * @param {string} args.field           — feature property to filter on
+     * @param {number} args.min
+     * @param {number} args.max
+     * @param {number} [args.step=1]
+     * @param {'cumulative'|'step'} [args.mode='cumulative']
+     * @param {string} [args.label]
+     * @param {boolean} [args.animate=false] — show a play button that sweeps the range
+     * @param {number} [args.default]
+     * @returns {Promise<Object>} result
+     */
+    async createSlider(args = {}) {
+        const { layer_id, field, min, max } = args;
+        const state = this.layers.get(layer_id);
+        if (!state) {
+            return { success: false, error: `Unknown layer: ${layer_id}. Available: ${this.getLayerIds().join(', ')}` };
+        }
+        if (state.type === 'raster') {
+            return { success: false, error: `Sliders bind to a vector layer's feature field; "${layer_id}" is a raster layer.` };
+        }
+        if (!field || min == null || max == null) {
+            return { success: false, error: 'create_slider requires field, min, and max.' };
+        }
+        const mode = args.mode === 'step' ? 'step' : 'cumulative';
+        const controlConfig = {
+            type: 'slider',
+            bind: 'filter',
+            field,
+            label: args.label || field,
+            min, max,
+            step: args.step ?? 1,
+            mode,
+            animate: !!args.animate,
+            ...(args.default != null && { default: args.default }),
+        };
+        // Await registration so a lazy-import or constructor failure is reported
+        // to the agent instead of being silently swallowed.
+        const reg = await this._registerControl(layer_id, controlConfig);
+        if (!reg.success) {
+            return { success: false, error: `Failed to create slider: ${reg.error}` };
+        }
+        return {
+            success: true,
+            layer: layer_id,
+            displayName: state.displayName,
+            field, min, max, mode,
+            animate: !!args.animate,
+        };
+    }
+
     // ---- Layer Visibility ----
 
     /**
@@ -454,6 +573,7 @@ export class MapManager {
         }
         this.map.setLayoutProperty(state.mapLayerId, 'visibility', 'visible');
         if (state.outlineLayerId) this.map.setLayoutProperty(state.outlineLayerId, 'visibility', 'visible');
+        if (state.control) state.control.setVisible(true);
         if (this._hasLegend(state)) this._showLegend(layerId);
         return { success: true, layer: layerId, displayName: state.displayName, visible: true };
     }
@@ -474,6 +594,7 @@ export class MapManager {
         }
         this.map.setLayoutProperty(state.mapLayerId, 'visibility', 'none');
         if (state.outlineLayerId) this.map.setLayoutProperty(state.outlineLayerId, 'visibility', 'none');
+        if (state.control) state.control.setVisible(false);
         if (this._hasLegend(state)) this._hideLegend(layerId);
         return { success: true, layer: layerId, displayName: state.displayName, visible: false };
     }

--- a/app/map-tools.js
+++ b/app/map-tools.js
@@ -173,6 +173,34 @@ Note: some layers have a config default filter applied at startup. This tool rem
         },
 
         {
+            name: 'create_slider',
+            description: `Create an interactive slider that filters a vector layer by a numeric or temporal field — entirely client-side, with no round-trip per step. Use when the user wants to scrub, step, or animate through values of one field (e.g. "let me step through fire years", "add a year slider", "play the burn history over time").
+
+The slider binds as a MapLibre filter on \`field\`:
+- mode "cumulative" (default): shows every feature with field <= the slider value (e.g. fires accumulate as the year advances).
+- mode "step": shows only features whose field == the slider value (one year at a time).
+
+Set animate: true to add a play/pause button that sweeps min→max automatically. Only one slider can be attached to a layer at a time (creating a new one replaces it). The slider panel is shown while the layer is visible — call show_layer first if it isn't already on.
+
+${pickLayerNudge}`,
+            inputSchema: {
+                type: 'object',
+                properties: {
+                    layer_id: { type: 'string', description: 'Vector layer ID to attach the slider to' },
+                    field: { type: 'string', description: 'Feature property to filter on (e.g. "YEAR_"). Must be numeric or a value that compares numerically.' },
+                    min: { type: 'number', description: 'Slider minimum (low end of the field range)' },
+                    max: { type: 'number', description: 'Slider maximum (high end of the field range)' },
+                    step: { type: 'number', description: 'Slider step size (default 1)' },
+                    mode: { type: 'string', enum: ['cumulative', 'step'], description: 'cumulative (<=) or step (==). Default cumulative.' },
+                    label: { type: 'string', description: 'Label shown on the slider panel (defaults to the field name)' },
+                    animate: { type: 'boolean', description: 'Add a play button that sweeps the range (default false)' },
+                },
+                required: ['layer_id', 'field', 'min', 'max'],
+            },
+            execute: async (args) => JSON.stringify(await mapManager.createSlider(args)),
+        },
+
+        {
             name: 'set_tooltip',
             description: `Set which feature properties appear in the hover tooltip for a vector layer. Pass an array of property names; the tooltip displays them in order. Pass an empty array to disable the tooltip for that layer.
 

--- a/app/reactive-control.js
+++ b/app/reactive-control.js
@@ -1,0 +1,229 @@
+/**
+ * reactive-control.js — Reactive-parameter controls (sliders)
+ *
+ * A ReactiveControl renders a small slider panel over the map and, on each
+ * (debounced) change, rebinds a map property derived from the slider value —
+ * with no LLM round-trip per tick. The agent (or a `control` block in
+ * layers-input.json) sets up the binding once; the control drives it
+ * client-side thereafter.
+ *
+ * The headline use is a *temporal filter* (issue #147): step a year/date field
+ * across its range, either cumulatively ("show everything up to year N") or one
+ * step at a time. The same machinery is intended to generalise to other
+ * reactive parameters (a weight slider that re-styles, etc.) by adding `bind`
+ * kinds to `buildControlAction` — `filter` is implemented here.
+ *
+ * Owns a single DOM panel (`.reactive-controls`) and, when `animate` is set, a
+ * RAF autoplay loop. Lifecycle methods (setVisible / destroy) let MapManager
+ * treat it like the trajectory animation's controls.
+ */
+
+const DEFAULTS = {
+    type: 'slider',
+    bind: 'filter',
+    mode: 'cumulative',   // 'cumulative' (<=) | 'step' (==)
+    step: 1,
+    animate: false,
+    duration_seconds: 20,
+    loop: true,
+};
+
+/**
+ * Pure mapping from (control config, current value) → a map action.
+ * Exported so it can be unit-tested without a DOM. Returns null when the
+ * config can't produce an action (so callers can no-op safely).
+ *
+ * @param {Object} config — the resolved control config (DEFAULTS merged in)
+ * @param {number} value  — the current slider value
+ * @returns {{kind:'filter', expr:Array} | null}  — `style`/`query` binds are
+ *   reserved (see below) and not yet emitted.
+ */
+export function buildControlAction(config, value) {
+    const bind = config.bind || 'filter';
+    if (bind === 'filter') {
+        const field = config.field;
+        if (!field) return null;
+        const expr = config.mode === 'step'
+            ? ['==', ['get', field], value]
+            : ['<=', ['get', field], value];
+        return { kind: 'filter', expr };
+    }
+    // 'style' and 'query' binds are reserved for follow-up work (the
+    // landscape-frontiers weight slider). Unknown bind → no-op.
+    return null;
+}
+
+/** Initial slider value when the config doesn't pin one. */
+function initialValue(config) {
+    if (config.default != null) return config.default;
+    // Cumulative temporal: default to the high end so the static (pre-play)
+    // state shows every feature; step mode starts at the low end.
+    return config.mode === 'step' ? config.min : config.max;
+}
+
+export class ReactiveControl {
+    /**
+     * @param {Object} opts
+     * @param {string}   opts.layerId      — logical layer id from catalog
+     * @param {string}   opts.displayName  — label for the controls panel
+     * @param {Object}   opts.config       — `control` block from layers-input.json
+     * @param {(action:Object)=>void} opts.apply — called with buildControlAction's result
+     * @param {Document} [opts.doc]        — injectable for tests (defaults to global document)
+     */
+    constructor(opts) {
+        this.layerId = opts.layerId;
+        this.displayName = opts.displayName || opts.layerId;
+        this.config = { ...DEFAULTS, ...opts.config };
+        this.apply = opts.apply || (() => {});
+        this.doc = opts.doc || (typeof document !== 'undefined' ? document : null);
+
+        if (this.config.min == null || this.config.max == null) {
+            throw new Error('ReactiveControl requires numeric min and max');
+        }
+
+        this.value = clamp(initialValue(this.config), this.config.min, this.config.max);
+        this.visible = true;
+        this.playing = false;
+        this.rafId = null;
+        this.lastFrame = null;
+        this.destroyed = false;
+
+        this._panel = null;
+        if (this.doc) this._build();
+        this.emit();   // apply the initial binding
+    }
+
+    /** Compute and apply the action for the current value, then update the readout. */
+    emit() {
+        const action = buildControlAction(this.config, this.value);
+        if (action) this.apply(action);
+        if (this._valueEl) this._valueEl.textContent = this._format(this.value);
+    }
+
+    setValue(v) {
+        this.value = clamp(Number(v), this.config.min, this.config.max);
+        if (this._slider) this._slider.value = String(this.value);
+        this.emit();
+    }
+
+    _format(v) {
+        // Autoplay advances the value continuously (fractional), so round the
+        // readout to the step's precision: integer steps (years) show no
+        // decimal, fractional steps show two places.
+        const dp = Number.isInteger(this.config.step) ? 0 : 2;
+        return v.toFixed(dp);
+    }
+
+    _build() {
+        const panel = this.doc.createElement('div');
+        panel.className = 'reactive-controls';
+        panel.dataset.layerId = this.layerId;
+
+        const label = this.config.label || this.displayName;
+        const playBtn = this.config.animate
+            ? '<button class="rc-play" title="Play / Pause">▶</button>'
+            : '';
+        panel.innerHTML = `
+            <span class="rc-label" title="${escapeAttr(label)}">${escapeHtml(label)}</span>
+            ${playBtn}
+            <input class="rc-slider" type="range"
+                   min="${this.config.min}" max="${this.config.max}"
+                   step="${this.config.step}" value="${this.value}" />
+            <span class="rc-value"></span>
+        `;
+        // Stack above any trajectory-animation panels and other reactive panels.
+        const existing = this.doc.querySelectorAll('.reactive-controls, .anim-controls').length;
+        panel.style.bottom = (12 + existing * 44) + 'px';
+        this.doc.body.appendChild(panel);
+
+        this._panel = panel;
+        this._slider = panel.querySelector('.rc-slider');
+        this._valueEl = panel.querySelector('.rc-value');
+        this._playBtn = panel.querySelector('.rc-play');
+
+        this._slider.addEventListener('input', () => {
+            if (this.playing) this.pause();
+            this.value = Number(this._slider.value);
+            this.emit();
+        });
+        if (this._playBtn) {
+            this._playBtn.addEventListener('click', () => {
+                this.playing ? this.pause() : this.play();
+            });
+        }
+    }
+
+    // ---- Autoplay (temporal sweep) ----
+
+    play() {
+        if (!this.config.animate || this.destroyed) return;
+        // Restart from the low end so the sweep accumulates from the beginning.
+        if (this.value >= this.config.max) this.setValue(this.config.min);
+        this.playing = true;
+        this.lastFrame = null;
+        if (this._playBtn) this._playBtn.textContent = '❚❚';
+        this._tick = this._tick.bind(this);
+        this.rafId = requestAnimationFrame(this._tick);
+    }
+
+    pause() {
+        this.playing = false;
+        if (this._playBtn) this._playBtn.textContent = '▶';
+        if (this.rafId) { cancelAnimationFrame(this.rafId); this.rafId = null; }
+    }
+
+    _tick(now) {
+        if (this.destroyed || !this.playing) return;
+        if (this.lastFrame !== null) {
+            const delta = now - this.lastFrame;
+            const durationMs = this.config.duration_seconds * 1000;
+            const range = Math.max(1, this.config.max - this.config.min);
+            const next = this.value + (delta / durationMs) * range;
+            if (next >= this.config.max) {
+                if (this.value < this.config.max) {
+                    // Render the final frame (e.g. the most recent year) before
+                    // wrapping or stopping — otherwise it flickers past unseen.
+                    this.setValue(this.config.max);
+                } else if (this.config.loop) {
+                    this.setValue(this.config.min);
+                } else {
+                    this.pause();
+                    return;
+                }
+            } else {
+                this.setValue(next);
+            }
+        }
+        this.lastFrame = now;
+        this.rafId = requestAnimationFrame(this._tick);
+    }
+
+    // ---- Lifecycle ----
+
+    setVisible(visible) {
+        this.visible = visible;
+        if (this._panel) this._panel.style.display = visible ? '' : 'none';
+        if (!visible) this.pause();
+    }
+
+    destroy() {
+        this.destroyed = true;
+        this.pause();
+        if (this._panel) this._panel.remove();
+    }
+}
+
+// ---- helpers ----
+
+function clamp(v, lo, hi) {
+    if (Number.isNaN(v)) return lo;
+    return Math.min(hi, Math.max(lo, v));
+}
+
+function escapeHtml(s) {
+    return String(s).replace(/[&<>]/g, c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;' }[c]));
+}
+
+function escapeAttr(s) {
+    return escapeHtml(s).replace(/"/g, '&quot;');
+}

--- a/app/style.css
+++ b/app/style.css
@@ -592,6 +592,63 @@ details.layer-group:not([open]) .layer-group-title::before {
     font-size: 12px;
 }
 
+/* ── Reactive-parameter controls (temporal / value sliders, #147) ────────
+   Same frosted-glass surface as .anim-controls; floats bottom-left and
+   stacks above any animation panels. */
+.reactive-controls {
+    position: absolute;
+    left: 12px;
+    z-index: 2;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 10px;
+    background: rgba(255, 255, 255, 0.92);
+    backdrop-filter: blur(6px);
+    -webkit-backdrop-filter: blur(6px);
+    border: 1px solid rgba(0, 0, 0, 0.15);
+    border-radius: 6px;
+    font-family: 'Open Sans', sans-serif;
+    font-size: 12px;
+    color: #222;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.15);
+}
+
+.reactive-controls .rc-label {
+    font-weight: 600;
+    max-width: 160px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.reactive-controls .rc-play {
+    border: 1px solid rgba(0, 0, 0, 0.2);
+    background: #fff;
+    border-radius: 4px;
+    width: 26px;
+    height: 26px;
+    cursor: pointer;
+    font-size: 11px;
+    line-height: 1;
+}
+
+.reactive-controls .rc-play:hover {
+    background: #f5f5f5;
+}
+
+.reactive-controls .rc-slider {
+    width: 160px;
+    cursor: pointer;
+}
+
+.reactive-controls .rc-value {
+    font-variant-numeric: tabular-nums;
+    min-width: 48px;
+    text-align: right;
+    color: #555;
+}
+
 /* ── Geocoder search box (maplibre-gl-geocoder) ──────────────────────────
    Frosted-glass surface to match the app's other map controls (#menu,
    .version-select) instead of the library's solid white — light tint +

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -206,7 +206,53 @@ For GeoJSON assets containing `LineString` features with a parallel timestamp ar
 }
 ```
 
-Only point-trajectory animation is supported today. Raster time-series playback and temporal filtering of static features are tracked as future work in [#144](https://github.com/boettiger-lab/geo-agent/issues/144).
+For *temporal filtering of static features* — stepping a year/date field on an ordinary vector layer rather than animating moving points — use a reactive-parameter control (below) instead. Raster time-series playback remains future work.
+
+## Reactive-parameter controls (sliders)
+
+A `control` block turns an asset into a layer with a slider that rebinds a map property as you drag it — entirely client-side, with no LLM round-trip per step. The headline use is a **temporal filter**: scrub a year/date field across its range, either cumulatively ("show everything up to year N") or one step at a time ([#147](https://github.com/boettiger-lab/geo-agent/issues/147)). The slider panel floats over the map (like the trajectory controls) and appears whenever the layer is visible.
+
+The same control is also available to the agent at runtime via the **`create_slider`** tool — e.g. "let me step through the fire years" attaches a year slider to the active layer without any config.
+
+The slider composes with the layer's configured `default_filter` (applied as `["all", default_filter, sliderPredicate]`), so a base predicate survives. While a slider is active it governs the layer's filter slot, so a separate `set_filter` on the same layer is superseded the next time the slider moves.
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `type` | string | `"slider"` | Control widget. Currently only `"slider"` is supported. |
+| `field` | string | — | **Required.** Feature property the slider filters on (must compare numerically). |
+| `min` | number | — | **Required.** Low end of the slider range. |
+| `max` | number | — | **Required.** High end of the slider range. |
+| `step` | number | `1` | Slider increment. |
+| `bind` | string | `"filter"` | What the slider drives. Currently `"filter"` (a MapLibre filter expression); `"style"` and `"query"` binds are reserved for future work. |
+| `mode` | string | `"cumulative"` | For `filter` bind: `"cumulative"` shows `field <= value`; `"step"` shows `field == value`. |
+| `label` | string | field name | Text shown on the slider panel. |
+| `default` | number | `max` (cumulative) / `min` (step) | Initial slider value. |
+| `animate` | boolean | `false` | Add a play/pause button that sweeps `min → max` automatically. |
+| `duration_seconds` | number | `20` | Real-time seconds for one autoplay sweep (when `animate` is set). |
+| `loop` | boolean | `true` | Restart at `min` after an autoplay sweep reaches `max`. |
+
+```json
+{
+  "collection_id": "calfire-perimeters",
+  "assets": [
+    {
+      "id": "firep-pmtiles",
+      "display_name": "CAL FIRE Wildfire Perimeters",
+      "control": {
+        "type": "slider",
+        "field": "YEAR_",
+        "label": "Year",
+        "min": 1835,
+        "max": 2024,
+        "step": 1,
+        "mode": "cumulative",
+        "animate": true,
+        "duration_seconds": 20
+      }
+    }
+  ]
+}
+```
 
 ## Collapsed groups
 

--- a/test/dataset-catalog.test.js
+++ b/test/dataset-catalog.test.js
@@ -313,6 +313,21 @@ describe('DatasetCatalog.extractMapLayers', () => {
         expect(layers[0].sourceLayer).toBe('holdings_layer');
     });
 
+    it('threads a `control` block through to the vector layer record (#147)', () => {
+        const control = { type: 'slider', field: 'YEAR_', min: 1835, max: 2024, mode: 'cumulative' };
+        const layers = cat.extractMapLayers(collectionWithAssets({
+            fires: { type: 'application/vnd.pmtiles', href: 'https://x/fires.pmtiles' },
+        }), {}, [{ key: 'fires', assetId: 'fires', config: { control } }]);
+        expect(layers[0].control).toEqual(control);
+    });
+
+    it('leaves control null when no control block is configured', () => {
+        const layers = cat.extractMapLayers(collectionWithAssets({
+            fires: { type: 'application/vnd.pmtiles', href: 'https://x/fires.pmtiles' },
+        }), {}, [{ key: 'fires', assetId: 'fires', config: {} }]);
+        expect(layers[0].control).toBeNull();
+    });
+
     it('normalizes legend_classes ({label,color}) for a categorical vector layer (issue #118)', () => {
         const layers = cat.extractMapLayers(collectionWithAssets({
             geo: { type: 'application/vnd.pmtiles', href: 'https://x/geo.pmtiles' },

--- a/test/map-manager.filter.test.js
+++ b/test/map-manager.filter.test.js
@@ -48,6 +48,53 @@ describe('MapManager.setFilter empty-filter guard (#243)', () => {
     });
 });
 
+describe('MapManager._applyControlAction (reactive slider, #147)', () => {
+    const setup = (extra = {}) => {
+        const setFilterCalls = [];
+        const queryCalls = { n: 0 };
+        const mm = Object.create(MapManager.prototype);
+        mm.map = {
+            setFilter: (id, f) => setFilterCalls.push({ id, f }),
+            queryRenderedFeatures: () => { queryCalls.n++; return []; },
+        };
+        mm.layers = new Map([
+            ['vec', { type: 'vector', mapLayerId: 'layer-vec', outlineLayerId: 'layer-vec-outline', displayName: 'Vec', ...extra }],
+        ]);
+        mm._setFilterCalls = setFilterCalls;
+        mm._queryCalls = queryCalls;
+        return mm;
+    };
+
+    it('applies the slider expression to the layer and its outline', () => {
+        const mm = setup();
+        mm._applyControlAction('vec', { kind: 'filter', expr: ['<=', ['get', 'YEAR_'], 1990] });
+        expect(mm._setFilterCalls).toEqual([
+            { id: 'layer-vec', f: ['<=', ['get', 'YEAR_'], 1990] },
+            { id: 'layer-vec-outline', f: ['<=', ['get', 'YEAR_'], 1990] },
+        ]);
+    });
+
+    it('does NOT call queryRenderedFeatures (cheap per-frame path, unlike setFilter)', () => {
+        const mm = setup();
+        mm._applyControlAction('vec', { kind: 'filter', expr: ['<=', ['get', 'YEAR_'], 1990] });
+        expect(mm._queryCalls.n).toBe(0);
+    });
+
+    it('composes the slider predicate with the layer base filter so a defaultFilter survives', () => {
+        const base = ['==', ['get', 'severity'], 'high'];
+        const mm = setup({ controlBaseFilter: base });
+        mm._applyControlAction('vec', { kind: 'filter', expr: ['<=', ['get', 'YEAR_'], 1990] });
+        expect(mm._setFilterCalls[0].f).toEqual(['all', base, ['<=', ['get', 'YEAR_'], 1990]]);
+    });
+
+    it('ignores non-filter actions and unknown layers', () => {
+        const mm = setup();
+        mm._applyControlAction('vec', { kind: 'style', paint: {} });
+        mm._applyControlAction('missing', { kind: 'filter', expr: ['<=', ['get', 'x'], 1] });
+        expect(mm._setFilterCalls.length).toBe(0);
+    });
+});
+
 describe('MapManager.setFilter 0-features-in-view', () => {
     it('reports plain success with no failure signal when 0 features are in the viewport', () => {
         // queryRenderedFeatures is viewport-scoped: a valid filter whose matches are

--- a/test/map-tools.test.js
+++ b/test/map-tools.test.js
@@ -300,6 +300,38 @@ describe('set_tooltip / reset_tooltip', () => {
     });
 });
 
+describe('create_slider', () => {
+    const stubMapManager = () => ({
+        createSlider: vi.fn((args) => ({ success: true, layer: args.layer_id, field: args.field, min: args.min, max: args.max, mode: args.mode === 'step' ? 'step' : 'cumulative' })),
+        getLayerSummaries: () => [{ id: 'fires', displayName: 'Fires', type: 'vector' }],
+    });
+    const stubCatalog = { records: new Map() };
+
+    const getTool = () => {
+        const mapManager = stubMapManager();
+        const tool = createMapTools(mapManager, stubCatalog).find(t => t.name === 'create_slider');
+        return { tool, mapManager };
+    };
+
+    it('forwards args verbatim to mapManager.createSlider', async () => {
+        const { tool, mapManager } = getTool();
+        const args = { layer_id: 'fires', field: 'YEAR_', min: 1835, max: 2024, step: 1, mode: 'cumulative', animate: true };
+        const result = JSON.parse(await tool.execute(args));
+        expect(result.success).toBe(true);
+        expect(mapManager.createSlider).toHaveBeenCalledWith(args);
+    });
+
+    it('requires layer_id, field, min, and max in its schema', () => {
+        const { tool } = getTool();
+        expect(tool.inputSchema.required).toEqual(['layer_id', 'field', 'min', 'max']);
+    });
+
+    it('constrains mode to cumulative | step', () => {
+        const { tool } = getTool();
+        expect(tool.inputSchema.properties.mode.enum).toEqual(['cumulative', 'step']);
+    });
+});
+
 describe('geocode tool', () => {
     const stubMap = { getLayerSummaries: () => [] };
     const stubCatalog = { records: new Map() };
@@ -397,6 +429,7 @@ describe('createMapTools smoke test', () => {
         expect(names).toEqual([
             'add_hex_tile_layer',
             'clear_filter',
+            'create_slider',
             'fly_to',
             'get_map_state',
             'get_schema',

--- a/test/reactive-control.test.js
+++ b/test/reactive-control.test.js
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi } from 'vitest';
+import { buildControlAction, ReactiveControl } from '../app/reactive-control.js';
+
+describe('buildControlAction', () => {
+    it('cumulative filter binds field <= value', () => {
+        const action = buildControlAction({ bind: 'filter', mode: 'cumulative', field: 'YEAR_' }, 1990);
+        expect(action).toEqual({ kind: 'filter', expr: ['<=', ['get', 'YEAR_'], 1990] });
+    });
+
+    it('step filter binds field == value', () => {
+        const action = buildControlAction({ bind: 'filter', mode: 'step', field: 'YEAR_' }, 1990);
+        expect(action).toEqual({ kind: 'filter', expr: ['==', ['get', 'YEAR_'], 1990] });
+    });
+
+    it('defaults to cumulative when mode is omitted', () => {
+        const action = buildControlAction({ bind: 'filter', field: 'depth' }, 50);
+        expect(action).toEqual({ kind: 'filter', expr: ['<=', ['get', 'depth'], 50] });
+    });
+
+    it('returns null when the filter bind has no field', () => {
+        expect(buildControlAction({ bind: 'filter' }, 5)).toBeNull();
+    });
+
+    it('returns null for unimplemented bind kinds (style/query reserved)', () => {
+        expect(buildControlAction({ bind: 'style', field: 'x' }, 5)).toBeNull();
+        expect(buildControlAction({ bind: 'query', field: 'x' }, 5)).toBeNull();
+    });
+});
+
+describe('ReactiveControl (no-DOM core)', () => {
+    // doc:null skips panel construction so the value→action pipeline can be
+    // tested without faking the DOM. The browser-bound _build / autoplay paths
+    // are verified manually in a deployed app (per the module-coverage policy).
+    const makeControl = (config) => {
+        const actions = [];
+        const ctrl = new ReactiveControl({
+            layerId: 'fires',
+            displayName: 'Fires',
+            config,
+            apply: (a) => actions.push(a),
+            doc: null,
+        });
+        return { ctrl, actions };
+    };
+
+    it('applies an initial action on construction at the default value', () => {
+        const { actions } = makeControl({ field: 'YEAR_', min: 1835, max: 2024, mode: 'cumulative' });
+        // cumulative default = max → reveals everything up front
+        expect(actions).toEqual([{ kind: 'filter', expr: ['<=', ['get', 'YEAR_'], 2024] }]);
+    });
+
+    it('step mode defaults the initial value to min', () => {
+        const { actions } = makeControl({ field: 'YEAR_', min: 1835, max: 2024, mode: 'step' });
+        expect(actions[0]).toEqual({ kind: 'filter', expr: ['==', ['get', 'YEAR_'], 1835] });
+    });
+
+    it('honours an explicit default value', () => {
+        const { actions } = makeControl({ field: 'YEAR_', min: 1835, max: 2024, default: 1990 });
+        expect(actions[0]).toEqual({ kind: 'filter', expr: ['<=', ['get', 'YEAR_'], 1990] });
+    });
+
+    it('setValue recomputes and re-applies the action', () => {
+        const { ctrl, actions } = makeControl({ field: 'YEAR_', min: 1835, max: 2024 });
+        ctrl.setValue(2000);
+        expect(actions.at(-1)).toEqual({ kind: 'filter', expr: ['<=', ['get', 'YEAR_'], 2000] });
+    });
+
+    it('setValue clamps to [min, max]', () => {
+        const { ctrl, actions } = makeControl({ field: 'YEAR_', min: 1835, max: 2024 });
+        ctrl.setValue(5000);
+        expect(actions.at(-1)).toEqual({ kind: 'filter', expr: ['<=', ['get', 'YEAR_'], 2024] });
+        ctrl.setValue(0);
+        expect(actions.at(-1)).toEqual({ kind: 'filter', expr: ['<=', ['get', 'YEAR_'], 1835] });
+    });
+
+    it('throws when min/max are missing', () => {
+        expect(() => makeControl({ field: 'YEAR_' })).toThrow(/min and max/);
+    });
+
+    it('destroy is safe with no DOM panel', () => {
+        const { ctrl } = makeControl({ field: 'YEAR_', min: 1835, max: 2024 });
+        expect(() => ctrl.destroy()).not.toThrow();
+        expect(ctrl.destroyed).toBe(true);
+    });
+});


### PR DESCRIPTION
## What

Adds a **reactive-parameter slider** to map layers — the generic primitive proposed in #147. The headline use is a **temporal filter**: scrub a year/date field across its range, either cumulatively ("show everything up to year N") or one step at a time, with optional autoplay. CAL FIRE wildfire perimeters (1835→2024) is the motivating dataset.

Two entry points:

- **Declarative** — a `control` block on an asset in `layers-input.json`:
  ```json
  "control": {
    "type": "slider", "field": "YEAR_", "label": "Year",
    "min": 1835, "max": 2024, "step": 1,
    "mode": "cumulative", "animate": true, "duration_seconds": 20
  }
  ```
- **Agent tool** — `create_slider` lets the LLM attach a slider on request ("let me step through the fire years").

The slider rebinds a MapLibre filter on every drag/tick **client-side — no LLM round-trip per step**.

## Generic by design

Per the #147 discussion (the temporal slider is one instance of a reactive-parameter control), this is built as a generic primitive: `bind: "filter"` is implemented; `style`/`query` binds are reserved seams in `buildControlAction` so the landscape-frontiers weight slider can follow without re-architecting.

## Design

Modeled on the existing `TrajectoryAnimation` (#146): `ReactiveControl` owns its own floating panel + RAF autoplay loop, with `setVisible`/`destroy` lifecycle so `MapManager` drives it like any layer control.

- `app/reactive-control.js` (new) — `ReactiveControl` + pure, tested `buildControlAction()`
- `app/map-manager.js` — `_registerControl` / `_applyControlAction` / `createSlider`; control toggles with layer visibility; works on versioned layers
- `app/dataset-catalog.js` — threads `control` through standard + versioned configs
- `app/map-tools.js` — `create_slider` tool
- `app/style.css` — `.reactive-controls` panel (matches `.anim-controls`)
- `docs/guide/configuration.md` — new "Reactive-parameter controls" section

## Correctness / perf (from an adversarial review pass)

- **Cheap per-frame apply** — the slider applies filters via a lightweight path that skips `setFilter`'s `queryRenderedFeatures` + `describeFilter` (those ran ~60×/s during autoplay and caused stutter on large layers).
- **Composes with `default_filter`** — applies `["all", default_filter, sliderPredicate]` so a configured base predicate isn't wiped.
- **Renders the final frame** before looping (the max year no longer flickers past unseen).
- **Surfaces mount failures** — `create_slider` awaits registration and reports a real error instead of false success if the lazy import fails.

## Tests

`npm test` → **366 passing**. New: `reactive-control` (buildControlAction + no-DOM core), `create_slider` tool, `_applyControlAction` (compose + cheap-path), and `control` passthrough in dataset-catalog.

## Follow-ups (intentionally out of scope)

- `style`/`query` binds (the weight-slider consumer).
- Extracting a shared playback base shared with `TrajectoryAnimation` (both now run their own RAF loop). The panel-overlap divergence between the two is fixed here; the larger refactor is deferred.

Closes #147.

---
🤖 This is **PR A** of two for sliders+charts. **PR B (charts, #277) will stack on this branch** so that after both merge, a single `main` SHA carries both features to pin and test downstream.