### PR TITLE
feat(agent): user-facing reasoning on/off toggle (#283)

### DIFF
--- a/app/agent.js
+++ b/app/agent.js
@@ -23,6 +23,11 @@ export class Agent {
         this.systemPrompt = '';
         this.messages = [];
         this.selectedModel = config.llm_model || config.llm_models?.[0]?.value || 'default';
+        // Runtime override for model thinking/reasoning, set by the chat-ui toggle.
+        // null = no override (fall back to config default, else omit → model default);
+        // true/false = user asked for reasoning on/off for subsequent turns. Reset to
+        // null on model switch so each model starts from its own configured default.
+        this.reasoningOverride = null;
         // Checkpoint thresholds: how many *remote* tool-call rounds before the
         // agent pauses to report progress and ask to continue. Auto-approve uses
         // the tighter value (the checkpoint is the user's periodic gate); manual
@@ -62,6 +67,9 @@ export class Agent {
      */
     setModel(modelValue) {
         this.selectedModel = modelValue;
+        // Clear any per-conversation reasoning override so the newly-selected
+        // model resolves from its own configured default.
+        this.reasoningOverride = null;
     }
 
     /**
@@ -407,6 +415,52 @@ export class Agent {
     }
 
     /**
+     * Whether the reasoning on/off toggle should be *offered* for a model.
+     * Capability is opt-in per deployment: `reasoning_toggle: true` per-model,
+     * else the top-level global. Off (absent) by default — most models/apps
+     * don't expose it. Consumed by chat-ui.js to decide whether to render the
+     * toggle. Resolved per-model first, then global (mirrors `_samplingParams`).
+     */
+    _reasoningCapable(modelConfig) {
+        const v = ('reasoning_toggle' in (modelConfig ?? {}))
+            ? modelConfig.reasoning_toggle
+            : this.config?.reasoning_toggle;
+        return v === true;
+    }
+
+    /**
+     * The configured default reasoning state (per-model first, then global).
+     * Returns a boolean when set, or `undefined` when unconfigured — in which
+     * case we emit nothing and let the model/proxy use its own default.
+     */
+    _reasoningDefault(modelConfig) {
+        const v = ('reasoning_default' in (modelConfig ?? {}))
+            ? modelConfig.reasoning_default
+            : this.config?.reasoning_default;
+        return typeof v === 'boolean' ? v : undefined;
+    }
+
+    /**
+     * Resolve the thinking-control payload for a turn. Emits `enable_thinking`
+     * (a normalized flag the open-llm-proxy maps to the correct per-backend
+     * chat-template knob) only when this model participates — i.e. the deployer
+     * enabled the toggle or set a default. Otherwise the key is omitted so the
+     * model's own default is untouched (no behavior change by default).
+     *
+     * Value precedence: per-conversation user override (the UI toggle) wins,
+     * then the configured default. See #283.
+     */
+    _thinkingParams(modelConfig) {
+        const dflt = this._reasoningDefault(modelConfig);
+        // Untouched unless the deployer opted this model in somehow.
+        if (!this._reasoningCapable(modelConfig) && dflt === undefined) return {};
+        const value = (typeof this.reasoningOverride === 'boolean')
+            ? this.reasoningOverride
+            : dflt;
+        return typeof value === 'boolean' ? { enable_thinking: value } : {};
+    }
+
+    /**
      * Resolve the per-attempt LLM timeout in milliseconds. Mirrors
      * `_samplingParams` resolution: per-model `llm_timeout_seconds` wins, then
      * global config, then a built-in default.
@@ -443,6 +497,7 @@ export class Agent {
             tool_choice: tools.length > 0 ? 'auto' : 'none',
             user: this.sessionId,
             ...this._samplingParams(modelConfig),
+            ...this._thinkingParams(modelConfig),
         };
 
         const timeoutMs = this._llmTimeoutMs(modelConfig);

--- a/app/agent.js
+++ b/app/agent.js
@@ -448,15 +448,19 @@ export class Agent {
      * model's own default is untouched (no behavior change by default).
      *
      * Value precedence: per-conversation user override (the UI toggle) wins,
-     * then the configured default. See #283.
+     * then the configured default, then — for a toggle-capable model — `true`.
+     * This mirrors chat-ui's `reasoningState()` exactly, so what the 🧠 toggle
+     * shows and what we send can never disagree. See #283.
      */
     _thinkingParams(modelConfig) {
+        const capable = this._reasoningCapable(modelConfig);
         const dflt = this._reasoningDefault(modelConfig);
         // Untouched unless the deployer opted this model in somehow.
-        if (!this._reasoningCapable(modelConfig) && dflt === undefined) return {};
-        const value = (typeof this.reasoningOverride === 'boolean')
-            ? this.reasoningOverride
-            : dflt;
+        if (!capable && dflt === undefined) return {};
+        let value;
+        if (typeof this.reasoningOverride === 'boolean') value = this.reasoningOverride;
+        else if (typeof dflt === 'boolean') value = dflt;
+        else value = capable ? true : undefined; // toggle shown → defaults on
         return typeof value === 'boolean' ? { enable_thinking: value } : {};
     }
 

--- a/app/chat-ui.js
+++ b/app/chat-ui.js
@@ -180,6 +180,9 @@ export class ChatUI {
         this.populateModelSelector();
         this.modelSelector?.addEventListener('change', () => {
             this.agent.setModel(this.modelSelector.value);
+            // setModel cleared any reasoning override; reflect the new model's
+            // capability + default in the toggle.
+            this.syncReasoningToggle();
         });
 
         // Voice input (only initialised when a transcription model is
@@ -198,6 +201,9 @@ export class ChatUI {
 
         // Auto-approve toggle (always shown)
         this.initAutoApproveToggle();
+
+        // Reasoning on/off toggle (shown only for reasoning-capable models)
+        this.initReasoningToggle();
 
         // Export-to-HTML button (always shown)
         this.initExportButton();
@@ -552,6 +558,53 @@ export class ChatUI {
         });
 
         footer.prepend(btn);
+    }
+
+    /* ------------------------------------------------------------------ */
+    /*  Reasoning on/off toggle                                            */
+    /* ------------------------------------------------------------------ */
+
+    /**
+     * The effective reasoning state shown by the toggle: a per-conversation
+     * user override if set, else the model's configured default, else `true`
+     * (reasoning-capable models think by default).
+     */
+    reasoningState() {
+        const mc = this.agent.getModelConfig();
+        if (typeof this.agent.reasoningOverride === 'boolean') return this.agent.reasoningOverride;
+        const dflt = this.agent._reasoningDefault(mc);
+        return typeof dflt === 'boolean' ? dflt : true;
+    }
+
+    /** Reflect capability (show/hide) and current state (active class + title). */
+    syncReasoningToggle() {
+        const btn = this.reasoningBtn;
+        if (!btn) return;
+        const capable = this.agent._reasoningCapable(this.agent.getModelConfig());
+        btn.style.display = capable ? '' : 'none';
+        if (!capable) return;
+        const on = this.reasoningState();
+        btn.classList.toggle('active', on);
+        btn.title = on
+            ? 'Reasoning on — the model thinks before answering (slower, better on hard questions). Click for faster answers.'
+            : 'Reasoning off — faster answers, may reduce quality on hard questions. Click to think first.';
+    }
+
+    initReasoningToggle() {
+        const footer = this.footerRightEl;
+        if (!footer) return;
+
+        const btn = document.createElement('button');
+        btn.id = 'reasoning-btn';
+        btn.textContent = '🧠';
+        btn.addEventListener('click', () => {
+            this.agent.reasoningOverride = !this.reasoningState();
+            this.syncReasoningToggle();
+        });
+
+        footer.prepend(btn);
+        this.reasoningBtn = btn;
+        this.syncReasoningToggle();
     }
 
     /* ------------------------------------------------------------------ */

--- a/app/chat.css
+++ b/app/chat.css
@@ -878,6 +878,28 @@ details[open]>.query-summary-btn::before {
     color: #d97706;
 }
 
+#reasoning-btn {
+    background: none;
+    border: none;
+    font-size: 14px;
+    cursor: pointer;
+    color: rgba(0, 0, 0, 0.4);
+    padding: 2px 6px;
+    line-height: 1;
+    opacity: 0.5;
+    transition: opacity 0.15s, color 0.15s;
+    border-radius: 4px;
+}
+
+#reasoning-btn:hover {
+    opacity: 0.9;
+}
+
+#reasoning-btn.active {
+    opacity: 1;
+    color: #7c3aed;
+}
+
 #export-btn {
     background: none;
     border: none;

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -516,6 +516,30 @@ To change sampling, set any of `temperature`, `top_p`, or `seed`. Each is read *
 
 > **Reproducibility caveat:** open-weights MoE inference (e.g. minimax-m2) is not bit-reproducible even at `temperature: 0`, so this is necessary-but-not-sufficient — pair it with a pinned methodology for headline numbers.
 
+### Reasoning toggle (optional)
+
+Reasoning ("thinking") models spend a large, sequential **decode** budget generating hidden reasoning before the answer. On easy tasks — a simple filter, a lookup, a single tool call — that's mostly latency for little gain, while on hard analytical/SQL questions it materially improves the answer. Because that tradeoff is **per question, not per app**, geo-agent can surface a 🧠 toggle in the chat footer so the user picks *fast* vs. *thorough* per conversation.
+
+The toggle emits a normalized `enable_thinking` flag that the [open-llm-proxy](https://github.com/boettiger-lab/open-llm-proxy) maps to the correct per-backend chat-template knob (e.g. `enable_thinking` for qwen3/glm, `thinking` for kimi). It is **off by default and opt-in per model** — when neither key below is set, geo-agent sends nothing and the model uses its own default (no behavior change).
+
+> **Only enable it where "off" is safe.** On weaker models, disabling reasoning can degrade tool-calling/SQL reliability. Enable the toggle only for models where measurement (see [open-llm-proxy#58](https://github.com/boettiger-lab/open-llm-proxy/issues/58)) shows reasoning-off doesn't hurt tool use.
+
+```json
+{
+  "llm_models": [
+    { "value": "qwen3", "endpoint": "…", "api_key": "…", "reasoning_toggle": true, "reasoning_default": true },
+    { "value": "minimax-m2", "endpoint": "…", "api_key": "…" }
+  ]
+}
+```
+
+| Field | Where | Default | Description |
+|---|---|---|---|
+| `reasoning_toggle` | per-model and/or top-level | `false` | Show the 🧠 reasoning on/off toggle for this model. Only enable it for models whose backend supports the thinking knob **and** where reasoning-off is safe for tool use. Hidden when `false`/absent. |
+| `reasoning_default` | per-model and/or top-level | unset | Initial reasoning state (`true` = on). When unset and the toggle is shown, it starts *on*. When set on a model with **no** toggle, it applies a fixed reasoning state without a user control. Unset entirely → `enable_thinking` is omitted and the model's own default is used. |
+
+Resolution mirrors the sampling params: per-model first, then top-level global. A per-conversation toggle click overrides the configured default until the model is switched (which resets to that model's default).
+
 ## Voice input (optional)
 
 Voice input is opt-in via a `transcription_model` entry in `config.json`. When present, a 🎤 button appears in the chat footer; when absent, the button stays hidden and the voice/transcription JS modules are never loaded (zero footprint).

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -536,7 +536,7 @@ The toggle emits a normalized `enable_thinking` flag that the [open-llm-proxy](h
 | Field | Where | Default | Description |
 |---|---|---|---|
 | `reasoning_toggle` | per-model and/or top-level | `false` | Show the 🧠 reasoning on/off toggle for this model. Only enable it for models whose backend supports the thinking knob **and** where reasoning-off is safe for tool use. Hidden when `false`/absent. |
-| `reasoning_default` | per-model and/or top-level | unset | Initial reasoning state (`true` = on). When unset and the toggle is shown, it starts *on*. When set on a model with **no** toggle, it applies a fixed reasoning state without a user control. Unset entirely → `enable_thinking` is omitted and the model's own default is used. |
+| `reasoning_default` | per-model and/or top-level | unset | Initial reasoning state (`true` = on). When unset **and the toggle is shown**, it starts *on* and `enable_thinking: true` is sent (so the toggle's displayed state matches what's sent). When set on a model with **no** toggle, it applies a fixed reasoning state without a user control. Unset **with no toggle** → `enable_thinking` is omitted and the model's own default is used. |
 
 Resolution mirrors the sampling params: per-model first, then top-level global. A per-conversation toggle click overrides the configured default until the model is switched (which resets to that model's default).
 

--- a/test/agent-reasoning.test.js
+++ b/test/agent-reasoning.test.js
@@ -125,3 +125,99 @@ describe('Agent reasoning extraction', () => {
         expect(lastAssistant.content).toBe('Answer.');
     });
 });
+
+// Build an agent whose config carries the given per-model + top-level keys.
+const makeConfiguredAgent = (modelExtra = {}, topLevel = {}) => new Agent(
+    {
+        llm_models: [{ value: 'm', endpoint: 'https://x/v1', api_key: 'k', ...modelExtra }],
+        ...topLevel,
+    },
+    stubToolRegistry,
+);
+
+describe('Agent reasoning-toggle resolution (#283)', () => {
+    it('_reasoningCapable is false by default (opt-in)', () => {
+        const a = makeConfiguredAgent();
+        expect(a._reasoningCapable(a.getModelConfig())).toBe(false);
+    });
+
+    it('_reasoningCapable reads per-model, then top-level, per-model wins', () => {
+        const perModel = makeConfiguredAgent({ reasoning_toggle: true });
+        expect(perModel._reasoningCapable(perModel.getModelConfig())).toBe(true);
+
+        const global = makeConfiguredAgent({}, { reasoning_toggle: true });
+        expect(global._reasoningCapable(global.getModelConfig())).toBe(true);
+
+        const perModelOff = makeConfiguredAgent({ reasoning_toggle: false }, { reasoning_toggle: true });
+        expect(perModelOff._reasoningCapable(perModelOff.getModelConfig())).toBe(false);
+    });
+
+    it('_reasoningDefault returns a boolean when set, else undefined', () => {
+        const none = makeConfiguredAgent();
+        expect(none._reasoningDefault(none.getModelConfig())).toBeUndefined();
+
+        const off = makeConfiguredAgent({ reasoning_default: false });
+        expect(off._reasoningDefault(off.getModelConfig())).toBe(false);
+
+        const globalOn = makeConfiguredAgent({}, { reasoning_default: true });
+        expect(globalOn._reasoningDefault(globalOn.getModelConfig())).toBe(true);
+    });
+
+    it('_thinkingParams emits nothing when the model does not participate', () => {
+        const a = makeConfiguredAgent();
+        expect(a._thinkingParams(a.getModelConfig())).toEqual({});
+    });
+
+    it('_thinkingParams emits a configured default even without a toggle', () => {
+        const a = makeConfiguredAgent({ reasoning_default: false });
+        expect(a._thinkingParams(a.getModelConfig())).toEqual({ enable_thinking: false });
+    });
+
+    it('_thinkingParams: toggle-capable but no default and no override → omit', () => {
+        const a = makeConfiguredAgent({ reasoning_toggle: true });
+        expect(a._thinkingParams(a.getModelConfig())).toEqual({});
+    });
+
+    it('_thinkingParams: user override wins over the configured default', () => {
+        const a = makeConfiguredAgent({ reasoning_toggle: true, reasoning_default: true });
+        a.reasoningOverride = false;
+        expect(a._thinkingParams(a.getModelConfig())).toEqual({ enable_thinking: false });
+    });
+
+    it('setModel clears the reasoning override', () => {
+        const a = makeConfiguredAgent({ reasoning_toggle: true });
+        a.reasoningOverride = false;
+        a.setModel('m');
+        expect(a.reasoningOverride).toBeNull();
+    });
+});
+
+describe('Agent.callLLM enable_thinking in payload (#283)', () => {
+    let originalFetch;
+    beforeEach(() => { originalFetch = global.fetch; });
+    afterEach(() => { global.fetch = originalFetch; vi.restoreAllMocks(); });
+
+    const captureBodies = () => {
+        const bodies = [];
+        global.fetch = vi.fn(async (url, opts) => {
+            bodies.push(JSON.parse(opts.body));
+            return okResponse({ role: 'assistant', content: 'ok' });
+        });
+        return bodies;
+    };
+
+    it('omits enable_thinking for a non-participating model', async () => {
+        const a = makeConfiguredAgent();
+        const bodies = captureBodies();
+        await a.callLLM('https://x/v1', a.getModelConfig(), [], []);
+        expect('enable_thinking' in bodies[0]).toBe(false);
+    });
+
+    it('sends enable_thinking:false when the user turns reasoning off', async () => {
+        const a = makeConfiguredAgent({ reasoning_toggle: true, reasoning_default: true });
+        a.reasoningOverride = false;
+        const bodies = captureBodies();
+        await a.callLLM('https://x/v1', a.getModelConfig(), [], []);
+        expect(bodies[0].enable_thinking).toBe(false);
+    });
+});

--- a/test/agent-reasoning.test.js
+++ b/test/agent-reasoning.test.js
@@ -173,9 +173,12 @@ describe('Agent reasoning-toggle resolution (#283)', () => {
         expect(a._thinkingParams(a.getModelConfig())).toEqual({ enable_thinking: false });
     });
 
-    it('_thinkingParams: toggle-capable but no default and no override → omit', () => {
+    it('_thinkingParams: toggle-capable, no default, no override → on (matches UI)', () => {
+        // The toggle renders as "on" in this state (chat-ui reasoningState()),
+        // so we must actually send enable_thinking:true — not omit and defer to
+        // the backend default, which could disagree with what the user sees.
         const a = makeConfiguredAgent({ reasoning_toggle: true });
-        expect(a._thinkingParams(a.getModelConfig())).toEqual({});
+        expect(a._thinkingParams(a.getModelConfig())).toEqual({ enable_thinking: true });
     });
 
     it('_thinkingParams: user override wins over the configured default', () => {

--- a/test/chat-ui-controls.test.js
+++ b/test/chat-ui-controls.test.js
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import { describe, it, expect } from 'vitest';
 import { ChatUI } from '../app/chat-ui.js';
+import { Agent } from '../app/agent.js';
 
 /**
  * #255 — checkpoint resume folded into the chat input. These exercise the
@@ -107,5 +108,45 @@ describe('ChatUI.handleSend resume semantics (#255)', () => {
         ui.inputEl.value = 'use the viridis palette';
         await ui.handleSend();
         expect(sent).toEqual(['use the viridis palette']);
+    });
+});
+
+describe('ChatUI reasoning toggle (#283)', () => {
+    const stubRegistry = { getToolsForLLM: () => [], isLocal: () => true, execute: async () => ({}), has: () => false };
+
+    // Minimal ChatUI wired to a real Agent so the capability/state gating
+    // (which lives on the Agent) is exercised end-to-end.
+    function makeUI(models) {
+        const ui = Object.create(ChatUI.prototype);
+        ui.agent = new Agent({ llm_models: models }, stubRegistry);
+        ui.footerRightEl = document.createElement('div');
+        return ui;
+    }
+
+    it('hides the toggle for a non-capable model', () => {
+        const ui = makeUI([{ value: 'plain', endpoint: 'e', api_key: 'k' }]);
+        ui.initReasoningToggle();
+        expect(ui.reasoningBtn.style.display).toBe('none');
+    });
+
+    it('shows the toggle, defaulting to the configured state', () => {
+        const ui = makeUI([{ value: 'r', endpoint: 'e', api_key: 'k', reasoning_toggle: true, reasoning_default: true }]);
+        ui.initReasoningToggle();
+        expect(ui.reasoningBtn.style.display).toBe('');
+        expect(ui.reasoningBtn.classList.contains('active')).toBe(true);
+    });
+
+    it('click flips the effective state and the agent override', () => {
+        const ui = makeUI([{ value: 'r', endpoint: 'e', api_key: 'k', reasoning_toggle: true, reasoning_default: true }]);
+        ui.initReasoningToggle();
+        ui.reasoningBtn.click();
+        expect(ui.agent.reasoningOverride).toBe(false);
+        expect(ui.reasoningBtn.classList.contains('active')).toBe(false);
+    });
+
+    it('capable-but-undefined default displays as on', () => {
+        const ui = makeUI([{ value: 'r', endpoint: 'e', api_key: 'k', reasoning_toggle: true }]);
+        ui.initReasoningToggle();
+        expect(ui.reasoningState()).toBe(true);
     });
 });


### PR DESCRIPTION
Closes #283.

## What

Adds a per-conversation **reasoning on/off toggle** to the chat footer. #282 showed our workload is decode-latency-bound and reasoning tokens are the bulk of decode, so disabling unnecessary thinking is our biggest latency lever. But whether reasoning is worth it is **per question, not per app** — a simple filter needs none; a hard multi-join SQL question does — so the control belongs to the user.

## Design (per the discussion on #283)

- **UI toggle = the control surface.** A 🧠 button in the footer flips reasoning for subsequent turns; reversible any time, reset to the model's default when the model is switched.
- **Config = the gate + default.** `reasoning_toggle` decides whether the toggle is *offered* for a model; `reasoning_default` sets its initial state. Both resolve per-model first, then top-level global (mirrors the sampling params). Seeded by measurement (open-llm-proxy#58) and refined with experience.
- **Off by default, no behavior change.** When a model doesn't opt in, `enable_thinking` is omitted entirely and the model's own default is used.

The agent emits a single normalized `enable_thinking` flag; the open-llm-proxy already maps it to the correct per-backend chat-template knob (`thinking_models` in its config — qwen3/glm→`enable_thinking`, kimi→`thinking`). No proxy change is needed for this to take effect.

## Safety

On weaker models, reasoning-off can degrade tool-calling/SQL reliability. `reasoning_toggle` is opt-in per model precisely so deployers only expose it where reasoning-off is safe (per open-llm-proxy#58). A user toggle keeps the default conservative and makes the fast path an explicit opt-in.

## Files
- `app/agent.js` — `_thinkingParams` / `_reasoningCapable` / `_reasoningDefault`, override state, emit in `callLLM`, reset on `setModel`.
- `app/chat-ui.js` + `app/chat.css` — the footer toggle, capability-gated, model-switch aware.
- `docs/guide/configuration.md` — new **Reasoning toggle** section.
- Tests: resolution + payload emission (`test/agent-reasoning.test.js`), UI gating (`test/chat-ui-controls.test.js`). Full suite green (437).

## Follow-up (not blocking)
- open-llm-proxy#64 — log the *requested* thinking mode so the toggle's production impact is measurable.