### PR TITLE
docs(design): prompt-prefix stability audit + regression guard (#273)

### DIFF
--- a/docs/design/prompt-prefix-stability.md
+++ b/docs/design/prompt-prefix-stability.md
@@ -1,0 +1,90 @@
+# Design decision: prompt-prefix stability for caching
+
+**Status:** settled (2026-07-10). Revisit only if the assembly path changes.
+**Tracking issue:** #273 (suggestion 1 — the byte-stable-prefix half).
+
+## The recurring question
+
+Prompt caching — implicit provider prefix-caching (vLLM APC on NRP, provider-side
+on OpenRouter) and the explicit `cache_control` breakpoint (#273, off by default)
+— only pays off when the **leading bytes of the request are identical across
+calls**. Any dynamic content placed early in the prefix invalidates the cache for
+everything after it. #273 measured a 43%→76% cache-hit spread across providers and
+asked: is geo-agent assembling an unstable prefix? This note records the audit
+answer so we stop re-deriving it.
+
+## Finding: the prefix is already byte-stable; the spread is provider-side
+
+The request the agent sends is `{ model, messages, tools, tool_choice, user, …sampling }`
+(`app/agent.js` `callLLM`). For caching, the cacheable prefix is the rendered
+`tools` + `messages` — and the dominant chunk is the **system message** (base
+prompt + injected dataset catalog + MCP analyst prompt, ~34k tokens for a large
+catalog, per #294). The audit confirms every part of that prefix is stable:
+
+1. **The system prompt is built once and frozen.** `main.js` assembles
+   `basePrompt + '\n\n' + catalog.generatePromptCatalog() + '\n\n' + analystPrompt`
+   at bootstrap and calls `agent.setSystemPrompt()` exactly once. Nothing mutates
+   `agent.systemPrompt` afterward — `processMessage` reads it verbatim into
+   `messages[0]` every turn, and `chat-ui.js` only calls `processMessage(text)`
+   (it never injects leading context or edits the system prompt).
+2. **The catalog is deterministic.** `generatePromptCatalog()` iterates
+   `datasets.values()` in Map-insertion order (fixed by the `collections` config)
+   and contains no dates, RNG, or unstable set/dict iteration. Same config → same
+   bytes, run to run and pod to pod (so cross-session cold-start hits are possible
+   too, not just within-session).
+3. **No dynamic content lands in the prefix.** The only `Date.now()` /
+   `crypto.randomUUID()` / `Math.random()` in the codebase are outside the prefix:
+   the session id is a top-level `user` field (not prompt tokens), and the rest are
+   UI timers, chat-export filenames, and synthetic tool-call ids (which live in the
+   per-turn suffix). No "current date" / "today" is injected.
+4. **Volatile content is strictly last.** Conversation turns and tool results
+   follow the system message; the growing, uncacheable tail is where it belongs.
+
+**Evidence the spread is provider-side, not ours.** Production vLLM prefix-cache
+hit rates (Prometheus, 7d) vary from **13% to 74%** *across models* on the same
+serving stack — Kimi 13%, GLM 16%, gemma 18–20%, gpt-oss 27%, Qwen3.6 42%,
+Qwen3.5 50%, MiniMax 74%. Since geo-agent sends the identical prefix regardless of
+model, a 13–74% range can only be a per-backend cache property (APC config,
+KV-cache pressure, eviction, batching), not prompt assembly. The audit therefore
+found **no harness-side fix** for the #273 spread.
+
+## The invariant (rules for future changes)
+
+Keep the prefix stable. Concretely, in `main.js` / `dataset-catalog.js` / `agent.js`:
+
+- **Never inject dynamic content into `systemPrompt`** — no `Date`/`now()`/random,
+  no per-turn map state, no session/user id, no "current date". If the model needs
+  volatile context, put it in a **user-turn message** (or, for operator instructions
+  on supporting models, a mid-conversation `role:"system"` message), never ahead of
+  the cached prefix.
+- **Keep catalog rendering deterministic** — no unsorted set/dict iteration, no
+  timestamps. If a new field is added, ensure identical config → identical bytes.
+- **Don't reorder tools mid-session.** `getToolsForLLM()` relies on stable Map
+  insertion order (locals, then MCP tools in server-advertised order). A reconnect
+  re-registers in the same order; keep it that way.
+
+`test/agent-prefix-stability.test.js` guards the load-bearing part: the outgoing
+system message is byte-identical across turns and equals the frozen `systemPrompt`.
+
+## Known limitation (accepted, not a bug)
+
+The context window is `this.messages.slice(-12)` (`agent.js`), a sliding window.
+Once a conversation exceeds 12 messages, the tokens *immediately after* the system
+prompt shift each turn, so the conversation body never accrues incremental
+cross-turn cache hits — only the **system prefix** caches turn-to-turn. That is
+acceptable: the system prefix is by far the largest chunk, so we already capture
+the dominant win, and the window exists for context-budget reasons. Restructuring
+to an append-only history for marginal conversation-tail caching isn't worth it.
+
+## Relationship to the explicit `cache_control` breakpoint (#273)
+
+The per-model `prompt_cache` flag (merged, off by default) adds an explicit
+Anthropic `cache_control` breakpoint on the system message. That is a **cost** lever
+for Claude only and is currently a no-op: the open-llm-proxy routes Claude to
+Anthropic's OpenAI-compat endpoint, which ignores message-embedded `cache_control`
+(see open-llm-proxy#75). This note covers the *implicit* prefix caching that every
+backend already does for free — which the audit confirms we are not undermining.
+
+Also note (#282): 72–98% of LLM compute *time* is decode, so prefix caching is a
+cost lever with ~zero latency benefit. Latency comes from fewer round-trips
+(#281), smaller outputs, and reasoning-off (#283).

--- a/test/agent-prefix-stability.test.js
+++ b/test/agent-prefix-stability.test.js
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { Agent } from '../app/agent.js';
+
+// Guards the prompt-prefix-stability invariant documented in
+// docs/design/prompt-prefix-stability.md (#273 suggestion 1): the cacheable
+// prefix — the system message — must be byte-identical across turns and equal to
+// the frozen systemPrompt. A regression that injects per-turn dynamic content
+// (a date, map state, a session id) into the system prefix would break caching
+// for the entire suffix; this test fails loudly if that happens.
+
+const stubToolRegistry = {
+    getToolsForLLM: () => [],
+    isLocal: () => true,
+    execute: async () => ({ result: '' }),
+};
+
+const makeAgent = () => new Agent(
+    { llm_models: [{ value: 'm', endpoint: 'https://x/v1', api_key: 'k' }] },
+    stubToolRegistry,
+);
+
+// Each LLM call returns a plain-text final answer (no tool_calls), so every
+// processMessage() completes in a single turn.
+const okResponse = (content = 'final answer') => ({
+    ok: true,
+    json: async () => ({ choices: [{ message: { role: 'assistant', content } }] }),
+});
+
+describe('prompt-prefix stability (#273)', () => {
+    afterEach(() => vi.restoreAllMocks());
+
+    it('sends a byte-identical system message across turns, equal to the frozen prompt', async () => {
+        const SYSTEM = '# Analyst\n\nStable system prompt with an injected catalog.\n' + 'dataset paths. '.repeat(50);
+        const agent = makeAgent();
+        agent.setSystemPrompt(SYSTEM);
+
+        const sent = [];
+        global.fetch = vi.fn(async (_url, opts) => {
+            sent.push(JSON.parse(opts.body));
+            return okResponse();
+        });
+
+        await agent.processMessage('first question');
+        await agent.processMessage('second question');
+
+        expect(sent).toHaveLength(2);
+        // System message is first, on both turns.
+        expect(sent[0].messages[0].role).toBe('system');
+        expect(sent[1].messages[0].role).toBe('system');
+        // Byte-identical across turns …
+        expect(sent[1].messages[0]).toEqual(sent[0].messages[0]);
+        // … and equal to exactly what was frozen (no per-send mutation/injection).
+        expect(sent[0].messages[0].content).toBe(SYSTEM);
+        // The volatile user turn differs, confirming the suffix — not the prefix —
+        // is what changes between requests.
+        expect(sent[0].messages.at(-1).content).toBe('first question');
+        expect(sent[1].messages.at(-1).content).toBe('second question');
+    });
+
+    it('does not mutate agent.systemPrompt while running a turn', async () => {
+        const SYSTEM = 'frozen prompt';
+        const agent = makeAgent();
+        agent.setSystemPrompt(SYSTEM);
+        global.fetch = vi.fn(async () => okResponse());
+
+        await agent.processMessage('q');
+
+        expect(agent.systemPrompt).toBe(SYSTEM);
+    });
+});


### PR DESCRIPTION
## What

The byte-stable-prefix half of #273 (suggestion 1). Audits whether geo-agent assembles a cache-stable request prefix, records the finding as a settled `docs/design/` note, and adds a regression guard.

## Finding: the prefix is already byte-stable — the #273 spread is provider-side

- **System prompt built once and frozen** (`main.js` → `setSystemPrompt`, never mutated per-turn; `chat-ui.js` only calls `processMessage`).
- **Catalog is deterministic** — `generatePromptCatalog()` iterates `datasets.values()` in fixed Map-insertion order, no dates/RNG/unstable iteration.
- **No dynamic content in the prefix** — the only `Date.now()`/`randomUUID()`/`Math.random()` are the session id (top-level `user` field), UI timers, export filenames, and synthetic tool-call ids (all in the per-turn suffix). No "current date" injection.
- **Volatile content strictly last** — conversation + tool results follow the system message.

**Evidence it's provider-side:** production vLLM prefix-cache hit rates span **13% → 74% across models** on the same stack (Kimi 13% … MiniMax 74%), on our identical prefix. A 13–74% range on the same bytes can only be a per-backend cache property, not prompt assembly. So there is **no harness-side fix** for the #273 spread — the implicit caching we already get for free is not being undermined.

## Deliverables

- **`docs/design/prompt-prefix-stability.md`** — the settled note: the audit, the invariant, rules for future changes (never inject dates/session/map-state ahead of the volatile tail; keep catalog rendering deterministic; don't reorder tools mid-session), the accepted `slice(-12)` sliding-window limitation, and the relationship to the explicit `cache_control` flag (blocked at the proxy, open-llm-proxy#75).
- **`test/agent-prefix-stability.test.js`** — guards the load-bearing property: the outgoing system message is byte-identical across turns and equals the frozen `systemPrompt`, so a future dynamic-injection regression fails loudly.

No source changes — nothing to fix; the audit confirms the assembly is correct. Full suite: 479 passing.

Refs #273