### PR TITLE
fix(agent): configurable LLM timeout, default 600s (was 300s)

### DIFF
--- a/app/agent.js
+++ b/app/agent.js
@@ -370,9 +370,33 @@ export class Agent {
     }
 
     /**
+     * Resolve the per-attempt LLM timeout in milliseconds. Mirrors
+     * `_samplingParams` resolution: per-model `llm_timeout_seconds` wins, then
+     * global config, then a built-in default.
+     *
+     * Default is 600s to match the upstream llm-proxy's own timeout — a
+     * shorter client cutoff (the old 300s) aborts responses the proxy would
+     * still deliver, which made slow-decode models (e.g. glm-5.2, or anything
+     * on the gb10) unusable. Slow reasoning models legitimately spend minutes
+     * decoding; the client must not be the premature limiter. Raise per-model
+     * (or globally) when the whole chain is configured to run longer.
+     */
+    _llmTimeoutMs(modelConfig) {
+        const s = ('llm_timeout_seconds' in (modelConfig ?? {}))
+            ? modelConfig.llm_timeout_seconds
+            : this.config?.llm_timeout_seconds;
+        return Number.isFinite(s) && s > 0 ? s * 1000 : 600000;
+    }
+
+    /**
      * Call the LLM API, with one auto-retry on transient errors (gateway 5xx,
-     * network blips, client-side timeout). The retry uses a tight 90s timeout
-     * so a still-dead model fails fast instead of burning another 5 minutes.
+     * network blips, client-side timeout).
+     *
+     * Retry timeout depends on the failure: a *timeout* means the model is
+     * slow, not dead, so the retry gets the full budget again (a short retry
+     * window a slow model is guaranteed to blow through just wastes a round).
+     * A fast transient failure (5xx / network blip) keeps a tight 90s retry so
+     * a genuinely-dead endpoint fails fast instead of burning the full budget.
      */
     async callLLM(endpoint, modelConfig, messages, tools) {
         const payload = {
@@ -384,16 +408,18 @@ export class Agent {
             ...this._samplingParams(modelConfig),
         };
 
+        const timeoutMs = this._llmTimeoutMs(modelConfig);
         try {
-            return await this._attemptLLMCall(endpoint, modelConfig, payload, 300000);
+            return await this._attemptLLMCall(endpoint, modelConfig, payload, timeoutMs);
         } catch (error) {
             if (!this._isTransientLLMError(error)) throw error;
             if (this.abortController?.signal.aborted) throw error; // user-Stop, don't retry
 
-            console.warn('[Agent] Transient LLM error, retrying with 90s timeout:', error.message);
+            const retryMs = error.timedOut ? timeoutMs : 90000;
+            console.warn(`[Agent] Transient LLM error, retrying with ${Math.round(retryMs / 1000)}s timeout:`, error.message);
             this.onRetry?.(error);
 
-            return await this._attemptLLMCall(endpoint, modelConfig, payload, 90000);
+            return await this._attemptLLMCall(endpoint, modelConfig, payload, retryMs);
         }
     }
 

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -440,6 +440,7 @@ To change sampling, set any of `temperature`, `top_p`, or `seed`. Each is read *
 | `temperature` | per-model and/or top-level | `0` | Sampling temperature. `0` is the most deterministic; raise it for more varied/creative output. Set to `null` on a model to omit it entirely and inherit the endpoint's own default. |
 | `top_p` | per-model and/or top-level | unset | Nucleus-sampling cutoff. |
 | `seed` | per-model and/or top-level | unset | Fixed RNG seed, where the provider honors it. |
+| `llm_timeout_seconds` | per-model and/or top-level | `600` | Per-attempt client-side timeout for an LLM request. Resolved per-model first, then top-level. The default matches the upstream llm-proxy's own timeout; a shorter value aborts responses the proxy would still deliver, which makes slow-decode models (e.g. `glm-5.2`, or anything on the gb10) unusable. Raise it per-model for slow reasoning models when the whole request chain is configured to run longer. |
 
 > **Reproducibility caveat:** open-weights MoE inference (e.g. minimax-m2) is not bit-reproducible even at `temperature: 0`, so this is necessary-but-not-sufficient — pair it with a pinned methodology for headline numbers.
 

--- a/test/agent-retry.test.js
+++ b/test/agent-retry.test.js
@@ -226,6 +226,59 @@ describe('Agent.callLLM retry orchestration', () => {
         expect(global.fetch).toHaveBeenCalledTimes(2);
         expect(onRetry).toHaveBeenCalledOnce();
     });
+
+    it('retries a timeout with the full budget, not the tight 90s window', async () => {
+        // Spy the single-attempt call so we can read the timeoutMs it was
+        // handed on each attempt without dealing with real timers.
+        const spy = vi.spyOn(agent, '_attemptLLMCall')
+            .mockRejectedValueOnce(Object.assign(new Error('timed out'), { timedOut: true }))
+            .mockResolvedValueOnce({ role: 'assistant', content: 'ok' });
+        agent.config.llm_timeout_seconds = 480; // 8 min per-turn budget
+
+        const msg = await agent.callLLM('https://x/v1', { api_key: 'k' }, [], []);
+        expect(msg.content).toBe('ok');
+        // Both attempts get the full 480s — a timeout means slow, not dead.
+        expect(spy.mock.calls[0][3]).toBe(480000);
+        expect(spy.mock.calls[1][3]).toBe(480000);
+    });
+
+    it('retries a fast transient failure (5xx) with the tight 90s window', async () => {
+        const spy = vi.spyOn(agent, '_attemptLLMCall')
+            .mockRejectedValueOnce(Object.assign(new Error('boom'), { status: 503 }))
+            .mockResolvedValueOnce({ role: 'assistant', content: 'ok' });
+        agent.config.llm_timeout_seconds = 480;
+
+        await agent.callLLM('https://x/v1', { api_key: 'k' }, [], []);
+        expect(spy.mock.calls[0][3]).toBe(480000); // first attempt: full budget
+        expect(spy.mock.calls[1][3]).toBe(90000);  // retry: tight window
+    });
+});
+
+describe('Agent._llmTimeoutMs', () => {
+    const makeAgentWithConfig = (config) =>
+        new Agent({ llm_models: [{ value: 'm', endpoint: 'https://x/v1', api_key: 'k' }], ...config }, stubToolRegistry);
+
+    it('defaults to 600s when nothing is configured', () => {
+        expect(makeAgentWithConfig({})._llmTimeoutMs({})).toBe(600000);
+    });
+
+    it('reads llm_timeout_seconds from the per-model config', () => {
+        expect(makeAgentWithConfig({})._llmTimeoutMs({ llm_timeout_seconds: 900 })).toBe(900000);
+    });
+
+    it('falls back to global config when per-model is unset', () => {
+        expect(makeAgentWithConfig({ llm_timeout_seconds: 720 })._llmTimeoutMs({})).toBe(720000);
+    });
+
+    it('per-model value overrides the global default', () => {
+        expect(makeAgentWithConfig({ llm_timeout_seconds: 300 })._llmTimeoutMs({ llm_timeout_seconds: 1200 })).toBe(1200000);
+    });
+
+    it('ignores non-positive / non-finite values and uses the default', () => {
+        expect(makeAgentWithConfig({})._llmTimeoutMs({ llm_timeout_seconds: 0 })).toBe(600000);
+        expect(makeAgentWithConfig({})._llmTimeoutMs({ llm_timeout_seconds: -5 })).toBe(600000);
+        expect(makeAgentWithConfig({})._llmTimeoutMs({ llm_timeout_seconds: 'x' })).toBe(600000);
+    });
 });
 
 describe('Agent._samplingParams', () => {


### PR DESCRIPTION
## Problem

The client-side per-attempt LLM timeout was **300s**. Our upstream `open-llm-proxy` holds requests up to **600s**, so a legitimate slow response (long reasoning / slow decode) was being **aborted client-side before the proxy would have delivered it**. This makes slow-decode models — `glm-5.2`, and anything running on our gb10 (e.g. nemotron) — effectively unusable: the answer is killed mid-generation.

## Change

- **`_llmTimeoutMs(modelConfig)`** — resolves the per-attempt timeout per-model → top-level → built-in default, mirroring `_samplingParams`. Default is **600s** to match the proxy, so the client is no longer the premature limiter.
- **Retry budget** — on a *timeout*-triggered retry the model is slow, not dead, so the retry now reuses the **full budget** instead of the tight 90s window (a 90s retry is guaranteed to blow through for a slow model, wasting a round). Fast transient failures (5xx / network blip) keep the 90s fast-retry.
- **Config:** `llm_timeout_seconds`, per-model and/or top-level. Documented in `docs/guide/configuration.md` alongside the sampling params. Raise it per-model for slow reasoning models when the whole chain is configured to run longer than the proxy's current 600s.

## Tests

`test/agent-retry.test.js`: timeout resolution (per-model/global/default/invalid) + retry-budget selection (full budget on timeout, 90s on fast transient). Full suite: 352 passing.

## Follow-ups (separate issues)

Part of a broader performance pass — related issues being filed for client-side memoization of idempotent read tools and a prefill-vs-decode measurement plan.