### PR TITLE
feat(agent): send X-Client version header to our proxy for log attribution (#254)

### DIFF
--- a/app/agent.js
+++ b/app/agent.js
@@ -12,6 +12,12 @@
  * Handles embedded tool calls (XML tags) from models that don't use structured tool_calls.
  */
 
+// The pinned ref the app was loaded from lives in the module URL itself
+// (…/geo-agent@v3.13.1/app/agent.js), so it identifies the exact build with no
+// build step. Falls back to 'dev' for local/headless runs (a file:// URL). Used
+// only for the X-Client log-attribution header (#254). See `_clientHeaders`.
+const APP_VERSION = import.meta.url.match(/geo-agent@([^/]+)/)?.[1] || 'dev';
+
 export class Agent {
     /**
      * @param {Object} config
@@ -532,6 +538,35 @@ export class Agent {
     }
 
     /**
+     * Whether the endpoint is a trusted proxy host that should receive the
+     * `X-Client` attribution header (#254). Gated because geo-agent runs in the
+     * browser: a custom request header extends the CORS preflight, and a
+     * bring-your-own endpoint whose `Access-Control-Allow-Headers` doesn't list
+     * `X-Client` would have the browser block *every* request to it. Our proxy
+     * allowlists it (and only our logs use it), so send it only there.
+     *
+     * Default allowlist is `nrp-nautilus.io` (our infra — the same origin the
+     * proxy's own CORS regex trusts); override per deployment with
+     * `client_header_hosts` (array of host suffixes).
+     */
+    _isTrustedProxyHost(endpoint) {
+        let host;
+        try { host = new URL(endpoint).hostname; } catch { return false; }
+        const suffixes = this.config?.client_header_hosts ?? ['nrp-nautilus.io'];
+        return suffixes.some(s => host === s || host.endsWith('.' + s));
+    }
+
+    /**
+     * The `X-Client` header for log attribution, or `{}` when the endpoint isn't
+     * a trusted proxy host (spread into the fetch headers). See #254.
+     */
+    _clientHeaders(endpoint) {
+        return this._isTrustedProxyHost(endpoint)
+            ? { 'X-Client': `geo-agent/${APP_VERSION}` }
+            : {};
+    }
+
+    /**
      * Call the LLM API, with one auto-retry on transient errors (gateway 5xx,
      * network blips, client-side timeout).
      *
@@ -595,6 +630,7 @@ export class Agent {
                 headers: {
                     'Content-Type': 'application/json',
                     'Authorization': `Bearer ${modelConfig.api_key}`,
+                    ...this._clientHeaders(endpoint),
                 },
                 body: JSON.stringify(payload),
                 signal: internal.signal,

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -19,6 +19,7 @@ Client apps configure GLEN via `layers-input.json`. All fields except `catalog` 
 | `max_tool_calls` | No | Remote queries in auto-approve mode before the agent pauses at a checkpoint. Default: `15`. |
 | `max_tool_calls_manual` | No | Remote queries in manual mode before a checkpoint. Default: `100`. |
 | `catalog_index_threshold` | No | Dataset count above which the front-loaded catalog switches to a compact index (id + title + one-line summary + layer ids) to shrink the cold prompt; full descriptions/paths then arrive on demand via `get_schema`. Default: `8`. Set very high (e.g. `9999`) to always front-load the full catalog. |
+| `client_header_hosts` | No | Host suffixes that receive the `X-Client: geo-agent/<ref>` attribution header (for proxy log analysis). Default: `["nrp-nautilus.io"]`. The header is **only** sent to these hosts — never to bring-your-own external endpoints, where a custom header could trip CORS and block requests. Override only if your proxy runs on a different host. |
 | `links` | No | Optional links shown in the chat UI — see below. |
 
 ## View

--- a/test/agent-client-header.test.js
+++ b/test/agent-client-header.test.js
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { Agent } from '../app/agent.js';
+
+const stubToolRegistry = { getToolsForLLM: () => [], isLocal: () => true, execute: async () => ({ result: '' }) };
+const makeAgent = (config = {}) => new Agent(
+    { llm_models: [{ value: 'm', endpoint: 'https://x/v1', api_key: 'k' }], ...config },
+    stubToolRegistry,
+);
+const okResponse = () => ({ ok: true, json: async () => ({ choices: [{ message: { role: 'assistant', content: 'ok' } }] }) });
+
+// Capture the headers of the single fetch a callLLM makes against `endpoint`.
+const headersFor = async (agent, endpoint) => {
+    let headers;
+    global.fetch = vi.fn(async (_url, opts) => { headers = opts.headers; return okResponse(); });
+    await agent.callLLM(endpoint, { api_key: 'k' }, [{ role: 'user', content: 'hi' }], []);
+    return headers;
+};
+
+describe('X-Client attribution header, gated to trusted proxy hosts (#254)', () => {
+    afterEach(() => vi.restoreAllMocks());
+
+    it('sends X-Client to our proxy host', async () => {
+        const h = await headersFor(makeAgent(), 'https://open-llm-proxy.nrp-nautilus.io/v1/chat/completions');
+        expect(h['X-Client']).toMatch(/^geo-agent\//); // geo-agent/dev in tests (no @ref in a file:// URL)
+    });
+
+    it('does NOT send X-Client to a bring-your-own external endpoint', async () => {
+        const h = await headersFor(makeAgent(), 'https://openrouter.ai/api/v1/chat/completions');
+        expect(h['X-Client']).toBeUndefined();
+        // Auth/content-type are unaffected.
+        expect(h['Content-Type']).toBe('application/json');
+        expect(h['Authorization']).toBe('Bearer k');
+    });
+
+    it('_isTrustedProxyHost matches the infra suffix (incl. bare apex) and rejects others', () => {
+        const a = makeAgent();
+        expect(a._isTrustedProxyHost('https://open-llm-proxy.nrp-nautilus.io/v1')).toBe(true);
+        expect(a._isTrustedProxyHost('https://nrp-nautilus.io/v1')).toBe(true);
+        expect(a._isTrustedProxyHost('https://openrouter.ai/api/v1')).toBe(false);
+        expect(a._isTrustedProxyHost('https://evil-nrp-nautilus.io/v1')).toBe(false); // suffix, not substring
+        expect(a._isTrustedProxyHost('not a url')).toBe(false);
+    });
+
+    it('honors a per-deployment client_header_hosts override', async () => {
+        const agent = makeAgent({ client_header_hosts: ['myproxy.example.com'] });
+        expect((await headersFor(agent, 'https://myproxy.example.com/v1/chat/completions'))['X-Client']).toMatch(/^geo-agent\//);
+        // Default infra host no longer trusted once overridden.
+        expect((await headersFor(agent, 'https://open-llm-proxy.nrp-nautilus.io/v1/chat/completions'))['X-Client']).toBeUndefined();
+    });
+});


### PR DESCRIPTION
## What

Sends `X-Client: geo-agent/<ref>` on requests **to our proxy** so its logs can attribute a session to the exact build (the `client` column, currently always `null`).

- **Version source:** `import.meta.url` — the pinned jsDelivr ref the app actually loaded (`geo-agent@v3.13.1`, or a commit SHA). There's no build step and `package.json` is stale (`1.0.0`), so the module URL is the only accurate source. Falls back to `dev` on a `file://` URL (local/headless).

## The BYO-endpoint risk this avoids (gating)

geo-agent runs in the **browser**, so a custom request header extends the CORS preflight. A bring-your-own endpoint whose `Access-Control-Allow-Headers` is an explicit list without `X-Client` would have the browser **block every request** to it — a hard break, not just missing attribution. (The server *ignoring* an unknown header is harmless; CORS is the actual failure mode.)

So the header is **gated**: sent only to hosts matching `client_header_hosts` (default suffix `nrp-nautilus.io` — the same origin the proxy's own CORS regex trusts), never to external BYO endpoints. Attribution only matters in our logs anyway, so gating costs nothing.

## Proxy side is already done

Verified in `open-llm-proxy`: `llm_proxy.py:490` reads `x-client` → logs it as `client`; the HAProxy ingress `cors-allow-headers` already lists `X-Client` (`ingress.yaml:21`, with a comment noting it was pre-added for this). So this is purely the client half — no proxy change needed.

## Tests

`test/agent-client-header.test.js` (4 cases): header sent to our proxy, **not** sent to an external BYO endpoint (auth/content-type unaffected), suffix matching (incl. bare apex, rejects `evil-nrp-nautilus.io` substring attack and non-URLs), and the `client_header_hosts` override. Full suite: 489 passing.

Closes #254