### PR TITLE
docs(charts): note optional title/axis-label params on render_chart

### DIFF
--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -271,7 +271,7 @@ It is **off by default** (zero footprint — the tool isn't registered and no ch
 |---|---|---|---|
 | `enabled` | boolean | `false` | Register the `render_chart` tool and lazy-load the charting library. |
 
-When enabled, the agent calls `render_chart` with a chart type, the columns to plot (`x`, `y`, optional `series`), and the data — either an inline `data` array it already computed, or a `sql` query the panel runs itself (so large result sets never pass back through the LLM; if both are supplied, `sql` wins). Charts render client-side via [Observable Plot](https://observablehq.com/plot/), which (with d3) is fetched from the CDN via SRI-pinned scripts the first time a chart is drawn — downstream apps don't need to add any `<script>` tag. Each chart panel can be **resized** (drag the bottom-right grip — it re-plots to fit) or **popped out** to a large centered view, and closed with the ✕.
+When enabled, the agent calls `render_chart` with a chart type, the columns to plot (`x`, `y`, optional `series`), and the data — either an inline `data` array it already computed, or a `sql` query the panel runs itself (so large result sets never pass back through the LLM; if both are supplied, `sql` wins). An optional `title` and `x_label` / `y_label` override the panel heading and axis captions (axes default to the column names). Charts render client-side via [Observable Plot](https://observablehq.com/plot/), which (with d3) is fetched from the CDN via SRI-pinned scripts the first time a chart is drawn — downstream apps don't need to add any `<script>` tag. Each chart panel can be **resized** (drag the bottom-right grip — it re-plots to fit) or **popped out** to a large centered view, and closed with the ✕.
 
 | Chart type | Shape | Channels |
 |---|---|---|


### PR DESCRIPTION
Small completeness follow-up to the charts docs (#277): the `render_chart` tool accepts optional `title`, `x_label`, and `y_label` params, which weren't mentioned in the Charts section of the configuration reference. Docs-only.