### PR TITLE
feat(tools): session-scoped memoization of idempotent read tools (#281)

### DIFF
--- a/app/agent.js
+++ b/app/agent.js
@@ -913,9 +913,12 @@ export class Agent {
     }
 
     /**
-     * Clear conversation history.
+     * Clear conversation history. Also drops the registry's idempotent-read
+     * memo cache (#281) so a fresh conversation re-fetches metadata rather than
+     * serving results cached during the previous one.
      */
     clearHistory() {
         this.messages = [];
+        this.toolRegistry?.clearMemo?.();
     }
 }

--- a/app/main.js
+++ b/app/main.js
@@ -187,7 +187,11 @@ async function main() {
     }
 
     /* ── 5. Build tool registry ───────────────────────────────────────── */
-    const toolRegistry = new ToolRegistry();
+    // Idempotent-read memoization (#281) is on by default; set `tool_memo: false`
+    // in config to disable it (e.g. for debugging duplicate MCP traffic).
+    const toolRegistry = new ToolRegistry(
+        appConfig.tool_memo === false ? { memoTools: [] } : {},
+    );
 
     // Geocoder backend, shared by two independently-toggled surfaces:
     //   • the `geocode` agent tool — ON by default (opt-out: geocoder.enabled=false)

--- a/app/tool-registry.js
+++ b/app/tool-registry.js
@@ -12,10 +12,53 @@
  *   - isLocalTool(name) → for auto-approve logic
  */
 
+// Idempotent read tools whose result is a pure function of their args for the
+// life of a session. Memoizing these (#281) skips duplicate round-trips *and*
+// keeps repeated calls from re-growing the message suffix with byte-identical
+// result blocks — which is exactly the non-cacheable tail that dominates
+// prefill cost (#273). Deliberately excludes `query`: SQL results are large,
+// arg-varied, and have different invalidation semantics.
+const DEFAULT_MEMO_TOOLS = ['get_stac_details', 'get_collection', 'browse_stac_catalog', 'get_schema'];
+
+/**
+ * Stable JSON key so `{a:1, b:2}` and `{b:2, a:1}` produce the same memo key.
+ * Recurses objects/arrays; scalars fall through to JSON.stringify.
+ */
+function canonicalize(value) {
+    if (value === null || typeof value !== 'object') return JSON.stringify(value);
+    if (Array.isArray(value)) return '[' + value.map(canonicalize).join(',') + ']';
+    return '{' + Object.keys(value).sort()
+        .map(k => JSON.stringify(k) + ':' + canonicalize(value[k]))
+        .join(',') + '}';
+}
+
+/**
+ * A local tool can succeed at the transport level (returns a string) while
+ * reporting failure *inside* that string as `{"success": false, ...}` — e.g.
+ * get_schema on an unknown dataset or an MCP outage. Don't memoize those, or a
+ * transient failure poisons the session. Cheap prefix check before parsing.
+ */
+function reportsFailure(resultStr) {
+    if (typeof resultStr !== 'string' || !resultStr.trimStart().startsWith('{')) return false;
+    try {
+        return JSON.parse(resultStr)?.success === false;
+    } catch {
+        return false;
+    }
+}
+
 export class ToolRegistry {
-    constructor() {
+    /**
+     * @param {Object} [options]
+     * @param {string[]} [options.memoTools] - Override the idempotent-read
+     *   whitelist. Pass `[]` to disable memoization entirely.
+     */
+    constructor(options = {}) {
         /** @type {Map<string, ToolEntry>} */
         this.tools = new Map();
+        /** Session-scoped memo cache for idempotent reads (#281). */
+        this.memoCache = new Map();
+        this.memoWhitelist = new Set(options.memoTools ?? DEFAULT_MEMO_TOOLS);
     }
 
     /**
@@ -145,23 +188,35 @@ export class ToolRegistry {
             };
         }
 
+        // Memoize idempotent reads on (name, canonical args) so a model that
+        // re-issues the same metadata call gets a byte-identical result with no
+        // MCP round-trip (#281). Keyed on the model-facing args (pre-rewriter),
+        // so the argsRewriter's inline-STAC injection is skipped on a hit too.
+        const memoKey = this.memoWhitelist.has(name)
+            ? `${name}:${canonicalize(args ?? {})}`
+            : null;
+        if (memoKey && this.memoCache.has(memoKey)) {
+            return { ...this.memoCache.get(memoKey), cached: true };
+        }
+
+        let result;
         try {
             if (tool.source === 'local') {
-                const result = await tool.execute(args);
-                return {
+                const raw = await tool.execute(args);
+                result = {
                     success: true,
                     name,
-                    result: typeof result === 'string' ? result : JSON.stringify(result),
+                    result: typeof raw === 'string' ? raw : JSON.stringify(raw),
                     source: 'local',
                 };
             } else {
                 // Remote MCP tool
                 const finalArgs = tool.argsRewriter ? tool.argsRewriter(tool.name, args) : args;
-                const result = await tool.mcpClient.callTool(tool.name, finalArgs);
-                return {
+                const raw = await tool.mcpClient.callTool(tool.name, finalArgs);
+                result = {
                     success: true,
                     name,
-                    result,
+                    result: raw,
                     source: 'remote',
                     sqlQuery: args.sql_query || args.query || null,
                 };
@@ -175,6 +230,21 @@ export class ToolRegistry {
                 source: 'error',
             };
         }
+
+        // Only cache genuine successes — never a result that reports failure
+        // inside its own payload, so a transient outage doesn't stick.
+        if (memoKey && result.success && !reportsFailure(result.result)) {
+            this.memoCache.set(memoKey, result);
+        }
+        return result;
+    }
+
+    /**
+     * Drop the idempotent-read memo cache. Called on conversation reset so a
+     * fresh session re-fetches metadata rather than serving a prior session's.
+     */
+    clearMemo() {
+        this.memoCache.clear();
     }
 
     /**

--- a/test/tool-registry.test.js
+++ b/test/tool-registry.test.js
@@ -298,3 +298,127 @@ describe('ToolRegistry registerLocal duplicate handling', () => {
         warnSpy.mockRestore();
     });
 });
+
+describe('ToolRegistry idempotent-read memoization (#281)', () => {
+    const remote = (name, callTool) =>
+        [[{ name, description: '', inputSchema: { type: 'object', properties: {} } }], { callTool }];
+
+    it('serves a repeated whitelisted call from cache (no second round-trip)', async () => {
+        const callTool = vi.fn(async () => 'stac-md');
+        const reg = new ToolRegistry();
+        reg.registerRemote(...remote('get_stac_details', callTool));
+
+        const first = await reg.execute('get_stac_details', { dataset_id: 'foo' });
+        const second = await reg.execute('get_stac_details', { dataset_id: 'foo' });
+
+        expect(callTool).toHaveBeenCalledTimes(1);
+        expect(second.result).toBe('stac-md');
+        expect(first.cached).toBeUndefined();
+        expect(second.cached).toBe(true);
+    });
+
+    it('keys on args — different args miss the cache', async () => {
+        const callTool = vi.fn(async () => 'x');
+        const reg = new ToolRegistry();
+        reg.registerRemote(...remote('get_collection', callTool));
+
+        await reg.execute('get_collection', { collection_id: 'a' });
+        await reg.execute('get_collection', { collection_id: 'b' });
+
+        expect(callTool).toHaveBeenCalledTimes(2);
+    });
+
+    it('argument key order does not matter', async () => {
+        const callTool = vi.fn(async () => 'x');
+        const reg = new ToolRegistry();
+        reg.registerRemote(...remote('get_stac_details', callTool));
+
+        await reg.execute('get_stac_details', { a: 1, b: 2 });
+        await reg.execute('get_stac_details', { b: 2, a: 1 });
+
+        expect(callTool).toHaveBeenCalledTimes(1);
+    });
+
+    it('caches whitelisted local tools too (keyed pre-execute)', async () => {
+        const execute = vi.fn(async () => 'schema-md');
+        const reg = new ToolRegistry();
+        reg.registerLocal({
+            name: 'get_schema', description: '', inputSchema: { type: 'object', properties: {} }, execute,
+        });
+
+        await reg.execute('get_schema', { dataset_id: 'foo' });
+        const second = await reg.execute('get_schema', { dataset_id: 'foo' });
+
+        expect(execute).toHaveBeenCalledTimes(1);
+        expect(second.cached).toBe(true);
+    });
+
+    it('does not memoize non-whitelisted tools', async () => {
+        const callTool = vi.fn(async () => 'sql-rows');
+        const reg = new ToolRegistry();
+        reg.registerRemote(...remote('query', callTool));
+
+        await reg.execute('query', { sql_query: 'SELECT 1' });
+        await reg.execute('query', { sql_query: 'SELECT 1' });
+
+        expect(callTool).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not cache a transport failure (thrown → success:false)', async () => {
+        const callTool = vi.fn()
+            .mockRejectedValueOnce(new Error('mcp down'))
+            .mockResolvedValueOnce('recovered');
+        const reg = new ToolRegistry();
+        reg.registerRemote(...remote('get_stac_details', callTool));
+        const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+        const first = await reg.execute('get_stac_details', { dataset_id: 'foo' });
+        const second = await reg.execute('get_stac_details', { dataset_id: 'foo' });
+
+        expect(first.success).toBe(false);
+        expect(callTool).toHaveBeenCalledTimes(2);
+        expect(second.result).toBe('recovered');
+        errSpy.mockRestore();
+    });
+
+    it('does not cache a payload that reports failure inside its result string', async () => {
+        // get_schema on an unknown dataset returns a success:false JSON string
+        // while the ToolResult itself is a "successful" string return.
+        const execute = vi.fn()
+            .mockResolvedValueOnce(JSON.stringify({ success: false, error: 'not found' }))
+            .mockResolvedValueOnce('now-ok');
+        const reg = new ToolRegistry();
+        reg.registerLocal({
+            name: 'get_schema', description: '', inputSchema: { type: 'object', properties: {} }, execute,
+        });
+
+        await reg.execute('get_schema', { dataset_id: 'foo' });
+        const second = await reg.execute('get_schema', { dataset_id: 'foo' });
+
+        expect(execute).toHaveBeenCalledTimes(2);
+        expect(second.result).toBe('now-ok');
+    });
+
+    it('clearMemo forces a re-fetch', async () => {
+        const callTool = vi.fn(async () => 'x');
+        const reg = new ToolRegistry();
+        reg.registerRemote(...remote('browse_stac_catalog', callTool));
+
+        await reg.execute('browse_stac_catalog', {});
+        reg.clearMemo();
+        await reg.execute('browse_stac_catalog', {});
+
+        expect(callTool).toHaveBeenCalledTimes(2);
+    });
+
+    it('memoTools:[] disables memoization entirely', async () => {
+        const callTool = vi.fn(async () => 'x');
+        const reg = new ToolRegistry({ memoTools: [] });
+        reg.registerRemote(...remote('get_stac_details', callTool));
+
+        await reg.execute('get_stac_details', { dataset_id: 'foo' });
+        await reg.execute('get_stac_details', { dataset_id: 'foo' });
+
+        expect(callTool).toHaveBeenCalledTimes(2);
+    });
+});


### PR DESCRIPTION
## What

Adds a session-scoped memo cache for idempotent read tools at the `ToolRegistry.execute()` dispatch layer, keyed on `(name, canonical-JSON args)`.

Whitelisted: `get_stac_details`, `get_collection`, `browse_stac_catalog`, `get_schema`. Deliberately **not** `query` (large, arg-varied, different invalidation semantics — see #281).

## Why

Open models frequently re-issue the same `get_stac_details(id)` / `get_schema(id)` within or across turns. Each repeat was a fresh MCP round-trip **and** appended another large result block to the growing `turnMessages` — the exact non-cacheable suffix that dominates prefill cost (#273). On a hit we now return byte-identical content with no round-trip.

This is the fully-local, no-proxy-coordination complement to #273: don't generate the duplicate bytes in the first place.

## Design notes

- Keyed on the **model-facing args** (before `argsRewriter`), so the inline-STAC injection is skipped on a hit too.
- Only genuine successes are cached. A thrown error (`success:false`) is never cached; and a result that reports failure *inside its own payload* (`{"success":false,...}` — e.g. `get_schema` on an unknown dataset or an MCP outage) is skipped, so a transient failure can't poison the session.
- Default-on; `tool_memo: false` in config disables it. `clearHistory()` drops the cache so a fresh conversation re-fetches.

## Tests

9 new cases in `test/tool-registry.test.js`: cache hit/miss by args, key-order independence, local-tool caching, non-whitelist bypass, transport-failure and payload-failure non-caching, `clearMemo()`, and the disable knob. Full suite: 470 passing.

Closes #281