### PR TITLE
feat(agent): opt-in Claude prompt caching via cache_control on the system prefix (#273)

### DIFF
--- a/app/agent.js
+++ b/app/agent.js
@@ -465,6 +465,54 @@ export class Agent {
     }
 
     /**
+     * Whether to attach Anthropic-style `cache_control` breakpoints to the
+     * outgoing prompt for this model (#273). Off by default — resolved per-model
+     * first, then global (mirrors `_samplingParams`/`_thinkingParams`).
+     *
+     * This is a **Claude-specific** lever and should be enabled per-model on
+     * Anthropic-routed entries only. Two reasons it's opt-in, not fleet-wide:
+     *   1. Anthropic caching is opt-in — you get *nothing* without cache_control,
+     *      so this is the only way Claude turns benefit. Open backends (NRP vLLM,
+     *      some OpenRouter providers) already do automatic prefix caching for
+     *      free, so the breakpoints buy them nothing.
+     *   2. Enabling it reshapes the system message from a plain string into the
+     *      content-parts array form (below) so the breakpoint has a block to ride
+     *      on. That reshape — not the ignored `cache_control` key — is the only
+     *      cross-backend compatibility surface; keeping it per-model avoids
+     *      changing payload shape for models that gain nothing.
+     * The open-llm-proxy forwards the `messages` array verbatim, so a
+     * message-embedded breakpoint reaches the provider (unlike top-level cache
+     * params, which the proxy drops). See #273.
+     */
+    _promptCacheEnabled(modelConfig) {
+        const v = ('prompt_cache' in (modelConfig ?? {}))
+            ? modelConfig.prompt_cache
+            : this.config?.prompt_cache;
+        return v === true;
+    }
+
+    /**
+     * Return a copy of `messages` with a `cache_control` breakpoint on the
+     * system prompt when prompt caching is enabled for this model, else the
+     * array unchanged (byte-identical to today — the default path).
+     *
+     * The breakpoint goes on the system message because it carries the big,
+     * every-call-identical prefix (base prompt + injected dataset catalog,
+     * ~34k tokens per #294). On the Anthropic side the render order is
+     * tools → system → messages, so a breakpoint on the last system block
+     * caches the tool definitions too. Only string-content system messages are
+     * reshaped; anything already in content-parts form is passed through.
+     */
+    _applyPromptCache(messages, modelConfig) {
+        if (!this._promptCacheEnabled(modelConfig)) return messages;
+        return messages.map(m =>
+            m.role === 'system' && typeof m.content === 'string'
+                ? { ...m, content: [{ type: 'text', text: m.content, cache_control: { type: 'ephemeral' } }] }
+                : m
+        );
+    }
+
+    /**
      * Resolve the per-attempt LLM timeout in milliseconds. Mirrors
      * `_samplingParams` resolution: per-model `llm_timeout_seconds` wins, then
      * global config, then a built-in default.
@@ -496,7 +544,7 @@ export class Agent {
     async callLLM(endpoint, modelConfig, messages, tools) {
         const payload = {
             model: this.selectedModel,
-            messages,
+            messages: this._applyPromptCache(messages, modelConfig),
             tools: tools.length > 0 ? tools : undefined,
             tool_choice: tools.length > 0 ? 'auto' : 'none',
             user: this.sessionId,

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -540,6 +540,27 @@ The toggle emits a normalized `enable_thinking` flag that the [open-llm-proxy](h
 
 Resolution mirrors the sampling params: per-model first, then top-level global. A per-conversation toggle click overrides the configured default until the model is switched (which resets to that model's default).
 
+### Prompt caching (optional)
+
+The agentic tool-use loop is heavily prefill-dominated — every turn re-sends the system prompt, the tool definitions, and the running transcript, while outputs are tiny (roughly 43:1 prompt:completion tokens; see [#273](https://github.com/boettiger-lab/geo-agent/issues/273)). The biggest identical chunk re-sent on every call is the system prompt plus its injected dataset catalog (~34k tokens).
+
+`prompt_cache` attaches an Anthropic-style `cache_control: {"type": "ephemeral"}` breakpoint to the system prompt so that prefix bills at cache-read rates (~10%) on repeat calls instead of full price.
+
+```json
+{
+  "llm_models": [
+    { "value": "claude", "endpoint": "…", "api_key": "…", "prompt_cache": true },
+    { "value": "minimax-m2", "endpoint": "…", "api_key": "…" }
+  ]
+}
+```
+
+| Field | Where | Default | Description |
+|---|---|---|---|
+| `prompt_cache` | per-model and/or top-level | `false` | Attach a `cache_control` breakpoint to the system prompt. Resolved per-model first, then top-level. |
+
+> **Enable it per-model on Anthropic-routed models only.** This is a Claude-specific lever, for two reasons: (1) Anthropic caching is *opt-in* — a request with no `cache_control` gets no caching, so this is the only way Claude turns benefit; open backends (NRP vLLM, some OpenRouter providers) already do automatic prefix caching for free and gain nothing from the breakpoint. (2) Enabling it reshapes the system message from a plain string into the content-parts array form so the breakpoint has a block to ride on. That reshape (not the ignored `cache_control` key) is the only cross-backend compatibility surface — keeping it per-model avoids changing payload shape for models that don't benefit. The [open-llm-proxy](https://github.com/boettiger-lab/open-llm-proxy) forwards the `messages` array verbatim, so the message-embedded breakpoint reaches the provider (top-level cache params are dropped by the proxy). Off by default → payload is byte-identical to before.
+
 ## Voice input (optional)
 
 Voice input is opt-in via a `transcription_model` entry in `config.json`. When present, a 🎤 button appears in the chat footer; when absent, the button stays hidden and the voice/transcription JS modules are never loaded (zero footprint).

--- a/test/agent-prompt-cache.test.js
+++ b/test/agent-prompt-cache.test.js
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { Agent } from '../app/agent.js';
+
+const stubToolRegistry = {
+    getToolsForLLM: () => [],
+    isLocal: () => true,
+    execute: async () => ({ result: '' }),
+};
+
+const makeAgent = (config = {}) => new Agent(
+    { llm_models: [{ value: 'm', endpoint: 'https://x/v1', api_key: 'k' }], ...config },
+    stubToolRegistry,
+);
+
+const okResponse = () => ({
+    ok: true,
+    json: async () => ({ choices: [{ message: { role: 'assistant', content: 'ok' } }] }),
+});
+
+/** Capture the JSON body of the single fetch a callLLM makes. */
+const captureCall = async (agent, modelConfig, messages) => {
+    let body;
+    global.fetch = vi.fn(async (_url, opts) => {
+        body = JSON.parse(opts.body);
+        return okResponse();
+    });
+    await agent.callLLM('https://x/chat/completions', { api_key: 'k', ...modelConfig }, messages, []);
+    return body;
+};
+
+const sys = (text = 'SYSTEM PROMPT') => ({ role: 'system', content: text });
+const user = (text = 'hi') => ({ role: 'user', content: text });
+
+describe('Agent prompt caching (#273)', () => {
+    afterEach(() => vi.restoreAllMocks());
+
+    it('default (no flag): system message stays a plain string — byte-identical to today', async () => {
+        const agent = makeAgent();
+        const body = await captureCall(agent, {}, [sys(), user()]);
+        expect(body.messages[0].content).toBe('SYSTEM PROMPT');
+        expect(JSON.stringify(body)).not.toContain('cache_control');
+    });
+
+    it('per-model prompt_cache:true adds a cache_control breakpoint on the system prompt', async () => {
+        const agent = makeAgent();
+        const body = await captureCall(agent, { prompt_cache: true }, [sys('BIG PREFIX'), user()]);
+        expect(body.messages[0]).toEqual({
+            role: 'system',
+            content: [{ type: 'text', text: 'BIG PREFIX', cache_control: { type: 'ephemeral' } }],
+        });
+    });
+
+    it('global prompt_cache:true is honored', async () => {
+        const agent = makeAgent({ prompt_cache: true });
+        const body = await captureCall(agent, {}, [sys(), user()]);
+        expect(body.messages[0].content[0].cache_control).toEqual({ type: 'ephemeral' });
+    });
+
+    it('per-model prompt_cache:false overrides a global true', async () => {
+        const agent = makeAgent({ prompt_cache: true });
+        const body = await captureCall(agent, { prompt_cache: false }, [sys(), user()]);
+        expect(body.messages[0].content).toBe('SYSTEM PROMPT');
+        expect(JSON.stringify(body)).not.toContain('cache_control');
+    });
+
+    it('leaves non-system messages untouched when enabled', async () => {
+        const agent = makeAgent();
+        const body = await captureCall(agent, { prompt_cache: true }, [sys(), user('question')]);
+        expect(body.messages[1]).toEqual({ role: 'user', content: 'question' });
+    });
+
+    it('does not mutate the caller\'s messages array', async () => {
+        const agent = makeAgent();
+        const messages = [sys(), user()];
+        await captureCall(agent, { prompt_cache: true }, messages);
+        expect(messages[0].content).toBe('SYSTEM PROMPT'); // still a plain string
+    });
+
+    it('handles a prompt with no system message without crashing', async () => {
+        const agent = makeAgent();
+        const body = await captureCall(agent, { prompt_cache: true }, [user('just a user turn')]);
+        expect(body.messages).toEqual([{ role: 'user', content: 'just a user turn' }]);
+    });
+});


### PR DESCRIPTION
## What

Adds a per-model `prompt_cache` flag. When enabled, the agent attaches an Anthropic-style `cache_control: {"type": "ephemeral"}` breakpoint to the **system prompt** — the big, every-call-identical prefix (base prompt + injected dataset catalog, ~34k tokens per #294) — so it bills at cache-read rates (~10%) on repeat Claude turns instead of full prefill.

## Why this is the right shape

The linked prompt-caching guidance targets the **native Anthropic Messages API**. geo-agent speaks **OpenAI Chat Completions** through a proxy, so the doc's top-level form isn't a drop-in. Two facts shape the design:

1. **Anthropic caching is opt-in.** A request with no `cache_control` gets *zero* caching — so Claude turns benefit from nothing today. Open backends (NRP vLLM, some OpenRouter providers) already do automatic prefix caching for free and gain nothing from an explicit breakpoint. → This is a **Claude-specific** lever.
2. **The compat surface is the reshape, not the field.** Enabling a breakpoint means reshaping the system message from a plain string into the content-parts array form (`content: [{type:"text", text, cache_control}]`). The `cache_control` key itself is ignored by non-Anthropic backends; the array reshape is the only thing they have to tolerate. Gating it per-model keeps payload shape unchanged for models that don't benefit.

The open-llm-proxy forwards the `messages` array verbatim, so a message-embedded breakpoint reaches the provider — unlike top-level cache params, which the proxy drops (#273).

## Design

- `_promptCacheEnabled(modelConfig)` + `_applyPromptCache(messages, modelConfig)` mirror the existing `_samplingParams`/`_thinkingParams` resolution (per-model first, then global).
- Applied **non-mutatingly** at payload-build time inside `callLLM`, so `turnMessages` / `suspendedTurn` keep their plain-string form and the tool-parse/history logic is untouched.
- **Off by default → payload byte-identical to today.** Open models are unaffected unless a deployer opts them in.

## Scope

This covers the **`cache_control` breakpoint** half of #273. The other two levers in that issue — auditing prefix byte-stability and trimming the growing tool-result suffix — remain open. Complements the client-side memoization in #281 (PR #301).

Before flipping `prompt_cache: true` on a Claude entry in production, worth confirming from proxy logs that the content-parts form is tolerated by the specific backend and that `cache_read` tokens actually show up.

## Tests

New `test/agent-prompt-cache.test.js` (7 cases): default plain-string passthrough, per-model + global enable, per-model override of global, non-system messages untouched, caller array not mutated, no-system-message safety. Full suite: 468 passing.

Docs: new "Prompt caching (optional)" subsection in `docs/guide/configuration.md`.

Refs #273