### PR TITLE
fix(agent): parse foreign tool-call dialects first-pass instead of re-prompting (#295)

### DIFF
--- a/app/agent.js
+++ b/app/agent.js
@@ -644,6 +644,29 @@ export class Agent {
             if (args !== undefined) { calls.push({ name: funcMatch[1], args }); return; }
         }
 
+        // Hermes/pythonic `<function=NAME>…` dialect (#295), incl. the corrupted
+        // `<function=query", "arguments": {…}` form observed live on qwen/nimbus —
+        // the sole failure mode still leaking under the #288 net. Take the name
+        // from the tag, then the first JSON object after it as args, unwrapping a
+        // lone {"arguments"|"parameters": {…}} envelope.
+        const fnTag = inner.match(/<function=(\w+)/);
+        if (fnTag) {
+            const rest = inner.slice(fnTag.index + fnTag[0].length);
+            const objs = this._scanJSONObjects(rest);
+            let args = objs.length ? objs[0].value : {};
+            if (args && typeof args === 'object' && !Array.isArray(args)) {
+                const keys = Object.keys(args);
+                if (keys.length === 1 && (keys[0] === 'arguments' || keys[0] === 'parameters')
+                    && args[keys[0]] && typeof args[keys[0]] === 'object') {
+                    args = args[keys[0]];
+                }
+            } else {
+                args = {};
+            }
+            calls.push({ name: fnTag[1], args });
+            return;
+        }
+
         // Lone quoted name against a known tool: {"list_datasets"}
         const bareName = inner.match(/^\{\s*"(\w+)"\s*\}$/);
         if (bareName && this.toolRegistry.has(bareName[1])) {

--- a/app/agent.js
+++ b/app/agent.js
@@ -224,9 +224,9 @@ export class Agent {
                     localOnlyStreak++;
                 }
 
-                // Strip embedded <tool_call> tags from content before displaying to user
+                // Strip recovered tool-call text from content before displaying to user
                 const displayContent = message.content
-                    ? message.content.replace(/<tool_call>[\s\S]*?<\/tool_call>/gi, '').trim()
+                    ? this.stripEmbeddedCalls(message.content)
                     : null;
 
                 let approved = true;
@@ -562,49 +562,122 @@ export class Agent {
     }
 
     /**
-     * Parse embedded tool calls from message content.
-     * Some models (e.g., GLM-4) emit <tool_call>...</tool_call> tags instead of structured tool_calls.
+     * Parse embedded tool calls from message content (#288, #295).
+     *
+     * Upstream hosts that stop emitting structured `tool_calls` fall back to a
+     * grab-bag of content dialects — we must be tolerant of all of them or the
+     * raw call leaks to the user as the final answer. Handled here:
+     *   - Wrappers: <tool_call>… (GLM-style) *and* <tool_code>… (Gemini-style),
+     *     with a missing / mismatched closing tag (#288, failure mode 1).
+     *   - Bare, unwrapped JSON tool-call objects, singly or concatenated (#295).
+     *   - Body shapes: flat {"name","arguments"} *and* nested OpenAI
+     *     {"type":"function","function":{"name","arguments"}} (#295).
+     *   - `parameters` as an alias for `arguments` (#295).
      */
     parseEmbeddedToolCalls(content) {
         if (!content) return [];
         const calls = [];
-        // Tolerant extractor (#288, failure mode 1): capture from <tool_call> up to
-        // the *first* of a closing tag (</… — including a mismatched </parameter>),
-        // a new <tool_call>, or EOF, instead of requiring an exact </tool_call> with
-        // no interior '<'. The lookahead leaves the terminator unconsumed; each match
-        // still consumes the literal <tool_call>, so lastIndex always advances.
-        const pattern = /<tool_call>\s*([\s\S]*?)\s*(?=<\/|<tool_call>|$)/gi;
+
+        // Wrapped calls: capture from a <tool_call>/<tool_code> open tag up to the
+        // *first* of a closing tag (</… — including a mismatched </parameter>), a new
+        // wrapper, or EOF, instead of requiring an exact close with no interior '<'.
+        // The lookahead leaves the terminator unconsumed; each match still consumes
+        // the literal open tag, so lastIndex always advances.
+        const pattern = /<tool_c(?:all|ode)>\s*([\s\S]*?)\s*(?=<\/|<tool_c(?:all|ode)>|$)/gi;
         let match;
-
+        let sawWrapper = false;
         while ((match = pattern.exec(content)) !== null) {
+            sawWrapper = true;
             const inner = match[1].trim();
-            if (!inner) continue;
+            if (inner) this._pushEmbeddedCall(inner, calls);
+        }
 
-            // Try JSON: {"name": "tool", "arguments": {...}} — lenient, so a trailing
-            // extra brace (failure mode 2's cousin) still yields a usable call.
-            const parsed = this.parseLenientJSON(inner);
-            if (parsed && parsed.name) {
-                calls.push({ name: parsed.name, args: parsed.arguments || {} });
-                continue;
-            }
-
-            // Try function call: tool_name({"arg": "val"})
-            const funcMatch = inner.match(/^(\w+)\s*\(([\s\S]+)\)$/);
-            if (funcMatch) {
-                const args = this.parseLenientJSON(funcMatch[2]);
-                if (args !== undefined) {
-                    calls.push({ name: funcMatch[1], args });
-                    continue;
-                }
-            }
-
-            // Simple name
-            if (/^\w+$/.test(inner) && this.toolRegistry.has(inner)) {
-                calls.push({ name: inner, args: {} });
+        // Bare (unwrapped) tool-call JSON — only when no wrapper was seen, to avoid
+        // double-extracting and to keep the scan off ordinary prose. `_normalizeCall`
+        // is signature-gated, so a final answer that merely contains JSON (e.g. a
+        // style blob) is not misread as a call.
+        if (!sawWrapper) {
+            for (const { value } of this._scanJSONObjects(content)) {
+                const call = this._normalizeCall(value);
+                if (call) calls.push(call);
             }
         }
 
         return calls;
+    }
+
+    /**
+     * Remove recovered tool-call text from content before it is shown to the user
+     * (#295). Strips both wrappers (closed, or unclosed to EOF), then excises any
+     * bare tool-call JSON objects the parser would have recognized. Spans are
+     * removed back-to-front so earlier indices stay valid.
+     */
+    stripEmbeddedCalls(content) {
+        if (!content) return content;
+        let out = content
+            .replace(/<tool_c(?:all|ode)>[\s\S]*?<\/tool_c(?:all|ode)>/gi, '')
+            .replace(/<tool_c(?:all|ode)>[\s\S]*$/gi, '');
+        const spans = this._scanJSONObjects(out).filter(o => this._normalizeCall(o.value));
+        for (let i = spans.length - 1; i >= 0; i--) {
+            out = out.slice(0, spans[i].start) + out.slice(spans[i].end + 1);
+        }
+        return out.trim();
+    }
+
+    /**
+     * Extract one or more calls from a single wrapper's inner blob (#295). Tries
+     * JSON objects first (one or several concatenated), then the non-JSON shapes.
+     */
+    _pushEmbeddedCall(inner, calls) {
+        // JSON object(s): flat or nested, lenient (a trailing extra brace still parses).
+        let found = false;
+        for (const { value } of this._scanJSONObjects(inner)) {
+            const call = this._normalizeCall(value);
+            if (call) { calls.push(call); found = true; }
+        }
+        if (found) return;
+
+        // Function-call shape: tool_name({"arg": "val"})
+        const funcMatch = inner.match(/^(\w+)\s*\(([\s\S]+)\)$/);
+        if (funcMatch) {
+            const args = this.parseLenientJSON(funcMatch[2]);
+            if (args !== undefined) { calls.push({ name: funcMatch[1], args }); return; }
+        }
+
+        // Lone quoted name against a known tool: {"list_datasets"}
+        const bareName = inner.match(/^\{\s*"(\w+)"\s*\}$/);
+        if (bareName && this.toolRegistry.has(bareName[1])) {
+            calls.push({ name: bareName[1], args: {} });
+            return;
+        }
+
+        // Simple name
+        if (/^\w+$/.test(inner) && this.toolRegistry.has(inner)) {
+            calls.push({ name: inner, args: {} });
+        }
+    }
+
+    /**
+     * Normalize a parsed JSON value into {name, args} if it is a tool call, else
+     * null (#295). Accepts both the flat shape and the nested OpenAI
+     * {"type":"function","function":{…}} shape, and `parameters` as an alias for
+     * `arguments`. Signature-gated for the bare-JSON path: a flat object with no
+     * args key and an unregistered name is rejected so stray JSON in a final answer
+     * is not swallowed as a call.
+     */
+    _normalizeCall(parsed) {
+        if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return null;
+        const nested = parsed.type === 'function'
+            && parsed.function && typeof parsed.function === 'object';
+        const fn = nested ? parsed.function : parsed;
+        const name = fn.name;
+        if (typeof name !== 'string' || !name) return null;
+        const hasArgsKey = ('arguments' in fn) || ('parameters' in fn);
+        if (!nested && !hasArgsKey && !this.toolRegistry.has(name)) return null;
+        let args = fn.arguments ?? fn.parameters ?? {};
+        if (typeof args === 'string') args = this.parseLenientJSON(args) ?? {};
+        if (!args || typeof args !== 'object') args = {};
+        return { name, args };
     }
 
     /**
@@ -632,8 +705,24 @@ export class Agent {
     _decodeFirstJSON(s) {
         const start = s.search(/[{[]/);
         if (start === -1) return undefined;
+        const end = this._matchBalanced(s, start);
+        if (end === -1) return undefined;
+        try {
+            return JSON.parse(s.slice(start, end + 1));
+        } catch {
+            return undefined;
+        }
+    }
+
+    /**
+     * Index of the closer that balances the opening bracket at `start`, or -1 if
+     * none. Respects strings and escapes so a bracket inside a string literal is
+     * not mistaken for structure. Shared by _decodeFirstJSON and _scanJSONObjects.
+     */
+    _matchBalanced(s, start) {
         const open = s[start];
-        const close = open === '{' ? '}' : ']';
+        const close = open === '{' ? '}' : open === '[' ? ']' : null;
+        if (!close) return -1;
         let depth = 0, inStr = false, esc = false;
         for (let i = start; i < s.length; i++) {
             const c = s[i];
@@ -645,15 +734,34 @@ export class Agent {
             }
             if (c === '"') { inStr = true; continue; }
             if (c === open) depth++;
-            else if (c === close && --depth === 0) {
-                try {
-                    return JSON.parse(s.slice(start, i + 1));
-                } catch {
-                    return undefined;
-                }
-            }
+            else if (c === close && --depth === 0) return i;
         }
-        return undefined;
+        return -1;
+    }
+
+    /**
+     * Scan a string for all top-level balanced JSON objects/arrays and return the
+     * valid ones as {value, start, end} (end inclusive). Handles several calls
+     * concatenated in one blob (#295) and, because it carries positions, lets the
+     * display stripper excise recovered bare calls. Invalid/unbalanced regions and
+     * non-JSON prose between objects are skipped.
+     */
+    _scanJSONObjects(s) {
+        const results = [];
+        if (typeof s !== 'string') return results;
+        let i = 0;
+        while (i < s.length) {
+            const rel = s.slice(i).search(/[{[]/);
+            if (rel === -1) break;
+            const start = i + rel;
+            const end = this._matchBalanced(s, start);
+            if (end === -1) { i = start + 1; continue; }
+            try {
+                results.push({ value: JSON.parse(s.slice(start, end + 1)), start, end });
+            } catch { /* skip this region */ }
+            i = end + 1;
+        }
+        return results;
     }
 
     /**
@@ -684,7 +792,7 @@ export class Agent {
      */
     looksLikeAttemptedToolCall(content) {
         if (!content) return false;
-        if (/<tool_call/i.test(content)) return true;
+        if (/<tool_c(?:all|ode)/i.test(content)) return true;
         if (/"(?:name|function|parameters|arguments)"\s*:/.test(content)) return true;
         // Bare function-call shape against a known tool, e.g. get_schema({...}).
         const m = content.match(/\b(\w+)\s*\(\s*[{[]/);

--- a/test/agent-tool-parse.test.js
+++ b/test/agent-tool-parse.test.js
@@ -162,6 +162,26 @@ describe('parseEmbeddedToolCalls — dialect tolerance (#295)', () => {
         ]);
     });
 
+    it('parses the Hermes <function=NAME> dialect, incl. the corrupted live form', () => {
+        const a = agentFor();
+        // Verbatim from barred-owl/qwen proxy logs — the one dialect that still
+        // leaked under the #288 recovery net before this handler.
+        const calls = a.parseEmbeddedToolCalls(
+            '<tool_call>\n<function=query", "arguments": {"sql_query": "SELECT DISTINCT i.HEXID '
+            + "FROM read_parquet('s3://public-barred-owl/inputs/hex/h0=*/data_0.parquet') i "
+            + 'WHERE i.nso_ccap = 20"}}\n</tool_call>');
+        expect(calls).toEqual([{ name: 'query', args: {
+            sql_query: "SELECT DISTINCT i.HEXID FROM read_parquet('s3://public-barred-owl/inputs/hex/h0=*/data_0.parquet') i WHERE i.nso_ccap = 20",
+        } }]);
+    });
+
+    it('unwraps a lone arguments/parameters envelope in the <function=> dialect', () => {
+        const a = agentFor();
+        const calls = a.parseEmbeddedToolCalls(
+            '<tool_call><function=get_schema>\n{"parameters": {"dataset_id": "barred-owl"}}</function></tool_call>');
+        expect(calls).toEqual([{ name: 'get_schema', args: { dataset_id: 'barred-owl' } }]);
+    });
+
     it('does NOT misread stray JSON in a plain final answer as a call', () => {
         const a = agentFor();
         // A style blob with no name / no args-key / unregistered → not a call.

--- a/test/agent-tool-parse.test.js
+++ b/test/agent-tool-parse.test.js
@@ -8,7 +8,8 @@ import { Agent } from '../app/agent.js';
 const stubRegistry = (overrides = {}) => ({
     getToolsForLLM: () => [],
     isLocal: () => true,
-    has: (name) => ['get_schema', 'query', 'set_filter'].includes(name),
+    has: (name) => ['get_schema', 'query', 'set_filter', 'clear_filter',
+        'list_datasets', 'show_layer'].includes(name),
     execute: async () => ({ result: '' }),
     ...overrides,
 });
@@ -107,6 +108,99 @@ describe('parseEmbeddedToolCalls — tolerant extraction (#288)', () => {
     });
 });
 
+describe('parseEmbeddedToolCalls — dialect tolerance (#295)', () => {
+    // The barred-owl / qwen-nimbus leaks: host returned these as content and the
+    // old parser only knew <tool_call>{name,arguments}, so they surfaced to the user.
+
+    it('recognizes the <tool_code> wrapper (Gemini-style) with parameters alias', () => {
+        const a = agentFor();
+        const calls = a.parseEmbeddedToolCalls(
+            '<tool_code>{"name": "clear_filter", "parameters": {"layer_id": "barred-owl/nso-ccap"}}</tool_code>');
+        expect(calls).toEqual([{ name: 'clear_filter', args: { layer_id: 'barred-owl/nso-ccap' } }]);
+    });
+
+    it('recovers a lone quoted name against a known tool: {"list_datasets"}', () => {
+        const a = agentFor();
+        const calls = a.parseEmbeddedToolCalls('<tool_call>{"list_datasets"}');
+        expect(calls).toEqual([{ name: 'list_datasets', args: {} }]);
+    });
+
+    it('yields nothing on truly-garbled content (recovery path handles it)', () => {
+        const a = agentFor();
+        expect(a.parseEmbeddedToolCalls('<tool_call>{"function_call> </function_call>')).toEqual([]);
+    });
+
+    it('parses bare (unwrapped), concatenated nested calls with parameters alias', () => {
+        const a = agentFor();
+        const calls = a.parseEmbeddedToolCalls(
+            '{"type": "function", "function": {"name": "query", "parameters": {"sql_query": "SELECT 1"}}}'
+            + '{"type": "function", "function": {"name": "query", "parameters": {"sql_query": "SELECT 2"}}}');
+        expect(calls).toEqual([
+            { name: 'query', args: { sql_query: 'SELECT 1' } },
+            { name: 'query', args: { sql_query: 'SELECT 2' } },
+        ]);
+    });
+
+    it('parses the nested OpenAI shape inside a <tool_call> wrapper', () => {
+        const a = agentFor();
+        const calls = a.parseEmbeddedToolCalls(
+            '<tool_call>{"type": "function", "function": {"name": "get_schema", '
+            + '"parameters": {"dataset_id": "barred-owl"}}}</tool_call>');
+        expect(calls).toEqual([{ name: 'get_schema', args: { dataset_id: 'barred-owl' } }]);
+    });
+
+    it('parses a nested call followed by concatenated query calls in one wrapper', () => {
+        const a = agentFor();
+        const calls = a.parseEmbeddedToolCalls(
+            '<tool_call>{"type": "function", "function": {"name": "show_layer", "parameters": {"layer_id": "x"}}}'
+            + '{"type": "function", "function": {"name": "query", "parameters": {"sql_query": "SELECT 1"}}}'
+            + '{"type": "function", "function": {"name": "query", "parameters": {"sql_query": "SELECT 2"}}}</tool_call>');
+        expect(calls).toEqual([
+            { name: 'show_layer', args: { layer_id: 'x' } },
+            { name: 'query', args: { sql_query: 'SELECT 1' } },
+            { name: 'query', args: { sql_query: 'SELECT 2' } },
+        ]);
+    });
+
+    it('does NOT misread stray JSON in a plain final answer as a call', () => {
+        const a = agentFor();
+        // A style blob with no name / no args-key / unregistered → not a call.
+        expect(a.parseEmbeddedToolCalls(
+            'Here is the style you asked for: {"fill-color": "#ff0000", "fill-opacity": 0.5}')).toEqual([]);
+        // A flat object whose name is not a registered tool and carries no args key.
+        expect(a.parseEmbeddedToolCalls('{"name": "fibonacci"}')).toEqual([]);
+    });
+});
+
+describe('stripEmbeddedCalls — display cleanup (#295)', () => {
+    it('strips a <tool_code> wrapper from displayed content', () => {
+        const a = agentFor();
+        expect(a.stripEmbeddedCalls(
+            'Filtering now.\n<tool_code>{"name": "clear_filter", "parameters": {}}</tool_code>'))
+            .toBe('Filtering now.');
+    });
+
+    it('strips an unclosed wrapper through EOF', () => {
+        const a = agentFor();
+        expect(a.stripEmbeddedCalls(
+            'One moment.\n<tool_call>{"name": "query", "arguments": {"sql": "select 1"}}'))
+            .toBe('One moment.');
+    });
+
+    it('excises bare tool-call JSON so it does not echo to the user', () => {
+        const a = agentFor();
+        expect(a.stripEmbeddedCalls(
+            'Running the query. {"type": "function", "function": {"name": "query", "parameters": {"sql_query": "SELECT 1"}}}'))
+            .toBe('Running the query.');
+    });
+
+    it('leaves a genuine final answer (with incidental JSON) intact', () => {
+        const a = agentFor();
+        const text = 'The style is {"fill-color": "#ff0000"} — apply it in the panel.';
+        expect(a.stripEmbeddedCalls(text)).toBe(text);
+    });
+});
+
 describe('parseLenientJSON / _decodeFirstJSON (#288)', () => {
     it('parses valid JSON strictly', () => {
         const a = agentFor();
@@ -184,6 +278,9 @@ describe('looksLikeAttemptedToolCall (#288)', () => {
     it('flags a stray <tool_call tag', () => {
         expect(agentFor().looksLikeAttemptedToolCall('<tool_call>oops')).toBe(true);
     });
+    it('flags a stray <tool_code tag (#295)', () => {
+        expect(agentFor().looksLikeAttemptedToolCall('<tool_code>oops')).toBe(true);
+    });
     it('flags JSON-shaped call keys', () => {
         expect(agentFor().looksLikeAttemptedToolCall('{"function": "get_schema"}')).toBe(true);
     });
@@ -230,6 +327,26 @@ describe('agent loop — malformed-call recovery (#288 failure mode 1/3)', () =>
         // 1 initial + 2 corrective retries = 3 calls, then falls through.
         expect(global.fetch.mock.calls.length).toBe(3);
         expect(response).toContain('<tool_call>');
+    });
+
+    it('executes a leaked <tool_code> call instead of surfacing it as text (#295)', async () => {
+        // Round 1: host returns the call as content in a foreign dialect (no
+        // structured tool_calls). Round 2: the clean final answer after it ran.
+        global.fetch = vi.fn()
+            .mockResolvedValueOnce(okText(
+                '<tool_code>{"type": "function", "function": {"name": "query", '
+                + '"parameters": {"sql_query": "SELECT 1"}}}</tool_code>'))
+            .mockResolvedValueOnce(okText('Done — 1 row.'));
+        const executed = [];
+        const agent = agentFor({
+            execute: async (name, args) => { executed.push({ name, args }); return { result: 'ok' }; },
+        });
+        agent.autoApprove = true;
+
+        const { response } = await agent.processMessage('run it');
+
+        expect(executed).toEqual([{ name: 'query', args: { sql_query: 'SELECT 1' } }]);
+        expect(response).toBe('Done — 1 row.');
     });
 
     it('does not re-prompt a genuine final answer', async () => {


### PR DESCRIPTION
Fixes #295.

## Context — robustness + latency, validated against live logs

`parseEmbeddedToolCalls` only recognized `<tool_call>…</tool_call>` around a flat `{"name","arguments"}` body. When an upstream host stops emitting structured `tool_calls` and returns the call as **content** in another dialect (observed live on `qwen`/DSE-nimbus for barred-owl), the old parser didn't recover it.

Since #288, this no longer *hard-leaks* on apps that have it — most foreign-dialect calls trip the re-prompt-and-recover path. So this PR's value is (1) executing on the **first** pass instead of paying a recovery round-trip, and (2) covering dialects the recovery net misses.

## Change

Broadened `parseEmbeddedToolCalls` to be dialect-tolerant:

- **Wrappers**: `<tool_code>…` (Gemini) alongside `<tool_call>…`.
- **Bare JSON**: unwrapped tool-call objects, **signature-gated** via `_normalizeCall` so a final answer's incidental JSON is never misread as a call.
- **Body shapes**: flat `{"name","arguments"}` *and* nested `{"type":"function","function":{…}}` (incl. nested inside `<tool_call>`, which HEAD dropped).
- **`<function=NAME>`**: the Hermes/pythonic dialect, including the corrupted `<function=query", "arguments":{…}` form seen live.
- **`parameters`** aliased to `arguments`; several concatenated calls all extracted.

Supporting: `_scanJSONObjects`/`_matchBalanced` share the balanced-JSON scan with `_decodeFirstJSON` and carry positions so `stripEmbeddedCalls` can excise recovered bare calls from displayed content; `looksLikeAttemptedToolCall` also flags `<tool_code>`.

## Verification

- **Unit**: `#295` block in `test/agent-tool-parse.test.js` covers all evidence strings (each → expected `{name,args}`, or `[]` for garbled), the `<function=NAME>` dialect (verbatim from logs), plus negatives proving stray JSON in a plain answer is not misread. Full suite: **438 passing**.
- **End-to-end**: a loop test drives `processMessage` through a leaked `<tool_code>` nested call and asserts it **executes** first-pass.

## Validated in production (barred-owl proxy logs, 2026-07-09)

Replayed the day's **36 real leaked strings** through the actual parser: **28/36 (78%) parse first-pass**; the remaining 8 are genuinely-malformed JSON / empty tags, correctly left to the #288 net.

After barred-owl was pinned to this branch (~15:23Z, 3.5h of live traffic):

| | old pin | on this branch |
|---|---|---|
| foreign-dialect responses that were **terminal leaks** | **11 / 11 (100%)** | **1 / 24 (4%)** |
| — executed first-pass (#295) | — | 15 |
| — caught by #288 recovery net | — | 8 |

The single residual post-bump leak was a `<function=query"…` string that also exhausted #288's retry cap — the last commit adds the `<function=NAME>` handler that closes exactly that case.

## Out of scope (tracked in #295)

- DSE-nimbus host-side tool parser degradation — geo-agent should be robust regardless, which is what this delivers.