### PR TITLE
fix(catalog): retry transient STAC fetch failures on boot (#287)

### DIFF
--- a/app/dataset-catalog.js
+++ b/app/dataset-catalog.js
@@ -883,9 +883,38 @@ export class DatasetCatalog {
 
     // ---- Utilities ----
 
-    async fetchJson(url) {
-        const response = await fetch(url);
-        if (!response.ok) throw new Error(`HTTP ${response.status}: ${url}`);
-        return response.json();
+    async fetchJson(url, { attempts = 3, baseDelayMs = 300 } = {}) {
+        // The catalog fetch is on the boot critical path, so a single transient
+        // blip on the object store (a 5xx, a network drop) must not take the
+        // whole app down. Retry transient failures with exponential backoff;
+        // permanent failures (4xx, malformed JSON) still fail fast. Mirrors the
+        // transient-vs-permanent split in agent.js._isTransientLLMError.
+        for (let attempt = 1; ; attempt++) {
+            try {
+                const response = await fetch(url);
+                if (!response.ok) {
+                    const err = new Error(`HTTP ${response.status}: ${url}`);
+                    err.status = response.status;
+                    throw err;
+                }
+                return await response.json();
+            } catch (error) {
+                if (attempt >= attempts || !this._isTransientFetchError(error)) throw error;
+                const delayMs = baseDelayMs * 2 ** (attempt - 1);
+                console.warn(`[Catalog] Transient fetch error for ${url} (attempt ${attempt}/${attempts}), retrying in ${delayMs}ms: ${error.message}`);
+                await new Promise(resolve => setTimeout(resolve, delayMs));
+            }
+        }
+    }
+
+    /**
+     * Classify a fetch failure as transient (worth retrying) or permanent.
+     * Retry on: network errors (surface as TypeError), HTTP 5xx.
+     * Skip on: HTTP 4xx (bad/missing URL), JSON parse errors, anything else.
+     */
+    _isTransientFetchError(error) {
+        if (error.name === 'TypeError') return true;
+        if (typeof error.status === 'number' && error.status >= 500 && error.status < 600) return true;
+        return false;
     }
 }

--- a/test/dataset-catalog.test.js
+++ b/test/dataset-catalog.test.js
@@ -292,6 +292,64 @@ describe('DatasetCatalog.load (mocked fetch)', () => {
     });
 });
 
+describe('DatasetCatalog.fetchJson retry/backoff (issue #287)', () => {
+    let originalFetch, warnSpy;
+    beforeEach(() => {
+        originalFetch = global.fetch;
+        warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    });
+    afterEach(() => {
+        global.fetch = originalFetch;
+        warnSpy.mockRestore();
+    });
+
+    const okResponse = (body) => ({ ok: true, status: 200, json: async () => body });
+    const errResponse = (status) => ({ ok: false, status, json: async () => null });
+
+    it('retries a transient 5xx and succeeds on a later attempt', async () => {
+        const cat = new DatasetCatalog();
+        global.fetch = vi.fn()
+            .mockResolvedValueOnce(errResponse(503))
+            .mockResolvedValueOnce(errResponse(502))
+            .mockResolvedValueOnce(okResponse({ ok: 'data' }));
+
+        const result = await cat.fetchJson('https://x/catalog.json', { baseDelayMs: 0 });
+
+        expect(result).toEqual({ ok: 'data' });
+        expect(global.fetch).toHaveBeenCalledTimes(3);
+    });
+
+    it('retries a transient network TypeError then succeeds', async () => {
+        const cat = new DatasetCatalog();
+        global.fetch = vi.fn()
+            .mockRejectedValueOnce(new TypeError('Failed to fetch'))
+            .mockResolvedValueOnce(okResponse({ ok: 'data' }));
+
+        const result = await cat.fetchJson('https://x/catalog.json', { baseDelayMs: 0 });
+
+        expect(result).toEqual({ ok: 'data' });
+        expect(global.fetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('gives up after the attempt budget and throws the last transient error', async () => {
+        const cat = new DatasetCatalog();
+        global.fetch = vi.fn().mockResolvedValue(errResponse(503));
+
+        await expect(cat.fetchJson('https://x/catalog.json', { attempts: 3, baseDelayMs: 0 }))
+            .rejects.toThrow('HTTP 503');
+        expect(global.fetch).toHaveBeenCalledTimes(3);
+    });
+
+    it('fails fast on a permanent 404 without retrying', async () => {
+        const cat = new DatasetCatalog();
+        global.fetch = vi.fn().mockResolvedValue(errResponse(404));
+
+        await expect(cat.fetchJson('https://x/missing.json', { baseDelayMs: 0 }))
+            .rejects.toThrow('HTTP 404');
+        expect(global.fetch).toHaveBeenCalledTimes(1);
+    });
+});
+
 describe('DatasetCatalog.extractMapLayers', () => {
     const cat = new DatasetCatalog();
 


### PR DESCRIPTION
## Problem

`DatasetCatalog.fetchJson` did a single `fetch` with no retry, and `load()` awaits it on the boot critical path. So **one transient 5xx / network blip on the object store took down the entire app boot** — no retry, no graceful degradation. During the **2026-07-03 `s3-west.nrp-nautilus.io` (Ceph) outage**, every geo-agent app failed to boot and the headless benchmark matrix crashed on all cells before reaching a single LLM call.

## Fix

Add bounded **retry-with-backoff** to `fetchJson` for **transient** failures (HTTP 5xx, network `TypeError`): 3 attempts, exponential backoff (300ms → 600ms). Permanent failures (4xx bad/missing URL, malformed JSON) still **fail fast**, using the same transient-vs-permanent classification pattern as `agent.js._isTransientLLMError`.

- `attempts` / `baseDelayMs` are options with sane defaults; all existing call sites are unchanged (happy path and 404 behavior identical).
- Closes #287.

## Tests

`test/dataset-catalog.test.js` — new `fetchJson retry/backoff` block:
- retries a transient 5xx and succeeds on a later attempt
- retries a network `TypeError` then succeeds
- gives up after the attempt budget and throws the last transient error
- fails fast on a permanent 404 without retrying

Full suite green (383 tests).

## Follow-ups (out of scope, noted in #287)

- A "data backend unavailable — retrying" boot UI state instead of a blank panel.
- An optional mirror/fallback catalog endpoint for degraded-mode boot.