### PR TITLE
fix(agent): flag the non-JSON tool-call tail so #288 recovery fires (#297 step 1)

### DIFF
--- a/app/agent.js
+++ b/app/agent.js
@@ -876,9 +876,22 @@ export class Agent {
         if (!content) return false;
         if (/<tool_c(?:all|ode)/i.test(content)) return true;
         if (/"(?:name|function|parameters|arguments)"\s*:/.test(content)) return true;
-        // Bare function-call shape against a known tool, e.g. get_schema({...}).
-        const m = content.match(/\b(\w+)\s*\(\s*[{[]/);
-        if (m && this.toolRegistry.has(m[1])) return true;
+        // Non-JSON XML-ish tool-call markers no genuine prose emits (#297): the
+        // corrupted `<function=NAME>` tag, mangled `<parameter=…>` / `<parameter …>`,
+        // and Claude's `<invoke …>` / `<model_calls>` fn-call XML.
+        if (/<function=|<parameter[=\s]|<invoke\b|<model_calls>/i.test(content)) return true;
+        // Bare call or tool-name-as-tag against a *known* tool — gated on the
+        // registry so prose that merely names a tool doesn't trip a re-prompt (#297).
+        // Covers the whole leaking tail so the #288 recovery at least fires:
+        //   show_layer(layer_id="…")   and   <show_layer>{…}</show_layer>
+        // Scan *all* matches, not just the first — the real tool tag is often
+        // preceded by hallucinated reasoning tags (<antThinking>, </think>, …).
+        for (const m of content.matchAll(/\b(\w+)\s*\(/g)) {
+            if (this.toolRegistry.has(m[1])) return true;
+        }
+        for (const m of content.matchAll(/<(\w+)[\s>]/g)) {
+            if (this.toolRegistry.has(m[1])) return true;
+        }
         return false;
     }
 

--- a/app/agent.js
+++ b/app/agent.js
@@ -886,7 +886,10 @@ export class Agent {
         //   show_layer(layer_id="…")   and   <show_layer>{…}</show_layer>
         // Scan *all* matches, not just the first — the real tool tag is often
         // preceded by hallucinated reasoning tags (<antThinking>, </think>, …).
-        for (const m of content.matchAll(/\b(\w+)\s*\(/g)) {
+        // The `(` must be followed by something call-shaped — a quote, `{`/`[`, or
+        // a `kwarg=` — so a common tool word in prose ("the query (SQL) returned …",
+        // "set_filter (applied earlier)") is not misread as an attempted call.
+        for (const m of content.matchAll(/\b(\w+)\s*\(\s*(?:["'{[]|[\w-]+\s*=)/g)) {
             if (this.toolRegistry.has(m[1])) return true;
         }
         for (const m of content.matchAll(/<(\w+)[\s>]/g)) {

--- a/test/agent-tool-parse.test.js
+++ b/test/agent-tool-parse.test.js
@@ -315,6 +315,45 @@ describe('looksLikeAttemptedToolCall (#288)', () => {
     });
 });
 
+describe('looksLikeAttemptedToolCall — non-JSON dialect tail (#297)', () => {
+    // Each row of #297: forms that leak with ZERO recovery today because neither
+    // the parser nor this heuristic recognized them. Flagging here at least fires
+    // the #288 re-prompt. All gated on the tool registry.
+    const a = () => agentFor();
+
+    it('flags a bare python-call, double quotes', () => {
+        expect(a().looksLikeAttemptedToolCall('show_layer(layer_id="barred-owl/bo-occ")')).toBe(true);
+    });
+    it('flags a bare python-call, single quotes', () => {
+        expect(a().looksLikeAttemptedToolCall("show_layer(layer_id='barred-owl/bo-occ')")).toBe(true);
+    });
+    it('flags a tool-name-as-tag with JSON body', () => {
+        expect(a().looksLikeAttemptedToolCall('<show_layer>{"layer_id":"barred-owl/bo-occ"}</show_layer>')).toBe(true);
+    });
+    it('flags a tool-name-as-tag with XML body', () => {
+        expect(a().looksLikeAttemptedToolCall('<show_layer><layer_id>barred-owl/bo-occ</layer_id></show_layer>')).toBe(true);
+    });
+    it('flags the mangled <parameter=…> form', () => {
+        expect(a().looksLikeAttemptedToolCall(
+            '<parameter=function>\nshow_layer\n</parameter>\n<parameter=layer_id>\nx\n</parameter>')).toBe(true);
+    });
+    it('flags Claude <model_calls>/<invoke name=…> XML', () => {
+        expect(a().looksLikeAttemptedToolCall(
+            '<model_calls>\n<invoke name="get_schema">\n<parameter name="dataset_id">barred-owl</parameter>\n</invoke>\n</model_calls>')).toBe(true);
+    });
+    it('flags a tool tag even when hallucinated reasoning tags precede it', () => {
+        // Real barred-owl leak: <antThinking>…</antThinking> then the actual
+        // <show_layer><layer_id>… tag. Must scan past the first <word>.
+        expect(a().looksLikeAttemptedToolCall(
+            "I'll display the layer.\n\n<antThinking>\nreasoning here\n</antThinking>\n\n"
+            + '<show_layer>\n<layer_id>\nbarred-owl/bo-occ\n</layer_id>\n</show_layer>')).toBe(true);
+    });
+    it('does not flag prose that merely names a tool without a call/tag', () => {
+        expect(a().looksLikeAttemptedToolCall('The query returned 5 rows; I can show_layer next if you like.')).toBe(false);
+        expect(a().looksLikeAttemptedToolCall('I used get_schema earlier to inspect the columns.')).toBe(false);
+    });
+});
+
 describe('agent loop — malformed-call recovery (#288 failure mode 1/3)', () => {
     afterEach(() => { vi.restoreAllMocks(); });
 

--- a/test/agent-tool-parse.test.js
+++ b/test/agent-tool-parse.test.js
@@ -352,6 +352,14 @@ describe('looksLikeAttemptedToolCall — non-JSON dialect tail (#297)', () => {
         expect(a().looksLikeAttemptedToolCall('The query returned 5 rows; I can show_layer next if you like.')).toBe(false);
         expect(a().looksLikeAttemptedToolCall('I used get_schema earlier to inspect the columns.')).toBe(false);
     });
+    it('does not flag a tool word followed by a *parenthetical*, not a call', () => {
+        // `query` is both a registered tool and a common English word: a final
+        // answer that mentions it parenthetically must NOT trip the re-prompt.
+        // The `(` has to be followed by an arg-shaped token (quote / brace / kwarg=).
+        expect(a().looksLikeAttemptedToolCall('The query (running over the H3 parquet) returned 5 rows.')).toBe(false);
+        expect(a().looksLikeAttemptedToolCall('Here is the result of set_filter (applied earlier).')).toBe(false);
+        expect(a().looksLikeAttemptedToolCall('You can call query() and show_layer() next if you like.')).toBe(false);
+    });
 });
 
 describe('agent loop — malformed-call recovery (#288 failure mode 1/3)', () => {


### PR DESCRIPTION
Step 1 of #297 (follow-up to #295/#296).

## Problem

#296 closed the JSON-family embedded dialects. The **non-JSON tail** still leaks — and worse than the JSON cases did: neither `parseEmbeddedToolCalls` *nor* `looksLikeAttemptedToolCall` recognized these shapes, so the #288 re-prompt **never fired**. They surfaced raw to the user with zero recovery attempt:

- `show_layer(layer_id="…")` / `show_layer(layer_id='…')` — bare python-call
- `<show_layer>{"layer_id":"…"}</show_layer>` and `<show_layer><layer_id>…</layer_id></show_layer>` — tool-name-as-tag
- `<model_calls><invoke name="get_schema"><parameter name="dataset_id">…</parameter></invoke></model_calls>` — Claude fn-call XML
- `<parameter=function>show_layer</parameter>…` — mangled param tags

## Change (cheapest, highest-value step per #297)

Broaden `looksLikeAttemptedToolCall` to flag the whole tail so the #288 recovery at least fires:

- Unambiguous XML markers no prose emits: `<function=`, `<parameter=`/`<parameter `, `<invoke`, `<model_calls>`.
- Bare `known_tool(` and tool-name-as-tag `<known_tool>` — **gated on `toolRegistry.has`** so prose that merely names a tool isn't misread.
- Scan **all** `<word>` / `word(` matches (`matchAll`), not just the first — the real tool tag is routinely preceded by hallucinated reasoning tags (`<antThinking>`, `</think>`). (This was a bug in my first cut of the fix, caught by replaying the real logs.)

This does not yet *parse* these shapes first-pass — that's steps 2–3 of #297. It ensures none of them leak silently.

## Verification

- **Unit**: `#297` block in `test/agent-tool-parse.test.js` covers each tail row (→ `true`), the reasoning-tags-precede-tool-tag case, and negatives proving prose that merely names a tool stays `false`. Full suite: **460 passing**.
- **Live logs** (barred-owl/qwen, 2026-07-09): of **23 real terminal-leak strings**, 10 now parse first-pass (merged #296) and the remaining **13 now trigger the recovery re-prompt — 0 leak with zero recovery** (was 13 silent before this PR).

## Remaining (#297 steps 2–3)

First-pass *parsing* of the bare python-call (incl. `kwarg="v"` args), tool-name-as-tag, and `<invoke>` XML forms, plus growing `stripEmbeddedCalls` to strip whatever those handlers recognize.