### PR TITLE
fix(agent): recover from malformed tool calls instead of terminating (#288)

### DIFF
--- a/app/agent.js
+++ b/app/agent.js
@@ -154,6 +154,13 @@ export class Agent {
         // re-issuing a local tool — e.g. set_filter failing — would loop forever
         // with no checkpoint to stop it (#243). This counter bounds that.
         let localOnlyStreak = 0;
+        // Malformed-tool-call recovery attempts this turn (#288). When the model
+        // emits something that *looks* like a tool call but we can't parse it, we
+        // re-prompt it to re-emit a well-formed call instead of silently treating
+        // the garbage as a final answer. Bounded so a model that simply cannot
+        // produce a parseable call falls through to its text rather than looping.
+        let parseRetries = 0;
+        const MAX_PARSE_RETRIES = 2;
 
         try {
         while (true) {
@@ -184,6 +191,13 @@ export class Agent {
             // the message so it isn't re-sent on subsequent turns.
             const reasoning = this.extractReasoning(message);
             if (reasoning) this.onReasoning(reasoning, iterations);
+            // Canonicalize native tool-call arguments before they enter history
+            // (#288, failure mode 2): a malformed `arguments` string (e.g. an
+            // extra trailing brace) is parseable-for-execution below but, left
+            // verbatim in the assistant message, poisons the *next* upstream
+            // request (400 Extra data). Normalize once here so history is always
+            // valid JSON regardless of what the model emitted.
+            this.normalizeToolCallArguments(message);
             turnMessages.push(message);
 
             // Check for tool calls
@@ -191,6 +205,9 @@ export class Agent {
             const embeddedCalls = toolCalls.length === 0 ? this.parseEmbeddedToolCalls(message.content) : [];
 
             if (toolCalls.length > 0 || embeddedCalls.length > 0) {
+                // A parseable call ends any malformed-call streak — a single glitch
+                // over a long turn shouldn't accumulate toward the recovery cap.
+                parseRetries = 0;
                 const calls = toolCalls.length > 0 ? toolCalls : this.syntheticToolCalls(embeddedCalls);
 
                 // Classify: are all calls local (auto-approve) or mixed?
@@ -271,8 +288,28 @@ export class Agent {
                 continue;
             }
 
-            // No tool calls — final response
             const content = message.content || '';
+
+            // Malformed tool-call recovery (#288, failure modes 1 & 3): we got
+            // neither structured tool_calls nor a parseable embedded call, yet the
+            // content looks like the model *tried* to call a tool (wrong wrapper,
+            // mismatched close tag, or invalid inner JSON). Rather than silently
+            // returning the garbage as the final answer, nudge it to re-emit a
+            // well-formed call and continue the loop. Bounded by MAX_PARSE_RETRIES
+            // so a model that can't recover degrades to its text instead of looping.
+            if (parseRetries < MAX_PARSE_RETRIES && this.looksLikeAttemptedToolCall(content)) {
+                parseRetries++;
+                turnMessages.push({
+                    role: 'user',
+                    content: 'That looked like a tool call but could not be parsed. Re-emit it as a single '
+                        + 'well-formed call: <tool_call>{"name": "<tool_name>", "arguments": {…}}</tool_call> '
+                        + 'with valid JSON and a matching </tool_call> tag. If you already have your answer, '
+                        + 'reply in plain text instead.',
+                });
+                continue;
+            }
+
+            // No tool calls — final response
             if (!content.trim()) {
                 return {
                     response: 'I received your question but had trouble generating a response. Please try rephrasing.',
@@ -505,28 +542,34 @@ export class Agent {
     parseEmbeddedToolCalls(content) {
         if (!content) return [];
         const calls = [];
-        const pattern = /<tool_call>([^<]+)<\/tool_call>/gi;
+        // Tolerant extractor (#288, failure mode 1): capture from <tool_call> up to
+        // the *first* of a closing tag (</… — including a mismatched </parameter>),
+        // a new <tool_call>, or EOF, instead of requiring an exact </tool_call> with
+        // no interior '<'. The lookahead leaves the terminator unconsumed; each match
+        // still consumes the literal <tool_call>, so lastIndex always advances.
+        const pattern = /<tool_call>\s*([\s\S]*?)\s*(?=<\/|<tool_call>|$)/gi;
         let match;
 
         while ((match = pattern.exec(content)) !== null) {
             const inner = match[1].trim();
+            if (!inner) continue;
 
-            // Try JSON: {"name": "tool", "arguments": {...}}
-            try {
-                const parsed = JSON.parse(inner);
-                if (parsed.name) {
-                    calls.push({ name: parsed.name, args: parsed.arguments || {} });
-                    continue;
-                }
-            } catch { /* not JSON */ }
+            // Try JSON: {"name": "tool", "arguments": {...}} — lenient, so a trailing
+            // extra brace (failure mode 2's cousin) still yields a usable call.
+            const parsed = this.parseLenientJSON(inner);
+            if (parsed && parsed.name) {
+                calls.push({ name: parsed.name, args: parsed.arguments || {} });
+                continue;
+            }
 
             // Try function call: tool_name({"arg": "val"})
-            const funcMatch = inner.match(/^(\w+)\s*\((.+)\)$/s);
+            const funcMatch = inner.match(/^(\w+)\s*\(([\s\S]+)\)$/);
             if (funcMatch) {
-                try {
-                    calls.push({ name: funcMatch[1], args: JSON.parse(funcMatch[2]) });
+                const args = this.parseLenientJSON(funcMatch[2]);
+                if (args !== undefined) {
+                    calls.push({ name: funcMatch[1], args });
                     continue;
-                } catch { /* bad args */ }
+                }
             }
 
             // Simple name
@@ -536,6 +579,91 @@ export class Agent {
         }
 
         return calls;
+    }
+
+    /**
+     * Parse a JSON value leniently (#288, failure mode 2/3). Tries a strict parse
+     * first; on failure, falls back to a raw_decode-style scan that returns the
+     * first complete, balanced JSON object/array and ignores any trailing junk —
+     * recovering the common `{"k": "v"}}` extra-brace case. Returns the parsed
+     * value, or `undefined` if nothing valid could be extracted.
+     */
+    parseLenientJSON(str) {
+        if (typeof str !== 'string') return undefined;
+        const s = str.trim();
+        if (!s) return undefined;
+        try {
+            return JSON.parse(s);
+        } catch { /* fall through to raw_decode */ }
+        return this._decodeFirstJSON(s);
+    }
+
+    /**
+     * raw_decode helper: scan from the first '{' or '[' and return the first
+     * balanced, valid JSON value, respecting strings and escapes. Trailing text
+     * after the balanced value is ignored. Returns `undefined` on no match.
+     */
+    _decodeFirstJSON(s) {
+        const start = s.search(/[{[]/);
+        if (start === -1) return undefined;
+        const open = s[start];
+        const close = open === '{' ? '}' : ']';
+        let depth = 0, inStr = false, esc = false;
+        for (let i = start; i < s.length; i++) {
+            const c = s[i];
+            if (inStr) {
+                if (esc) esc = false;
+                else if (c === '\\') esc = true;
+                else if (c === '"') inStr = false;
+                continue;
+            }
+            if (c === '"') { inStr = true; continue; }
+            if (c === open) depth++;
+            else if (c === close && --depth === 0) {
+                try {
+                    return JSON.parse(s.slice(start, i + 1));
+                } catch {
+                    return undefined;
+                }
+            }
+        }
+        return undefined;
+    }
+
+    /**
+     * Canonicalize a message's native tool-call `arguments` to valid JSON strings
+     * (#288, failure mode 2). A malformed `arguments` string left verbatim in the
+     * assistant message poisons the next upstream request. We parse leniently and
+     * re-serialize; anything unrecoverable becomes `{}` so history stays valid.
+     * Mutates the message in place.
+     */
+    normalizeToolCallArguments(message) {
+        if (!Array.isArray(message?.tool_calls)) return;
+        for (const tc of message.tool_calls) {
+            if (!tc.function) continue;
+            const raw = tc.function.arguments;
+            if (typeof raw !== 'string') {
+                // Some backends hand back an object — canonicalize to a string.
+                tc.function.arguments = JSON.stringify(raw ?? {});
+                continue;
+            }
+            const parsed = this.parseLenientJSON(raw);
+            tc.function.arguments = JSON.stringify(parsed ?? {});
+        }
+    }
+
+    /**
+     * Heuristic (#288): does this content look like an *attempted* tool call that
+     * we failed to parse? Kept tight to avoid re-prompting genuine final answers.
+     */
+    looksLikeAttemptedToolCall(content) {
+        if (!content) return false;
+        if (/<tool_call/i.test(content)) return true;
+        if (/"(?:name|function|parameters|arguments)"\s*:/.test(content)) return true;
+        // Bare function-call shape against a known tool, e.g. get_schema({...}).
+        const m = content.match(/\b(\w+)\s*\(\s*[{[]/);
+        if (m && this.toolRegistry.has(m[1])) return true;
+        return false;
     }
 
     /**

--- a/test/agent-tool-parse.test.js
+++ b/test/agent-tool-parse.test.js
@@ -1,0 +1,245 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { Agent } from '../app/agent.js';
+
+// Regression tests for #288: the tool-call parser used to fail silently and
+// terminally on malformed calls, killing runs from otherwise-capable weaker
+// models. These cover the three observed failure modes plus the helpers.
+
+const stubRegistry = (overrides = {}) => ({
+    getToolsForLLM: () => [],
+    isLocal: () => true,
+    has: (name) => ['get_schema', 'query', 'set_filter'].includes(name),
+    execute: async () => ({ result: '' }),
+    ...overrides,
+});
+
+const baseConfig = (overrides = {}) => ({
+    llm_models: [{ value: 'm', endpoint: 'https://x/v1', api_key: 'k' }],
+    ...overrides,
+});
+
+const okText = (content) => ({
+    ok: true,
+    json: async () => ({ choices: [{ message: { role: 'assistant', content } }] }),
+});
+
+const agentFor = (registryOverrides = {}) =>
+    new Agent(baseConfig(), stubRegistry(registryOverrides));
+
+describe('parseEmbeddedToolCalls — tolerant extraction (#288)', () => {
+    it('parses a well-formed embedded call (baseline)', () => {
+        const a = agentFor();
+        const calls = a.parseEmbeddedToolCalls(
+            '<tool_call>{"name": "get_schema", "arguments": {"dataset_id": "ebsa"}}</tool_call>');
+        expect(calls).toEqual([{ name: 'get_schema', args: { dataset_id: 'ebsa' } }]);
+    });
+
+    it('recovers a mismatched closing tag (failure mode 1)', () => {
+        const a = agentFor();
+        // Wrong wrapper close tag: </parameter> instead of </tool_call>. The old
+        // regex required an exact </tool_call> and no interior '<' → zero matches.
+        const calls = a.parseEmbeddedToolCalls(
+            '<tool_call>{"name": "get_schema", "arguments": {"dataset_id":"ebsa"}} </parameter>');
+        expect(calls).toEqual([{ name: 'get_schema', args: { dataset_id: 'ebsa' } }]);
+    });
+
+    it('recovers a missing closing tag (EOF terminator)', () => {
+        const a = agentFor();
+        const calls = a.parseEmbeddedToolCalls(
+            'sure, calling it:\n<tool_call>{"name": "query", "arguments": {"sql": "select 1"}}');
+        expect(calls).toEqual([{ name: 'query', args: { sql: 'select 1' } }]);
+    });
+
+    it('recovers an inner JSON with a trailing extra brace (lenient parse)', () => {
+        const a = agentFor();
+        const calls = a.parseEmbeddedToolCalls(
+            '<tool_call>{"name": "get_schema", "arguments": {"dataset_id": "ebsa"}}}</tool_call>');
+        expect(calls).toEqual([{ name: 'get_schema', args: { dataset_id: 'ebsa' } }]);
+    });
+
+    it('does not break on interior "<" that is not a closing tag (filter operators)', () => {
+        const a = agentFor();
+        // A '<' comparison operator inside args must NOT terminate extraction —
+        // the old [^<]+ regex broke on this entirely.
+        const calls = a.parseEmbeddedToolCalls(
+            '<tool_call>{"name": "set_filter", "arguments": {"expr": ["<", 5]}}</tool_call>');
+        expect(calls).toEqual([{ name: 'set_filter', args: { expr: ['<', 5] } }]);
+    });
+
+    it('parses the function-call shape: name({...})', () => {
+        const a = agentFor();
+        const calls = a.parseEmbeddedToolCalls(
+            '<tool_call>get_schema({"dataset_id": "ebsa"})</tool_call>');
+        expect(calls).toEqual([{ name: 'get_schema', args: { dataset_id: 'ebsa' } }]);
+    });
+
+    it('parses a bare known tool name with no args', () => {
+        const a = agentFor();
+        const calls = a.parseEmbeddedToolCalls('<tool_call>query</tool_call>');
+        expect(calls).toEqual([{ name: 'query', args: {} }]);
+    });
+
+    it('parses multiple embedded calls in one message', () => {
+        const a = agentFor();
+        const calls = a.parseEmbeddedToolCalls(
+            '<tool_call>{"name":"get_schema","arguments":{"dataset_id":"a"}}</tool_call>'
+            + '<tool_call>{"name":"query","arguments":{"sql":"select 1"}}</tool_call>');
+        expect(calls).toEqual([
+            { name: 'get_schema', args: { dataset_id: 'a' } },
+            { name: 'query', args: { sql: 'select 1' } },
+        ]);
+    });
+
+    it('returns [] on structurally-invalid inner JSON (failure mode 3)', () => {
+        const a = agentFor();
+        // {"function:get_schema", ...} is not recoverable JSON, not a func-call
+        // shape, and not a bare name → 0 calls. Recovery is handled by the loop.
+        const calls = a.parseEmbeddedToolCalls(
+            '<tool_call>{"function:get_schema", "parameters":{"dataset_id":"ebsa"}}</tool_call>');
+        expect(calls).toEqual([]);
+    });
+
+    it('returns [] on empty/absent content', () => {
+        const a = agentFor();
+        expect(a.parseEmbeddedToolCalls('')).toEqual([]);
+        expect(a.parseEmbeddedToolCalls(null)).toEqual([]);
+        expect(a.parseEmbeddedToolCalls('just a normal answer')).toEqual([]);
+    });
+});
+
+describe('parseLenientJSON / _decodeFirstJSON (#288)', () => {
+    it('parses valid JSON strictly', () => {
+        const a = agentFor();
+        expect(a.parseLenientJSON('{"a": 1}')).toEqual({ a: 1 });
+    });
+
+    it('recovers a trailing extra brace', () => {
+        const a = agentFor();
+        expect(a.parseLenientJSON('{"dataset_id": "ebsa"}}')).toEqual({ dataset_id: 'ebsa' });
+    });
+
+    it('ignores trailing prose after a complete object', () => {
+        const a = agentFor();
+        expect(a.parseLenientJSON('{"a": 1} and then some words')).toEqual({ a: 1 });
+    });
+
+    it('does not confuse a brace inside a string for the closer', () => {
+        const a = agentFor();
+        expect(a.parseLenientJSON('{"a": "}"}}')).toEqual({ a: '}' });
+    });
+
+    it('returns undefined when nothing valid can be extracted', () => {
+        const a = agentFor();
+        expect(a.parseLenientJSON('not json at all')).toBeUndefined();
+        expect(a.parseLenientJSON('')).toBeUndefined();
+        expect(a.parseLenientJSON(null)).toBeUndefined();
+    });
+});
+
+describe('normalizeToolCallArguments (#288 failure mode 2)', () => {
+    it('repairs a trailing extra brace so history is valid JSON', () => {
+        const a = agentFor();
+        const message = {
+            role: 'assistant',
+            tool_calls: [{ id: 'c1', type: 'function',
+                function: { name: 'get_schema', arguments: '{"dataset_id": "ebsa"}}' } }],
+        };
+        a.normalizeToolCallArguments(message);
+        expect(message.tool_calls[0].function.arguments).toBe('{"dataset_id":"ebsa"}');
+        // and it must round-trip cleanly (the check that prevents the 400)
+        expect(() => JSON.parse(message.tool_calls[0].function.arguments)).not.toThrow();
+    });
+
+    it('replaces unrecoverable arguments with {}', () => {
+        const a = agentFor();
+        const message = {
+            role: 'assistant',
+            tool_calls: [{ id: 'c1', type: 'function',
+                function: { name: 'get_schema', arguments: 'total garbage' } }],
+        };
+        a.normalizeToolCallArguments(message);
+        expect(message.tool_calls[0].function.arguments).toBe('{}');
+    });
+
+    it('canonicalizes an object-typed arguments field to a string', () => {
+        const a = agentFor();
+        const message = {
+            role: 'assistant',
+            tool_calls: [{ id: 'c1', type: 'function',
+                function: { name: 'get_schema', arguments: { dataset_id: 'ebsa' } } }],
+        };
+        a.normalizeToolCallArguments(message);
+        expect(message.tool_calls[0].function.arguments).toBe('{"dataset_id":"ebsa"}');
+    });
+
+    it('is a no-op for messages without tool_calls', () => {
+        const a = agentFor();
+        const message = { role: 'assistant', content: 'hi' };
+        expect(() => a.normalizeToolCallArguments(message)).not.toThrow();
+        expect(message).toEqual({ role: 'assistant', content: 'hi' });
+    });
+});
+
+describe('looksLikeAttemptedToolCall (#288)', () => {
+    it('flags a stray <tool_call tag', () => {
+        expect(agentFor().looksLikeAttemptedToolCall('<tool_call>oops')).toBe(true);
+    });
+    it('flags JSON-shaped call keys', () => {
+        expect(agentFor().looksLikeAttemptedToolCall('{"function": "get_schema"}')).toBe(true);
+    });
+    it('flags a bare call against a known tool', () => {
+        expect(agentFor().looksLikeAttemptedToolCall('get_schema({"dataset_id": "ebsa"})')).toBe(true);
+    });
+    it('does not flag a call against an unknown name', () => {
+        expect(agentFor().looksLikeAttemptedToolCall('fibonacci({"n": 10})')).toBe(false);
+    });
+    it('does not flag a plain final answer', () => {
+        expect(agentFor().looksLikeAttemptedToolCall('The answer is 42 square kilometers.')).toBe(false);
+    });
+});
+
+describe('agent loop — malformed-call recovery (#288 failure mode 1/3)', () => {
+    afterEach(() => { vi.restoreAllMocks(); });
+
+    it('re-prompts on an unparseable call instead of terminating, then completes', async () => {
+        // Round 1: garbage that looks like a call but yields 0 parsed calls.
+        // Round 2 (after the corrective nudge): a clean final answer.
+        global.fetch = vi.fn()
+            .mockResolvedValueOnce(okText('<tool_call>{"function:get_schema", "parameters":{}}</tool_call>'))
+            .mockResolvedValueOnce(okText('The answer is 42.'));
+        const agent = agentFor();
+        agent.autoApprove = true;
+
+        const { response } = await agent.processMessage('how much?');
+
+        expect(response).toBe('The answer is 42.');
+        expect(global.fetch.mock.calls.length).toBe(2); // it recovered, didn't stop at round 1
+    });
+
+    it('stops re-prompting after the cap and falls through to the content', async () => {
+        // The model NEVER produces a parseable call — always garbage. The loop
+        // must bound the corrective retries (2) and then return the content
+        // rather than looping forever.
+        global.fetch = vi.fn().mockResolvedValue(
+            okText('<tool_call>{"function:get_schema", "parameters":{}}</tool_call>'));
+        const agent = agentFor();
+        agent.autoApprove = true;
+
+        const { response } = await agent.processMessage('how much?');
+
+        // 1 initial + 2 corrective retries = 3 calls, then falls through.
+        expect(global.fetch.mock.calls.length).toBe(3);
+        expect(response).toContain('<tool_call>');
+    });
+
+    it('does not re-prompt a genuine final answer', async () => {
+        global.fetch = vi.fn().mockResolvedValueOnce(okText('The area is 42 sq km.'));
+        const agent = agentFor();
+        agent.autoApprove = true;
+
+        const { response } = await agent.processMessage('how much?');
+
+        expect(response).toBe('The area is 42 sq km.');
+        expect(global.fetch.mock.calls.length).toBe(1);
+    });
+});


### PR DESCRIPTION
Closes #288.

Weaker/quantized models are analytically capable but frequently emit tool calls with **syntax** the parser couldn't survive — killing runs that would otherwise complete. On the nimbus (`Qwen3.6-35B-A3B-NVFP4`) benchmark cited in the issue, correct answers were produced whenever the call was well-formed, but only 1/4 runs completed; the other three died on tool-call syntax, not reasoning. These are cheap, model-agnostic robustness wins.

## The three failure modes (all confirmed against `main`)

**1 — Mismatched / absent close tag → silent termination.** `parseEmbeddedToolCalls`'s regex `/<tool_call>([^<]+)<\/tool_call>/gi` required an exact `</tool_call>` and forbade any interior `<`, so `<tool_call>…</parameter>` (or a missing close tag) yielded **zero** matches and the garbage was returned as the final answer.
→ Tolerant extractor: match lazily up to the first closing tag, next `<tool_call>`, or EOF. As a bonus this also stops breaking on legitimate interior `<` (e.g. `["<", 5]` filter operators).

**2 — Extra trailing brace in native `arguments` poisons history.** `{"dataset_id":"ebsa"}}` is caught for *execution* ([`agent.js:240`](../blob/main/app/agent.js#L240)) but the assistant message was pushed to history **verbatim** at [`agent.js:187`](../blob/main/app/agent.js#L187), so the *next* upstream request was rejected with `400 Extra data: line 1 column 23` — a non-transient error that kills the whole turn.
→ New `normalizeToolCallArguments()` canonicalizes every tool-call `arguments` to valid JSON *before* it enters history; unrecoverable payloads become `{}`.

**3 — Unparseable inner JSON → silent termination.** `{"function:get_schema", …}` parses as neither JSON nor a `name(...)` shape → 0 calls → same silent termination as mode 1.
→ The loop now detects "this looked like a tool call but didn't parse" and **re-prompts** the model to re-emit a well-formed call, bounded by `MAX_PARSE_RETRIES` (2) so a model that genuinely can't recover degrades to returning its text instead of looping forever. The heuristic is kept tight (stray `<tool_call`, JSON call-keys, or a bare call against a *known* tool) to avoid re-prompting genuine final answers.

Also adds `parseLenientJSON` (a `raw_decode`-style parser: strict parse first, then first-balanced-value scan) shared by the embedded and native paths to recover trailing-junk cases.

## Design notes / deviations from the issue's suggestions
- The issue lists lenient JSON (#3) as optional; it's included because *recovering* the extra-brace case raises completion rates more than merely neutralizing it.
- The corrective-reprompt (#1) gets its own retry cap — these rounds produce **zero** tool calls, so neither `iterations` nor `localOnlyStreak` bounds them; without a dedicated cap a model stuck emitting garbage would loop forever.

## Tests
New `test/agent-tool-parse.test.js` — 27 cases across all three failure modes, the lenient parser, argument normalization, the heuristic, and the end-to-end recovery loop (re-prompt → complete; cap → fall through; genuine answer → no re-prompt). Full suite: **372 passing**.