### PR TITLE
feat(charts): resizable/pop-out chart panels + resize-grip & default styles (WIP)

### DIFF
--- a/app/animation-manager.js
+++ b/app/animation-manager.js
@@ -208,8 +208,9 @@ export class TrajectoryAnimation {
                 <option value="4">4×</option>
             </select>
         `;
-        // Stack multiple panels vertically
-        const existing = document.querySelectorAll('.anim-controls').length;
+        // Stack multiple panels vertically — count reactive-control sliders too
+        // so the two panel types never render on top of each other.
+        const existing = document.querySelectorAll('.anim-controls, .reactive-controls').length;
         panel.style.bottom = (12 + existing * 44) + 'px';
         document.body.appendChild(panel);
 

--- a/app/chart-renderer.js
+++ b/app/chart-renderer.js
@@ -1,0 +1,198 @@
+/**
+ * chart-renderer.js — Opt-in lightweight charting primitive (#277)
+ *
+ * Turns a query result set into a static chart (bar / line / scatter /
+ * histogram) rendered in a floating panel over the map. Generic, not
+ * app-specific: the agent runs a `query`, then hands the rows (or the SQL) to
+ * the `render_chart` tool, which calls ChartRenderer.render here.
+ *
+ * The charting library (Observable Plot) is loaded lazily from the CDN the
+ * first time a chart is drawn — so apps that don't enable charts pay nothing,
+ * and downstream apps don't need to add a <script> tag to their index.html.
+ *
+ * `buildPlotOptions` is pure (Plot is injected) so the mark-selection /
+ * channel-mapping logic is unit-tested without a DOM or a network fetch.
+ */
+
+// Observable Plot ships as ESM + a UMD bundle whose browser global expects a
+// `d3` global, so we load d3 then Plot via SRI-pinned <script> tags — matching
+// the opt-in CDN convention in map-draw.js / map-geocoder.js. Lazy: nothing
+// loads until the first chart is drawn.
+const D3_JS = 'https://cdn.jsdelivr.net/npm/d3@7.9.0/dist/d3.min.js';
+const D3_JS_SRI = 'sha384-CjloA8y00+1SDAUkjs099PVfnY2KmDC2BZnws9kh8D/lX1s46w6EPhpXdqMfjK6i';
+const PLOT_JS = 'https://cdn.jsdelivr.net/npm/@observablehq/plot@0.6.16/dist/plot.umd.min.js';
+const PLOT_JS_SRI = 'sha384-XzQ+KW4LBWHv6FLjiPA1vjDz//oGlY8We4XROgpir5jHgg2+Qvo/6fT5TjbnqyYi';
+
+const CHART_TYPES = ['bar', 'line', 'scatter', 'histogram'];
+
+/** Load a JS script by URL with SRI; resolves when loaded. */
+function loadScript(url, integrity) {
+    return new Promise((resolve, reject) => {
+        const s = document.createElement('script');
+        s.src = url;
+        if (integrity) {
+            s.integrity = integrity;
+            s.crossOrigin = 'anonymous';
+        }
+        s.onload = resolve;
+        s.onerror = () => reject(new Error(`Failed to load ${url}`));
+        document.head.appendChild(s);
+    });
+}
+
+/** True when `p` looks like the Observable Plot namespace we need. */
+function isPlot(p) {
+    return !!p && typeof p.plot === 'function' && typeof p.barY === 'function' && typeof p.binX === 'function';
+}
+
+/**
+ * Validate a chart spec (pure, no Plot/DOM). Lets the tool reject a bad spec
+ * before paying for an MCP/SQL round-trip.
+ * @throws if chart_type is unsupported or a required channel is missing
+ */
+export function validateChartSpec(spec) {
+    const type = spec.chart_type;
+    if (!CHART_TYPES.includes(type)) {
+        throw new Error(`Unsupported chart_type "${type}". Use one of: ${CHART_TYPES.join(', ')}.`);
+    }
+    if (!spec.x) throw new Error(`chart_type "${type}" requires an x column.`);
+    if (type !== 'histogram' && !spec.y) throw new Error(`chart_type "${type}" requires a y column.`);
+}
+
+/**
+ * Build the Observable Plot options object for a chart spec + rows.
+ * Pure: the Plot namespace is passed in, so callers (and tests) control it.
+ *
+ * @param {Object} Plot — the Observable Plot namespace (barY, lineY, dot, …)
+ * @param {Object} spec — { chart_type, x, y, series, x_label, y_label }
+ * @param {Array<Object>} rows — result rows
+ * @returns {Object} options for Plot.plot()
+ * @throws if chart_type is unsupported or required channels are missing
+ */
+export function buildPlotOptions(Plot, spec, rows) {
+    validateChartSpec(spec);
+    const type = spec.chart_type;
+    const { x, y, series } = spec;
+
+    let mark;
+    switch (type) {
+        case 'bar':       mark = Plot.barY(rows, { x, y, fill: series, tip: true }); break;
+        case 'line':      mark = Plot.lineY(rows, { x, y, stroke: series, marker: 'circle', tip: true }); break;
+        case 'scatter':   mark = Plot.dot(rows, { x, y, stroke: series, tip: true }); break;
+        case 'histogram': mark = Plot.rectY(rows, Plot.binX({ y: 'count' }, { x, tip: true })); break;
+    }
+
+    const marks = [];
+    // A baseline at y=0 reads more honestly for bars/lines/histograms.
+    if (type !== 'scatter') marks.push(Plot.ruleY([0]));
+    marks.push(mark);
+
+    return {
+        marginLeft: 60,
+        marginBottom: 44,
+        marginTop: 16,
+        grid: true,
+        x: { label: spec.x_label ?? x ?? null },
+        y: { label: spec.y_label ?? (type === 'histogram' ? 'count' : y) ?? null },
+        // histogram bins ignore `series`, so a color legend there would be empty.
+        ...(series && type !== 'histogram' && { color: { legend: true } }),
+        marks,
+    };
+}
+
+export class ChartRenderer {
+    /**
+     * @param {Object} [opts]
+     * @param {Document} [opts.doc] — injectable for tests
+     */
+    constructor(opts = {}) {
+        this.doc = opts.doc || (typeof document !== 'undefined' ? document : null);
+        this._plot = null;
+        this._seq = 0;
+        this._panels = new Map();   // id → panel element
+    }
+
+    /**
+     * Lazy-load Observable Plot once (d3 first, then Plot). Reuses a valid
+     * preloaded global if present; otherwise injects the SRI-pinned scripts.
+     */
+    async _loadPlot() {
+        if (this._plot) return this._plot;
+        if (isPlot(globalThis.Plot)) {
+            this._plot = globalThis.Plot;
+            return this._plot;
+        }
+        if (typeof document === 'undefined') {
+            throw new Error('Charting requires a browser document to load Observable Plot.');
+        }
+        if (typeof globalThis.d3 === 'undefined') await loadScript(D3_JS, D3_JS_SRI);
+        await loadScript(PLOT_JS, PLOT_JS_SRI);
+        if (!isPlot(globalThis.Plot)) {
+            throw new Error('Observable Plot loaded but its API was not found on window.Plot.');
+        }
+        this._plot = globalThis.Plot;
+        return this._plot;
+    }
+
+    /**
+     * Render a chart into a floating panel. Returns { id } once mounted.
+     * @param {Object} spec — see buildPlotOptions
+     * @param {Array<Object>} rows
+     */
+    async render(spec, rows) {
+        const Plot = await this._loadPlot();
+        const options = buildPlotOptions(Plot, spec, rows);
+        const figure = Plot.plot(options);
+
+        const id = `chart-${++this._seq}`;
+        if (!this.doc) return { id };   // headless (shouldn't happen in-app)
+
+        const panel = this.doc.createElement('div');
+        panel.className = 'chart-panel';
+        panel.dataset.chartId = id;
+
+        const header = this.doc.createElement('div');
+        header.className = 'chart-panel-header';
+        const title = this.doc.createElement('span');
+        title.className = 'chart-panel-title';
+        title.textContent = spec.title || `${cap(spec.chart_type)} chart`;
+        const close = this.doc.createElement('button');
+        close.className = 'chart-panel-close';
+        close.title = 'Close chart';
+        close.textContent = '✕';
+        close.addEventListener('click', () => this.remove(id));
+        header.appendChild(title);
+        header.appendChild(close);
+
+        const body = this.doc.createElement('div');
+        body.className = 'chart-panel-body';
+        body.appendChild(figure);
+
+        panel.appendChild(header);
+        panel.appendChild(body);
+
+        // Cascade panels up the right edge. Use the monotonic sequence (not the
+        // live panel count) so closing a middle panel can't make the next chart
+        // land exactly on an open one; wrap after a few so it stays on-screen.
+        const offset = 12 + ((this._seq - 1) % 6) * 20;
+        panel.style.bottom = offset + 'px';
+        panel.style.right = offset + 'px';
+
+        this.doc.body.appendChild(panel);
+        this._panels.set(id, panel);
+        return { id };
+    }
+
+    remove(id) {
+        const panel = this._panels.get(id);
+        if (panel) { panel.remove(); this._panels.delete(id); }
+    }
+
+    removeAll() {
+        for (const id of [...this._panels.keys()]) this.remove(id);
+    }
+}
+
+function cap(s) {
+    return s ? s.charAt(0).toUpperCase() + s.slice(1) : s;
+}

--- a/app/chart-renderer.js
+++ b/app/chart-renderer.js
@@ -140,9 +140,8 @@ export class ChartRenderer {
      * @param {Array<Object>} rows
      */
     async render(spec, rows) {
-        const Plot = await this._loadPlot();
-        const options = buildPlotOptions(Plot, spec, rows);
-        const figure = Plot.plot(options);
+        validateChartSpec(spec);      // reject a bad spec before touching the DOM
+        await this._loadPlot();
 
         const id = `chart-${++this._seq}`;
         if (!this.doc) return { id };   // headless (shouldn't happen in-app)
@@ -156,17 +155,31 @@ export class ChartRenderer {
         const title = this.doc.createElement('span');
         title.className = 'chart-panel-title';
         title.textContent = spec.title || `${cap(spec.chart_type)} chart`;
+
+        // Pop-out: toggle between the docked corner card and a large centered
+        // view. The size change is picked up by the ResizeObserver, which
+        // re-plots to fit — so charts stay sharp at any size.
+        const pop = this.doc.createElement('button');
+        pop.className = 'chart-panel-pop';
+        pop.title = 'Pop out / restore';
+        pop.textContent = '⤢';
+        pop.addEventListener('click', () => {
+            const popped = panel.classList.toggle('chart-panel--popped');
+            pop.textContent = popped ? '⤡' : '⤢';
+        });
+
         const close = this.doc.createElement('button');
         close.className = 'chart-panel-close';
         close.title = 'Close chart';
         close.textContent = '✕';
         close.addEventListener('click', () => this.remove(id));
+
         header.appendChild(title);
+        header.appendChild(pop);
         header.appendChild(close);
 
         const body = this.doc.createElement('div');
         body.className = 'chart-panel-body';
-        body.appendChild(figure);
 
         panel.appendChild(header);
         panel.appendChild(body);
@@ -181,13 +194,45 @@ export class ChartRenderer {
         panel.style.setProperty('--chart-cascade', offset + 'px');
 
         this.doc.body.appendChild(panel);
-        this._panels.set(id, panel);
+
+        const entry = { panel, body, spec, rows, observer: null, raf: 0 };
+        this._drawFigure(entry);
+
+        // Re-plot to fit whenever the user drags the resize grip or pops out.
+        if (typeof ResizeObserver !== 'undefined') {
+            entry.observer = new ResizeObserver(() => {
+                if (entry.raf) cancelAnimationFrame(entry.raf);
+                entry.raf = requestAnimationFrame(() => this._drawFigure(entry));
+            });
+            entry.observer.observe(body);
+        }
+
+        this._panels.set(id, entry);
         return { id };
     }
 
+    /** (Re)render an entry's Plot figure sized to its current panel body. */
+    _drawFigure(entry) {
+        if (!entry || !this._plot || !entry.body) return;
+        const { body, spec, rows } = entry;
+        const width = Math.max(220, body.clientWidth || 400);
+        const height = Math.max(160, body.clientHeight || 300);
+        let figure;
+        try {
+            figure = this._plot.plot({ ...buildPlotOptions(this._plot, spec, rows), width, height });
+        } catch {
+            return;   // keep the prior figure on a transient draw error
+        }
+        body.replaceChildren(figure);
+    }
+
     remove(id) {
-        const panel = this._panels.get(id);
-        if (panel) { panel.remove(); this._panels.delete(id); }
+        const entry = this._panels.get(id);
+        if (!entry) return;
+        if (entry.observer) entry.observer.disconnect();
+        if (entry.raf) cancelAnimationFrame(entry.raf);
+        entry.panel.remove();
+        this._panels.delete(id);
     }
 
     removeAll() {

--- a/app/chart-renderer.js
+++ b/app/chart-renderer.js
@@ -171,12 +171,14 @@ export class ChartRenderer {
         panel.appendChild(header);
         panel.appendChild(body);
 
-        // Cascade panels up the right edge. Use the monotonic sequence (not the
-        // live panel count) so closing a middle panel can't make the next chart
-        // land exactly on an open one; wrap after a few so it stays on-screen.
+        // Cascade panels up the bottom-right corner of the MAP area. Use the
+        // monotonic sequence (not the live panel count) so closing a middle
+        // panel can't make the next chart land exactly on an open one; wrap
+        // after a few so it stays on-screen. The base anchor is set in CSS via
+        // calc(--sidebar-width + --chart-cascade) so panels clear the sidebar
+        // in sidebar-mode layouts instead of hiding behind it.
         const offset = 12 + ((this._seq - 1) % 6) * 20;
-        panel.style.bottom = offset + 'px';
-        panel.style.right = offset + 'px';
+        panel.style.setProperty('--chart-cascade', offset + 'px');
 
         this.doc.body.appendChild(panel);
         this._panels.set(id, panel);

--- a/app/chart-renderer.js
+++ b/app/chart-renderer.js
@@ -25,6 +25,15 @@ const PLOT_JS_SRI = 'sha384-XzQ+KW4LBWHv6FLjiPA1vjDz//oGlY8We4XROgpir5jHgg2+Qvo/
 
 const CHART_TYPES = ['bar', 'line', 'scatter', 'histogram'];
 
+// Bold, readable defaults. Categorical range is the validated CVD-safe palette
+// (dataviz skill, light surface) — assigned in fixed order, never cycled. A
+// chart with no `series` uses one confident color instead of Plot's thin
+// default. Text stays ink; only marks carry the data color.
+const CATEGORICAL = ['#2a78d6', '#1baf7a', '#eda100', '#008300', '#4a3aa7', '#e34948', '#e87ba4', '#eb6834'];
+const SERIES_1 = '#2a78d6';   // default single-series color (bold blue)
+const INK = '#1a1a1a';        // axis / label text
+const CHART_FONT = "'Open Sans', system-ui, -apple-system, sans-serif";
+
 /** Load a JS script by URL with SRI; resolves when loaded. */
 function loadScript(url, integrity) {
     return new Promise((resolve, reject) => {
@@ -74,12 +83,30 @@ export function buildPlotOptions(Plot, spec, rows) {
     const type = spec.chart_type;
     const { x, y, series } = spec;
 
+    // A single confident color when there's no `series`; a real grouping paints
+    // marks from the categorical range. A string that is a valid CSS color is a
+    // constant fill/stroke in Plot; a column name is a channel — so `series`
+    // colors by category and `SERIES_1` is a flat bold color.
+    const paint = series || SERIES_1;
+
     let mark;
     switch (type) {
-        case 'bar':       mark = Plot.barY(rows, { x, y, fill: series, tip: true }); break;
-        case 'line':      mark = Plot.lineY(rows, { x, y, stroke: series, marker: 'circle', tip: true }); break;
-        case 'scatter':   mark = Plot.dot(rows, { x, y, stroke: series, tip: true }); break;
-        case 'histogram': mark = Plot.rectY(rows, Plot.binX({ y: 'count' }, { x, tip: true })); break;
+        case 'bar':
+            // Filled bars, a 2px surface gap between neighbors (never a stroke).
+            mark = Plot.barY(rows, { x, y, fill: paint, insetLeft: 1, insetRight: 1, tip: true });
+            break;
+        case 'line':
+            // A bold 2.5px line reads over the basemap; no per-point markers —
+            // those are chart-junk. The tooltip and endpoints carry the points.
+            mark = Plot.lineY(rows, { x, y, stroke: paint, strokeWidth: 2.5, strokeLinejoin: 'round', strokeLinecap: 'round', tip: true });
+            break;
+        case 'scatter':
+            // Big FILLED dots with a white surface ring — not small open circles.
+            mark = Plot.dot(rows, { x, y, fill: paint, r: 5, stroke: 'white', strokeWidth: 1.5, tip: true });
+            break;
+        case 'histogram':
+            mark = Plot.rectY(rows, Plot.binX({ y: 'count' }, { x, fill: SERIES_1, insetLeft: 1, insetRight: 1, tip: true }));
+            break;
     }
 
     const marks = [];
@@ -87,15 +114,44 @@ export function buildPlotOptions(Plot, spec, rows) {
     if (type !== 'scatter') marks.push(Plot.ruleY([0]));
     marks.push(mark);
 
+    // --- de-crowd the x axis ---------------------------------------------
+    // Categorical axes overcrowd and overprint the fastest. When there are many
+    // bands or long labels, rotate the ticks and reserve room instead of letting
+    // Plot stack them on top of each other; cap continuous ticks so numbers
+    // don't collide.
+    const xVals = rows.map(r => r && r[x]);
+    const numericX = xVals.every(v => v == null || typeof v === 'number');
+    const distinctX = new Set(xVals).size;
+    const longestX = xVals.reduce((m, v) => Math.max(m, String(v ?? '').length), 0);
+    const rotateX = !numericX && (distinctX > 6 || longestX > 8);
+
+    const xAxis = { label: spec.x_label ?? x ?? null };
+    let marginBottom = 48;
+    if (rotateX) {
+        xAxis.tickRotate = -35;
+        marginBottom = Math.min(120, 48 + Math.round(longestX * 4.5));
+    } else if (numericX) {
+        xAxis.ticks = 6;
+    }
+
+    // Short SI tick labels (1k, 2.5M) keep the y axis readable and let the left
+    // margin stay tight. Only when y is actually quantitative.
+    const yVals = type === 'histogram' ? [] : rows.map(r => r && r[y]);
+    const numericY = type === 'histogram' || yVals.every(v => v == null || typeof v === 'number');
+    const yAxis = { label: spec.y_label ?? (type === 'histogram' ? 'count' : y) ?? null, grid: true };
+    if (numericY) yAxis.tickFormat = '~s';
+
     return {
-        marginLeft: 60,
-        marginBottom: 44,
-        marginTop: 16,
-        grid: true,
-        x: { label: spec.x_label ?? x ?? null },
-        y: { label: spec.y_label ?? (type === 'histogram' ? 'count' : y) ?? null },
+        marginLeft: 56,
+        marginBottom,
+        marginTop: 18,
+        marginRight: 18,
+        // Bigger, bolder type; the whole figure inherits it (axes + legend).
+        style: { fontSize: '13px', fontFamily: CHART_FONT, color: INK, background: 'transparent' },
+        x: xAxis,
+        y: yAxis,
         // histogram bins ignore `series`, so a color legend there would be empty.
-        ...(series && type !== 'histogram' && { color: { legend: true } }),
+        ...(series && type !== 'histogram' && { color: { legend: true, range: CATEGORICAL } }),
         marks,
     };
 }
@@ -109,6 +165,7 @@ export class ChartRenderer {
         this.doc = opts.doc || (typeof document !== 'undefined' ? document : null);
         this._plot = null;
         this._seq = 0;
+        this._z = 3;                // top stacking order (matches .chart-panel z-index)
         this._panels = new Map();   // id → panel element
     }
 
@@ -181,8 +238,25 @@ export class ChartRenderer {
         const body = this.doc.createElement('div');
         body.className = 'chart-panel-body';
 
+        // Custom resize grip in the TOP-LEFT corner. The panel is anchored to
+        // its bottom-right, so the free corner to drag is the top-left; native
+        // CSS `resize` can only grip the bottom-right (which sits jammed in the
+        // screen corner here), so we drive width/height from a pointer drag and
+        // let the ResizeObserver re-plot. Min/max come from the CSS box.
+        const grip = this.doc.createElement('div');
+        grip.className = 'chart-panel-resize';
+        grip.title = 'Drag to resize';
+
+        panel.appendChild(grip);
         panel.appendChild(header);
         panel.appendChild(body);
+        this._wireResize(panel, grip);
+
+        // Clicking anywhere in a panel raises it above the others, so a chart
+        // buried under the cascade can be brought forward without closing the
+        // ones on top of it. New panels also open on top.
+        panel.addEventListener('pointerdown', () => this._bringToFront(panel));
+        this._bringToFront(panel);
 
         // Cascade panels up the bottom-right corner of the MAP area. Use the
         // monotonic sequence (not the live panel count) so closing a middle
@@ -209,6 +283,37 @@ export class ChartRenderer {
 
         this._panels.set(id, entry);
         return { id };
+    }
+
+    /** Raise a panel above every other chart panel. */
+    _bringToFront(panel) {
+        if (!panel) return;
+        panel.style.zIndex = String(++this._z);
+    }
+
+    /**
+     * Drive a top-left resize grip. Dragging up/left grows the panel; the box
+     * stays pinned at its bottom-right anchor. Clamping is left to the CSS
+     * min/max-width/height. Pointer capture keeps the drag alive off-grip.
+     */
+    _wireResize(panel, grip) {
+        if (!grip || !grip.addEventListener) return;
+        grip.addEventListener('pointerdown', (e) => {
+            e.preventDefault();
+            const rect = panel.getBoundingClientRect();
+            const startX = e.clientX, startY = e.clientY;
+            const startW = rect.width, startH = rect.height;
+            const move = (ev) => {
+                panel.style.width = (startW + (startX - ev.clientX)) + 'px';
+                panel.style.height = (startH + (startY - ev.clientY)) + 'px';
+            };
+            const up = () => {
+                this.doc.removeEventListener('pointermove', move);
+                this.doc.removeEventListener('pointerup', up);
+            };
+            this.doc.addEventListener('pointermove', move);
+            this.doc.addEventListener('pointerup', up);
+        });
     }
 
     /** (Re)render an entry's Plot figure sized to its current panel body. */

--- a/app/dataset-catalog.js
+++ b/app/dataset-catalog.js
@@ -368,6 +368,7 @@ export class DatasetCatalog {
                         legendClasses: normalizeLegendClasses(config.legend_classes),
                         legendRange: config.legend_range || null,
                         legendGradient: config.legend_gradient || null,
+                        control: config.control || null,
                         // Versioned metadata
                         versions,
                         defaultVersionIndex: defaultIndex,
@@ -402,6 +403,7 @@ export class DatasetCatalog {
                         legendClasses: normalizeLegendClasses(config.legend_classes),
                         legendRange: config.legend_range || null,
                         legendGradient: config.legend_gradient || null,
+                        control: config.control || null,
                     });
                 } else if (type.includes('geotiff') || type.includes('tiff')) {
                     const band0 = asset['raster:bands']?.[0];
@@ -455,6 +457,7 @@ export class DatasetCatalog {
                         legendRange: config.legend_range || null,
                         legendGradient: config.legend_gradient || null,
                         animation,
+                        control: config.control || null,
                     });
                 }
             }
@@ -792,6 +795,7 @@ export class DatasetCatalog {
                         legendClasses: ml.legendClasses || null,
                         legendRange: ml.legendRange || null,
                         legendGradient: ml.legendGradient || null,
+                        control: ml.control || null,
                         // Versioned metadata
                         versions: versionConfigs,
                         defaultVersionIndex: ml.defaultVersionIndex,
@@ -830,6 +834,7 @@ export class DatasetCatalog {
                         legendRange: ml.legendRange || null,
                         legendGradient: ml.legendGradient || null,
                         animation: ml.animation || null,
+                        control: ml.control || null,
                         tracksUrl: isGeoJson ? ml.url : null,
                     };
                     if (!isGeoJson) layerConfig.sourceLayer = ml.sourceLayer;

--- a/app/main.js
+++ b/app/main.js
@@ -9,7 +9,7 @@ import { MCPClient } from './mcp-client.js';
 import { DatasetCatalog } from './dataset-catalog.js';
 import { MapManager } from './map-manager.js';
 import { ToolRegistry } from './tool-registry.js';
-import { createMapTools } from './map-tools.js';
+import { createMapTools, createRenderChartTool } from './map-tools.js';
 import { createGeocoder } from './geocoder.js';
 import { Agent } from './agent.js';
 import { ChatUI } from './chat-ui.js';
@@ -263,6 +263,20 @@ async function main() {
                 });
             },
         });
+    }
+
+    // Opt-in charting primitive (#277). Off by default: the render_chart tool
+    // and the Observable Plot CDN load only exist when `charts.enabled` is set,
+    // so apps that don't want charts pay nothing.
+    if (appConfig.charts?.enabled) {
+        try {
+            const { ChartRenderer } = await import('./chart-renderer.js');
+            const chartRenderer = new ChartRenderer();
+            toolRegistry.registerLocal(createRenderChartTool(chartRenderer, mcp));
+            console.log('[main] Charting enabled (render_chart tool registered)');
+        } catch (err) {
+            console.warn('[main] Failed to enable charting:', err.message);
+        }
     }
 
     // Inline cached STAC content on LLM-issued direct calls to in-app data,

--- a/app/map-manager.js
+++ b/app/map-manager.js
@@ -272,10 +272,12 @@ export class MapManager {
                 legendClasses: legendClasses || null,
                 legendRange: legendRange || null,
                 legendGradient: legendGradient || null,
+                control: null,   // filled in by _registerControl when config.control is set
                 // Version tracking
                 versions: versionStates,
                 activeVersionIndex: config.defaultVersionIndex,
             });
+            if (config.control) this._registerControl(layerId, config.control);
             this._showLegendIfVisible(layerId);
             return;
         }
@@ -371,7 +373,11 @@ export class MapManager {
             legendClasses: legendClasses || null,
             legendRange: legendRange || null,
             legendGradient: legendGradient || null,
+            control: null,   // filled in by _registerControl when config.control is set
         });
+
+        // Declarative reactive-parameter control (e.g. a temporal slider, #147).
+        if (config.control) this._registerControl(layerId, config.control);
 
         // Wire tooltip handler on every vector layer (even those without
         // declared fields) so set_tooltip can attach fields at runtime. The
@@ -436,6 +442,119 @@ export class MapManager {
         }
     }
 
+    /**
+     * Attach a reactive-parameter control (e.g. a temporal slider, #147) to an
+     * existing layer. The control owns its own DOM panel + (optional) autoplay
+     * loop and, on each change, calls back through _applyControlAction to
+     * rebind the layer — no LLM round-trip per tick. Replaces any prior control
+     * on the same layer. Async because the module is lazy-loaded.
+     *
+     * @param {string} layerId
+     * @param {Object} controlConfig — the `control` block (type/field/min/max/…)
+     * @returns {Promise<{success:boolean, error?:string}>}
+     */
+    async _registerControl(layerId, controlConfig) {
+        const state = this.layers.get(layerId);
+        if (!state) return { success: false, error: `Unknown layer: ${layerId}` };
+        try {
+            const { ReactiveControl } = await import('./reactive-control.js');
+            if (state.control) state.control.destroy();
+            // The slider rebinds the layer's filter; remember the layer's
+            // configured predicate so the slider composes with it rather than
+            // wiping it (a layer may ship a defaultFilter like severity=high).
+            state.controlBaseFilter = state.defaultFilter || null;
+            const ctrl = new ReactiveControl({
+                layerId,
+                displayName: state.displayName,
+                config: controlConfig,
+                apply: (action) => this._applyControlAction(layerId, action),
+            });
+            state.control = ctrl;
+            ctrl.setVisible(state.visible);
+            return { success: true };
+        } catch (err) {
+            console.error(`[Map] Failed to init reactive control for ${layerId}:`, err);
+            return { success: false, error: err.message };
+        }
+    }
+
+    /**
+     * Apply a ReactiveControl's filter directly to the layer. This runs on
+     * every slider input and up to ~60×/s during autoplay, so it deliberately
+     * bypasses the heavy setFilter() path (which calls queryRenderedFeatures +
+     * describeFilter to report a feature count). It also composes the slider
+     * predicate with the layer's base filter (`["all", base, sliderExpr]`) so a
+     * configured defaultFilter survives the slider.
+     */
+    _applyControlAction(layerId, action) {
+        if (!action || action.kind !== 'filter') return;
+        const state = this.layers.get(layerId);
+        if (!state || state.type !== 'vector' || !state.mapLayerId) return;
+        const base = state.controlBaseFilter;
+        const combined = base ? ['all', base, action.expr] : action.expr;
+        this.map.setFilter(state.mapLayerId, combined);
+        if (state.outlineLayerId) this.map.setFilter(state.outlineLayerId, combined);
+        state.filter = combined;
+    }
+
+    /**
+     * Create a slider that filters a vector layer by a numeric/temporal field,
+     * client-side, with no round-trip per step (#147). Used by the agent's
+     * `create_slider` tool. The slider is bound as a MapLibre filter:
+     * cumulative (`<=`) reveals everything up to the value; step (`==`) shows
+     * only the matching value.
+     *
+     * @param {Object} args
+     * @param {string} args.layer_id
+     * @param {string} args.field           — feature property to filter on
+     * @param {number} args.min
+     * @param {number} args.max
+     * @param {number} [args.step=1]
+     * @param {'cumulative'|'step'} [args.mode='cumulative']
+     * @param {string} [args.label]
+     * @param {boolean} [args.animate=false] — show a play button that sweeps the range
+     * @param {number} [args.default]
+     * @returns {Promise<Object>} result
+     */
+    async createSlider(args = {}) {
+        const { layer_id, field, min, max } = args;
+        const state = this.layers.get(layer_id);
+        if (!state) {
+            return { success: false, error: `Unknown layer: ${layer_id}. Available: ${this.getLayerIds().join(', ')}` };
+        }
+        if (state.type === 'raster') {
+            return { success: false, error: `Sliders bind to a vector layer's feature field; "${layer_id}" is a raster layer.` };
+        }
+        if (!field || min == null || max == null) {
+            return { success: false, error: 'create_slider requires field, min, and max.' };
+        }
+        const mode = args.mode === 'step' ? 'step' : 'cumulative';
+        const controlConfig = {
+            type: 'slider',
+            bind: 'filter',
+            field,
+            label: args.label || field,
+            min, max,
+            step: args.step ?? 1,
+            mode,
+            animate: !!args.animate,
+            ...(args.default != null && { default: args.default }),
+        };
+        // Await registration so a lazy-import or constructor failure is reported
+        // to the agent instead of being silently swallowed.
+        const reg = await this._registerControl(layer_id, controlConfig);
+        if (!reg.success) {
+            return { success: false, error: `Failed to create slider: ${reg.error}` };
+        }
+        return {
+            success: true,
+            layer: layer_id,
+            displayName: state.displayName,
+            field, min, max, mode,
+            animate: !!args.animate,
+        };
+    }
+
     // ---- Layer Visibility ----
 
     /**
@@ -454,6 +573,7 @@ export class MapManager {
         }
         this.map.setLayoutProperty(state.mapLayerId, 'visibility', 'visible');
         if (state.outlineLayerId) this.map.setLayoutProperty(state.outlineLayerId, 'visibility', 'visible');
+        if (state.control) state.control.setVisible(true);
         if (this._hasLegend(state)) this._showLegend(layerId);
         return { success: true, layer: layerId, displayName: state.displayName, visible: true };
     }
@@ -474,6 +594,7 @@ export class MapManager {
         }
         this.map.setLayoutProperty(state.mapLayerId, 'visibility', 'none');
         if (state.outlineLayerId) this.map.setLayoutProperty(state.outlineLayerId, 'visibility', 'none');
+        if (state.control) state.control.setVisible(false);
         if (this._hasLegend(state)) this._hideLegend(layerId);
         return { success: true, layer: layerId, displayName: state.displayName, visible: false };
     }

--- a/app/map-tools.js
+++ b/app/map-tools.js
@@ -173,6 +173,34 @@ Note: some layers have a config default filter applied at startup. This tool rem
         },
 
         {
+            name: 'create_slider',
+            description: `Create an interactive slider that filters a vector layer by a numeric or temporal field — entirely client-side, with no round-trip per step. Use when the user wants to scrub, step, or animate through values of one field (e.g. "let me step through fire years", "add a year slider", "play the burn history over time").
+
+The slider binds as a MapLibre filter on \`field\`:
+- mode "cumulative" (default): shows every feature with field <= the slider value (e.g. fires accumulate as the year advances).
+- mode "step": shows only features whose field == the slider value (one year at a time).
+
+Set animate: true to add a play/pause button that sweeps min→max automatically. Only one slider can be attached to a layer at a time (creating a new one replaces it). The slider panel is shown while the layer is visible — call show_layer first if it isn't already on.
+
+${pickLayerNudge}`,
+            inputSchema: {
+                type: 'object',
+                properties: {
+                    layer_id: { type: 'string', description: 'Vector layer ID to attach the slider to' },
+                    field: { type: 'string', description: 'Feature property to filter on (e.g. "YEAR_"). Must be numeric or a value that compares numerically.' },
+                    min: { type: 'number', description: 'Slider minimum (low end of the field range)' },
+                    max: { type: 'number', description: 'Slider maximum (high end of the field range)' },
+                    step: { type: 'number', description: 'Slider step size (default 1)' },
+                    mode: { type: 'string', enum: ['cumulative', 'step'], description: 'cumulative (<=) or step (==). Default cumulative.' },
+                    label: { type: 'string', description: 'Label shown on the slider panel (defaults to the field name)' },
+                    animate: { type: 'boolean', description: 'Add a play button that sweeps the range (default false)' },
+                },
+                required: ['layer_id', 'field', 'min', 'max'],
+            },
+            execute: async (args) => JSON.stringify(await mapManager.createSlider(args)),
+        },
+
+        {
             name: 'set_tooltip',
             description: `Set which feature properties appear in the hover tooltip for a vector layer. Pass an array of property names; the tooltip displays them in order. Pass an empty array to disable the tooltip for that layer.
 

--- a/app/map-tools.js
+++ b/app/map-tools.js
@@ -1,6 +1,8 @@
+import { validateChartSpec } from './chart-renderer.js';
+
 /**
  * Map Tools - Local tool definitions for the LLM agent
- * 
+ *
  * Defines the tools the agent uses to control the map and query dataset metadata.
  * Each tool has: name, description, inputSchema, execute function.
  * 
@@ -637,4 +639,112 @@ ${pickLayerNudge}`,
         },
 
     ];
+}
+
+/**
+ * Build the opt-in `render_chart` tool (#277). Registered only when an app
+ * sets `charts.enabled` — so apps that don't want charts pay no footprint and
+ * the LLM never sees the tool.
+ *
+ * @param {{ render: Function }} chartRenderer — a ChartRenderer instance
+ * @param {import('./mcp-client.js').MCPClient} [mcpClient] — for the `sql` path
+ * @returns {Object} a tool definition (name/description/inputSchema/execute)
+ */
+/**
+ * Run a SELECT (already wrapped to emit `to_json(array_agg(...))`) through MCP
+ * and return its rows as a parsed array. Shared marshalling for the chart
+ * tool: DuckDB's array_agg over zero rows yields SQL NULL (no brackets), so an
+ * empty result is reported as `{ ok: true, rows: [] }`, not a parse failure.
+ *
+ * @returns {Promise<{ok:true, rows:Array}|{ok:false, error:string}>}
+ */
+async function runJsonArrayQuery(mcpClient, wrappedSql) {
+    let raw;
+    try {
+        raw = await mcpClient.callTool('query', { sql_query: wrappedSql });
+    } catch (err) {
+        return { ok: false, error: `SQL execution failed: ${err.message}` };
+    }
+    const text = typeof raw === 'string' ? raw : JSON.stringify(raw);
+    if (!text || /\bnull\b/i.test(text.trim().replace(/.*\n/, ''))) {
+        return { ok: true, rows: [] };
+    }
+    const rows = extractJsonArray(text);
+    if (!rows) {
+        return { ok: false, error: `Could not parse rows from query result. Raw: ${text.substring(0, 300)}` };
+    }
+    return { ok: true, rows };
+}
+
+export function createRenderChartTool(chartRenderer, mcpClient) {
+    return {
+        name: 'render_chart',
+        description: `Render query results as a chart in a floating panel. Use when a table or map can't show the shape of the data — e.g. "plot the top 10 countries", "show the distribution", "chart the trend over years".
+
+Chart types:
+- bar: ranking / category comparison (x = category, y = value)
+- line: time series / trend (x = ordered field e.g. year, y = value)
+- scatter: relationship / trade-off (x, y = two numerics)
+- histogram: distribution of one numeric (x = the value; bars are counts — omit y)
+
+Provide the data ONE of two ways (if you pass both, sql wins):
+- data: an array of row objects you already have, e.g. [{"country":"Brazil","pct":31}, ...]. Best for small, already-aggregated results.
+- sql: a SELECT the panel runs itself (rows never pass through the LLM). Best for larger results. Write a plain SELECT — do NOT wrap it in array_agg/to_json.
+
+x / y name the columns to plot; series (optional) splits/colors by a column. Keep result sets small (≈ a few hundred rows max).`,
+        inputSchema: {
+            type: 'object',
+            properties: {
+                chart_type: { type: 'string', enum: ['bar', 'line', 'scatter', 'histogram'], description: 'Chart type' },
+                title: { type: 'string', description: 'Chart title shown on the panel' },
+                data: { type: 'array', items: {}, description: 'Array of row objects to plot. Provide this OR sql.' },
+                sql: { type: 'string', description: 'A plain SELECT the panel runs to get rows. Provide this OR data.' },
+                x: { type: 'string', description: 'Column for the x axis (category for bar, the value for histogram)' },
+                y: { type: 'string', description: 'Column for the y axis (numeric). Omit for histogram.' },
+                series: { type: 'string', description: 'Optional column to split/color multiple series' },
+                x_label: { type: 'string', description: 'Optional x-axis label (defaults to the x column name)' },
+                y_label: { type: 'string', description: 'Optional y-axis label' },
+            },
+            required: ['chart_type', 'x'],
+        },
+        execute: async (args) => {
+            // Reject a bad spec cheaply, before paying for any SQL round-trip.
+            try {
+                validateChartSpec(args);
+            } catch (err) {
+                return JSON.stringify({ success: false, error: err.message });
+            }
+
+            let rows;
+            if (args.sql) {
+                // sql is authoritative when both are supplied — never silently
+                // chart a partial inline sample while ignoring the full query.
+                if (!mcpClient) return JSON.stringify({ success: false, error: 'MCP client not available for the sql path — pass data instead.' });
+                // Aggregate full rows to a JSON array via DuckDB. to_json() is
+                // required: DuckDB's native list display is not valid JSON.
+                const wrappedSql = `SELECT to_json(array_agg(_chart_rows)) AS rows FROM (${args.sql}) _chart_rows`;
+                const res = await runJsonArrayQuery(mcpClient, wrappedSql);
+                if (!res.ok) return JSON.stringify({ success: false, error: res.error });
+                rows = res.rows;
+            } else if (Array.isArray(args.data)) {
+                rows = args.data;
+            }
+
+            if (!rows || rows.length === 0) {
+                return JSON.stringify({
+                    success: false,
+                    error: args.sql
+                        ? 'Query returned no rows — nothing to chart.'
+                        : 'No data to chart — provide a non-empty `data` array or a `sql` query that returns rows.',
+                });
+            }
+
+            try {
+                const { id } = await chartRenderer.render(args, rows);
+                return JSON.stringify({ success: true, chart_id: id, chart_type: args.chart_type, title: args.title || null, points: rows.length });
+            } catch (err) {
+                return JSON.stringify({ success: false, error: `Could not render chart: ${err.message}` });
+            }
+        },
+    };
 }

--- a/app/reactive-control.js
+++ b/app/reactive-control.js
@@ -1,0 +1,229 @@
+/**
+ * reactive-control.js — Reactive-parameter controls (sliders)
+ *
+ * A ReactiveControl renders a small slider panel over the map and, on each
+ * (debounced) change, rebinds a map property derived from the slider value —
+ * with no LLM round-trip per tick. The agent (or a `control` block in
+ * layers-input.json) sets up the binding once; the control drives it
+ * client-side thereafter.
+ *
+ * The headline use is a *temporal filter* (issue #147): step a year/date field
+ * across its range, either cumulatively ("show everything up to year N") or one
+ * step at a time. The same machinery is intended to generalise to other
+ * reactive parameters (a weight slider that re-styles, etc.) by adding `bind`
+ * kinds to `buildControlAction` — `filter` is implemented here.
+ *
+ * Owns a single DOM panel (`.reactive-controls`) and, when `animate` is set, a
+ * RAF autoplay loop. Lifecycle methods (setVisible / destroy) let MapManager
+ * treat it like the trajectory animation's controls.
+ */
+
+const DEFAULTS = {
+    type: 'slider',
+    bind: 'filter',
+    mode: 'cumulative',   // 'cumulative' (<=) | 'step' (==)
+    step: 1,
+    animate: false,
+    duration_seconds: 20,
+    loop: true,
+};
+
+/**
+ * Pure mapping from (control config, current value) → a map action.
+ * Exported so it can be unit-tested without a DOM. Returns null when the
+ * config can't produce an action (so callers can no-op safely).
+ *
+ * @param {Object} config — the resolved control config (DEFAULTS merged in)
+ * @param {number} value  — the current slider value
+ * @returns {{kind:'filter', expr:Array} | null}  — `style`/`query` binds are
+ *   reserved (see below) and not yet emitted.
+ */
+export function buildControlAction(config, value) {
+    const bind = config.bind || 'filter';
+    if (bind === 'filter') {
+        const field = config.field;
+        if (!field) return null;
+        const expr = config.mode === 'step'
+            ? ['==', ['get', field], value]
+            : ['<=', ['get', field], value];
+        return { kind: 'filter', expr };
+    }
+    // 'style' and 'query' binds are reserved for follow-up work (the
+    // landscape-frontiers weight slider). Unknown bind → no-op.
+    return null;
+}
+
+/** Initial slider value when the config doesn't pin one. */
+function initialValue(config) {
+    if (config.default != null) return config.default;
+    // Cumulative temporal: default to the high end so the static (pre-play)
+    // state shows every feature; step mode starts at the low end.
+    return config.mode === 'step' ? config.min : config.max;
+}
+
+export class ReactiveControl {
+    /**
+     * @param {Object} opts
+     * @param {string}   opts.layerId      — logical layer id from catalog
+     * @param {string}   opts.displayName  — label for the controls panel
+     * @param {Object}   opts.config       — `control` block from layers-input.json
+     * @param {(action:Object)=>void} opts.apply — called with buildControlAction's result
+     * @param {Document} [opts.doc]        — injectable for tests (defaults to global document)
+     */
+    constructor(opts) {
+        this.layerId = opts.layerId;
+        this.displayName = opts.displayName || opts.layerId;
+        this.config = { ...DEFAULTS, ...opts.config };
+        this.apply = opts.apply || (() => {});
+        this.doc = opts.doc || (typeof document !== 'undefined' ? document : null);
+
+        if (this.config.min == null || this.config.max == null) {
+            throw new Error('ReactiveControl requires numeric min and max');
+        }
+
+        this.value = clamp(initialValue(this.config), this.config.min, this.config.max);
+        this.visible = true;
+        this.playing = false;
+        this.rafId = null;
+        this.lastFrame = null;
+        this.destroyed = false;
+
+        this._panel = null;
+        if (this.doc) this._build();
+        this.emit();   // apply the initial binding
+    }
+
+    /** Compute and apply the action for the current value, then update the readout. */
+    emit() {
+        const action = buildControlAction(this.config, this.value);
+        if (action) this.apply(action);
+        if (this._valueEl) this._valueEl.textContent = this._format(this.value);
+    }
+
+    setValue(v) {
+        this.value = clamp(Number(v), this.config.min, this.config.max);
+        if (this._slider) this._slider.value = String(this.value);
+        this.emit();
+    }
+
+    _format(v) {
+        // Autoplay advances the value continuously (fractional), so round the
+        // readout to the step's precision: integer steps (years) show no
+        // decimal, fractional steps show two places.
+        const dp = Number.isInteger(this.config.step) ? 0 : 2;
+        return v.toFixed(dp);
+    }
+
+    _build() {
+        const panel = this.doc.createElement('div');
+        panel.className = 'reactive-controls';
+        panel.dataset.layerId = this.layerId;
+
+        const label = this.config.label || this.displayName;
+        const playBtn = this.config.animate
+            ? '<button class="rc-play" title="Play / Pause">▶</button>'
+            : '';
+        panel.innerHTML = `
+            <span class="rc-label" title="${escapeAttr(label)}">${escapeHtml(label)}</span>
+            ${playBtn}
+            <input class="rc-slider" type="range"
+                   min="${this.config.min}" max="${this.config.max}"
+                   step="${this.config.step}" value="${this.value}" />
+            <span class="rc-value"></span>
+        `;
+        // Stack above any trajectory-animation panels and other reactive panels.
+        const existing = this.doc.querySelectorAll('.reactive-controls, .anim-controls').length;
+        panel.style.bottom = (12 + existing * 44) + 'px';
+        this.doc.body.appendChild(panel);
+
+        this._panel = panel;
+        this._slider = panel.querySelector('.rc-slider');
+        this._valueEl = panel.querySelector('.rc-value');
+        this._playBtn = panel.querySelector('.rc-play');
+
+        this._slider.addEventListener('input', () => {
+            if (this.playing) this.pause();
+            this.value = Number(this._slider.value);
+            this.emit();
+        });
+        if (this._playBtn) {
+            this._playBtn.addEventListener('click', () => {
+                this.playing ? this.pause() : this.play();
+            });
+        }
+    }
+
+    // ---- Autoplay (temporal sweep) ----
+
+    play() {
+        if (!this.config.animate || this.destroyed) return;
+        // Restart from the low end so the sweep accumulates from the beginning.
+        if (this.value >= this.config.max) this.setValue(this.config.min);
+        this.playing = true;
+        this.lastFrame = null;
+        if (this._playBtn) this._playBtn.textContent = '❚❚';
+        this._tick = this._tick.bind(this);
+        this.rafId = requestAnimationFrame(this._tick);
+    }
+
+    pause() {
+        this.playing = false;
+        if (this._playBtn) this._playBtn.textContent = '▶';
+        if (this.rafId) { cancelAnimationFrame(this.rafId); this.rafId = null; }
+    }
+
+    _tick(now) {
+        if (this.destroyed || !this.playing) return;
+        if (this.lastFrame !== null) {
+            const delta = now - this.lastFrame;
+            const durationMs = this.config.duration_seconds * 1000;
+            const range = Math.max(1, this.config.max - this.config.min);
+            const next = this.value + (delta / durationMs) * range;
+            if (next >= this.config.max) {
+                if (this.value < this.config.max) {
+                    // Render the final frame (e.g. the most recent year) before
+                    // wrapping or stopping — otherwise it flickers past unseen.
+                    this.setValue(this.config.max);
+                } else if (this.config.loop) {
+                    this.setValue(this.config.min);
+                } else {
+                    this.pause();
+                    return;
+                }
+            } else {
+                this.setValue(next);
+            }
+        }
+        this.lastFrame = now;
+        this.rafId = requestAnimationFrame(this._tick);
+    }
+
+    // ---- Lifecycle ----
+
+    setVisible(visible) {
+        this.visible = visible;
+        if (this._panel) this._panel.style.display = visible ? '' : 'none';
+        if (!visible) this.pause();
+    }
+
+    destroy() {
+        this.destroyed = true;
+        this.pause();
+        if (this._panel) this._panel.remove();
+    }
+}
+
+// ---- helpers ----
+
+function clamp(v, lo, hi) {
+    if (Number.isNaN(v)) return lo;
+    return Math.min(hi, Math.max(lo, v));
+}
+
+function escapeHtml(s) {
+    return String(s).replace(/[&<>]/g, c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;' }[c]));
+}
+
+function escapeAttr(s) {
+    return escapeHtml(s).replace(/"/g, '&quot;');
+}

--- a/app/style.css
+++ b/app/style.css
@@ -659,7 +659,16 @@ details.layer-group:not([open]) .layer-group-title::before {
        charts never hide behind a right-docked sidebar. */
     right: calc(var(--sidebar-width, 0px) + var(--chart-cascade, 12px));
     bottom: var(--chart-cascade, 12px);
-    max-width: min(440px, 80vw);
+    width: min(440px, 80vw);
+    height: 320px;
+    /* Drag the bottom-right grip to resize; the chart re-plots to fit. */
+    resize: both;
+    min-width: 260px;
+    min-height: 200px;
+    max-width: 96vw;
+    max-height: 92vh;
+    display: flex;
+    flex-direction: column;
     background: rgba(255, 255, 255, 0.97);
     backdrop-filter: blur(6px);
     -webkit-backdrop-filter: blur(6px);
@@ -668,6 +677,18 @@ details.layer-group:not([open]) .layer-group-title::before {
     box-shadow: 0 4px 16px rgba(0, 0, 0, 0.2);
     font-family: 'Open Sans', sans-serif;
     overflow: hidden;
+}
+
+/* Popped out: a large centered view. right/bottom are released so the
+   transform-centering takes over; the ResizeObserver re-plots to the new box. */
+.chart-panel.chart-panel--popped {
+    right: auto;
+    bottom: auto;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    width: min(900px, 92vw);
+    height: min(640px, 86vh);
 }
 
 .chart-panel-header {
@@ -680,6 +701,8 @@ details.layer-group:not([open]) .layer-group-title::before {
 }
 
 .chart-panel-title {
+    flex: 1 1 auto;
+    min-width: 0;
     font-weight: 600;
     font-size: 13px;
     color: #222;
@@ -688,7 +711,8 @@ details.layer-group:not([open]) .layer-group-title::before {
     white-space: nowrap;
 }
 
-.chart-panel-close {
+.chart-panel-close,
+.chart-panel-pop {
     border: none;
     background: transparent;
     cursor: pointer;
@@ -699,14 +723,21 @@ details.layer-group:not([open]) .layer-group-title::before {
     border-radius: 4px;
 }
 
-.chart-panel-close:hover {
+.chart-panel-header {
+    flex: 0 0 auto;
+}
+
+.chart-panel-close:hover,
+.chart-panel-pop:hover {
     background: rgba(0, 0, 0, 0.08);
     color: #000;
 }
 
 .chart-panel-body {
+    flex: 1 1 auto;
+    min-height: 0;
     padding: 8px 12px 12px;
-    overflow-x: auto;
+    overflow: auto;
 }
 
 /* ── Geocoder search box (maplibre-gl-geocoder) ──────────────────────────

--- a/app/style.css
+++ b/app/style.css
@@ -654,6 +654,11 @@ details.layer-group:not([open]) .layer-group-title::before {
 .chart-panel {
     position: absolute;
     z-index: 3;
+    /* Anchor to the bottom-right of the MAP area: offset past the sidebar
+       (--sidebar-width is 0 in floating mode) plus the per-panel cascade, so
+       charts never hide behind a right-docked sidebar. */
+    right: calc(var(--sidebar-width, 0px) + var(--chart-cascade, 12px));
+    bottom: var(--chart-cascade, 12px);
     max-width: min(440px, 80vw);
     background: rgba(255, 255, 255, 0.97);
     backdrop-filter: blur(6px);

--- a/app/style.css
+++ b/app/style.css
@@ -649,6 +649,61 @@ details.layer-group:not([open]) .layer-group-title::before {
     color: #555;
 }
 
+/* ── Chart panels (opt-in charting primitive, #277) ──────────────────────
+   Floating card anchored bottom-right; multiple charts cascade. */
+.chart-panel {
+    position: absolute;
+    z-index: 3;
+    max-width: min(440px, 80vw);
+    background: rgba(255, 255, 255, 0.97);
+    backdrop-filter: blur(6px);
+    -webkit-backdrop-filter: blur(6px);
+    border: 1px solid rgba(0, 0, 0, 0.15);
+    border-radius: 8px;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.2);
+    font-family: 'Open Sans', sans-serif;
+    overflow: hidden;
+}
+
+.chart-panel-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    padding: 8px 12px;
+    border-bottom: 1px solid rgba(0, 0, 0, 0.08);
+}
+
+.chart-panel-title {
+    font-weight: 600;
+    font-size: 13px;
+    color: #222;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.chart-panel-close {
+    border: none;
+    background: transparent;
+    cursor: pointer;
+    font-size: 14px;
+    line-height: 1;
+    color: #666;
+    padding: 2px 4px;
+    border-radius: 4px;
+}
+
+.chart-panel-close:hover {
+    background: rgba(0, 0, 0, 0.08);
+    color: #000;
+}
+
+.chart-panel-body {
+    padding: 8px 12px 12px;
+    overflow-x: auto;
+}
+
 /* ── Geocoder search box (maplibre-gl-geocoder) ──────────────────────────
    Frosted-glass surface to match the app's other map controls (#menu,
    .version-select) instead of the library's solid white — light tint +

--- a/app/style.css
+++ b/app/style.css
@@ -592,6 +592,63 @@ details.layer-group:not([open]) .layer-group-title::before {
     font-size: 12px;
 }
 
+/* ── Reactive-parameter controls (temporal / value sliders, #147) ────────
+   Same frosted-glass surface as .anim-controls; floats bottom-left and
+   stacks above any animation panels. */
+.reactive-controls {
+    position: absolute;
+    left: 12px;
+    z-index: 2;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 10px;
+    background: rgba(255, 255, 255, 0.92);
+    backdrop-filter: blur(6px);
+    -webkit-backdrop-filter: blur(6px);
+    border: 1px solid rgba(0, 0, 0, 0.15);
+    border-radius: 6px;
+    font-family: 'Open Sans', sans-serif;
+    font-size: 12px;
+    color: #222;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.15);
+}
+
+.reactive-controls .rc-label {
+    font-weight: 600;
+    max-width: 160px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.reactive-controls .rc-play {
+    border: 1px solid rgba(0, 0, 0, 0.2);
+    background: #fff;
+    border-radius: 4px;
+    width: 26px;
+    height: 26px;
+    cursor: pointer;
+    font-size: 11px;
+    line-height: 1;
+}
+
+.reactive-controls .rc-play:hover {
+    background: #f5f5f5;
+}
+
+.reactive-controls .rc-slider {
+    width: 160px;
+    cursor: pointer;
+}
+
+.reactive-controls .rc-value {
+    font-variant-numeric: tabular-nums;
+    min-width: 48px;
+    text-align: right;
+    color: #555;
+}
+
 /* ── Geocoder search box (maplibre-gl-geocoder) ──────────────────────────
    Frosted-glass surface to match the app's other map controls (#menu,
    .version-select) instead of the library's solid white — light tint +

--- a/app/style.css
+++ b/app/style.css
@@ -661,8 +661,9 @@ details.layer-group:not([open]) .layer-group-title::before {
     bottom: var(--chart-cascade, 12px);
     width: min(440px, 80vw);
     height: 320px;
-    /* Drag the bottom-right grip to resize; the chart re-plots to fit. */
-    resize: both;
+    /* Resize from the TOP-LEFT grip (.chart-panel-resize) — the panel is pinned
+       bottom-right, so that's the free corner. Native CSS `resize` only grips
+       the bottom-right, so it's not used here. */
     min-width: 260px;
     min-height: 200px;
     max-width: 96vw;
@@ -691,12 +692,39 @@ details.layer-group:not([open]) .layer-group-title::before {
     height: min(640px, 86vh);
 }
 
+/* Top-left resize grip. A small corner target with two diagonal ticks; the
+   drag itself is handled in chart-renderer.js (_wireResize). */
+.chart-panel-resize {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 18px;
+    height: 18px;
+    z-index: 4;
+    cursor: nwse-resize;
+    background:
+        linear-gradient(-45deg, transparent 0 4px, rgba(0, 0, 0, 0.28) 4px 5px, transparent 5px 8px, rgba(0, 0, 0, 0.28) 8px 9px, transparent 9px) top left / 12px 12px no-repeat;
+    border-top-left-radius: 8px;
+}
+
+.chart-panel-resize:hover {
+    background:
+        linear-gradient(-45deg, transparent 0 4px, rgba(0, 0, 0, 0.5) 4px 5px, transparent 5px 8px, rgba(0, 0, 0, 0.5) 8px 9px, transparent 9px) top left / 12px 12px no-repeat;
+}
+
+/* Popped-out is center-anchored via a transform, so the bottom-right pin the
+   grip's math assumes doesn't hold — hide it there. */
+.chart-panel--popped .chart-panel-resize {
+    display: none;
+}
+
 .chart-panel-header {
     display: flex;
     align-items: center;
     justify-content: space-between;
     gap: 8px;
-    padding: 8px 12px;
+    /* extra left padding clears the top-left resize grip */
+    padding: 8px 12px 8px 22px;
     border-bottom: 1px solid rgba(0, 0, 0, 0.08);
 }
 

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -254,6 +254,32 @@ The slider composes with the layer's configured `default_filter` (applied as `["
 }
 ```
 
+## Charts (opt-in)
+
+By default the agent answers analytical questions with the map and SQL result **tables**. Enabling charts gives it one more primitive — a `render_chart` tool that turns a query result into a **bar**, **line**, **scatter**, or **histogram** in a floating panel ([#277](https://github.com/boettiger-lab/geo-agent/issues/277)).
+
+It is **off by default** (zero footprint — the tool isn't registered and no charting library loads). Turn it on with a top-level flag in `layers-input.json`:
+
+```json
+{
+  "catalog": "https://…/catalog.json",
+  "charts": { "enabled": true }
+}
+```
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `enabled` | boolean | `false` | Register the `render_chart` tool and lazy-load the charting library. |
+
+When enabled, the agent calls `render_chart` with a chart type, the columns to plot (`x`, `y`, optional `series`), and the data — either an inline `data` array it already computed, or a `sql` query the panel runs itself (so large result sets never pass back through the LLM; if both are supplied, `sql` wins). Charts render client-side via [Observable Plot](https://observablehq.com/plot/), which (with d3) is fetched from the CDN via SRI-pinned scripts the first time a chart is drawn — downstream apps don't need to add any `<script>` tag.
+
+| Chart type | Shape | Channels |
+|---|---|---|
+| `bar` | ranking / category comparison | `x` = category, `y` = value |
+| `line` | time series / trend | `x` = ordered field (e.g. year), `y` = value |
+| `scatter` | relationship / trade-off (e.g. a Pareto frontier) | `x`, `y` = two numerics |
+| `histogram` | distribution of one numeric | `x` = the value (bars are counts; omit `y`) |
+
 ## Collapsed groups
 
 By default, layer groups in the panel start expanded. To start a group folded (useful when a collection has many layers), use the object form for `group`:

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -206,7 +206,53 @@ For GeoJSON assets containing `LineString` features with a parallel timestamp ar
 }
 ```
 
-Only point-trajectory animation is supported today. Raster time-series playback and temporal filtering of static features are tracked as future work in [#144](https://github.com/boettiger-lab/geo-agent/issues/144).
+For *temporal filtering of static features* — stepping a year/date field on an ordinary vector layer rather than animating moving points — use a reactive-parameter control (below) instead. Raster time-series playback remains future work.
+
+## Reactive-parameter controls (sliders)
+
+A `control` block turns an asset into a layer with a slider that rebinds a map property as you drag it — entirely client-side, with no LLM round-trip per step. The headline use is a **temporal filter**: scrub a year/date field across its range, either cumulatively ("show everything up to year N") or one step at a time ([#147](https://github.com/boettiger-lab/geo-agent/issues/147)). The slider panel floats over the map (like the trajectory controls) and appears whenever the layer is visible.
+
+The same control is also available to the agent at runtime via the **`create_slider`** tool — e.g. "let me step through the fire years" attaches a year slider to the active layer without any config.
+
+The slider composes with the layer's configured `default_filter` (applied as `["all", default_filter, sliderPredicate]`), so a base predicate survives. While a slider is active it governs the layer's filter slot, so a separate `set_filter` on the same layer is superseded the next time the slider moves.
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `type` | string | `"slider"` | Control widget. Currently only `"slider"` is supported. |
+| `field` | string | — | **Required.** Feature property the slider filters on (must compare numerically). |
+| `min` | number | — | **Required.** Low end of the slider range. |
+| `max` | number | — | **Required.** High end of the slider range. |
+| `step` | number | `1` | Slider increment. |
+| `bind` | string | `"filter"` | What the slider drives. Currently `"filter"` (a MapLibre filter expression); `"style"` and `"query"` binds are reserved for future work. |
+| `mode` | string | `"cumulative"` | For `filter` bind: `"cumulative"` shows `field <= value`; `"step"` shows `field == value`. |
+| `label` | string | field name | Text shown on the slider panel. |
+| `default` | number | `max` (cumulative) / `min` (step) | Initial slider value. |
+| `animate` | boolean | `false` | Add a play/pause button that sweeps `min → max` automatically. |
+| `duration_seconds` | number | `20` | Real-time seconds for one autoplay sweep (when `animate` is set). |
+| `loop` | boolean | `true` | Restart at `min` after an autoplay sweep reaches `max`. |
+
+```json
+{
+  "collection_id": "calfire-perimeters",
+  "assets": [
+    {
+      "id": "firep-pmtiles",
+      "display_name": "CAL FIRE Wildfire Perimeters",
+      "control": {
+        "type": "slider",
+        "field": "YEAR_",
+        "label": "Year",
+        "min": 1835,
+        "max": 2024,
+        "step": 1,
+        "mode": "cumulative",
+        "animate": true,
+        "duration_seconds": 20
+      }
+    }
+  ]
+}
+```
 
 ## Collapsed groups
 

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -271,7 +271,7 @@ It is **off by default** (zero footprint — the tool isn't registered and no ch
 |---|---|---|---|
 | `enabled` | boolean | `false` | Register the `render_chart` tool and lazy-load the charting library. |
 
-When enabled, the agent calls `render_chart` with a chart type, the columns to plot (`x`, `y`, optional `series`), and the data — either an inline `data` array it already computed, or a `sql` query the panel runs itself (so large result sets never pass back through the LLM; if both are supplied, `sql` wins). Charts render client-side via [Observable Plot](https://observablehq.com/plot/), which (with d3) is fetched from the CDN via SRI-pinned scripts the first time a chart is drawn — downstream apps don't need to add any `<script>` tag.
+When enabled, the agent calls `render_chart` with a chart type, the columns to plot (`x`, `y`, optional `series`), and the data — either an inline `data` array it already computed, or a `sql` query the panel runs itself (so large result sets never pass back through the LLM; if both are supplied, `sql` wins). Charts render client-side via [Observable Plot](https://observablehq.com/plot/), which (with d3) is fetched from the CDN via SRI-pinned scripts the first time a chart is drawn — downstream apps don't need to add any `<script>` tag. Each chart panel can be **resized** (drag the bottom-right grip — it re-plots to fit) or **popped out** to a large centered view, and closed with the ✕.
 
 | Chart type | Shape | Channels |
 |---|---|---|

--- a/test/chart-renderer.test.js
+++ b/test/chart-renderer.test.js
@@ -1,0 +1,78 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { buildPlotOptions, ChartRenderer } from '../app/chart-renderer.js';
+
+// Fake Plot namespace: each mark factory returns a tagged object so we can
+// assert mark selection + channel mapping without the real library.
+const fakePlot = {
+    barY: (data, opts) => ({ mark: 'barY', data, opts }),
+    lineY: (data, opts) => ({ mark: 'lineY', data, opts }),
+    dot: (data, opts) => ({ mark: 'dot', data, opts }),
+    rectY: (data, opts) => ({ mark: 'rectY', data, opts }),
+    binX: (outputs, opts) => ({ binX: outputs, opts }),
+    ruleY: (data) => ({ mark: 'ruleY', data }),
+    plot: (options) => ({ plotted: options }),
+};
+
+const rows = [{ country: 'Brazil', pct: 31 }, { country: 'Peru', pct: 22 }];
+
+describe('buildPlotOptions', () => {
+    it('bar → barY with x/y/fill channels and a y=0 baseline', () => {
+        const o = buildPlotOptions(fakePlot, { chart_type: 'bar', x: 'country', y: 'pct', series: 'region' }, rows);
+        const bar = o.marks.find(m => m.mark === 'barY');
+        expect(bar.data).toBe(rows);
+        expect(bar.opts).toMatchObject({ x: 'country', y: 'pct', fill: 'region' });
+        expect(o.marks.some(m => m.mark === 'ruleY')).toBe(true);
+        expect(o.color).toEqual({ legend: true });   // series → legend
+    });
+
+    it('scatter → dot with no y=0 baseline', () => {
+        const o = buildPlotOptions(fakePlot, { chart_type: 'scatter', x: 'carbon', y: 'biodiversity' }, rows);
+        expect(o.marks.some(m => m.mark === 'ruleY')).toBe(false);
+        expect(o.marks[0].mark).toBe('dot');
+        expect(o.color).toBeUndefined();   // no series → no legend
+    });
+
+    it('line → lineY', () => {
+        const o = buildPlotOptions(fakePlot, { chart_type: 'line', x: 'year', y: 'effort' }, rows);
+        expect(o.marks.some(m => m.mark === 'lineY')).toBe(true);
+    });
+
+    it('histogram → rectY+binX, count on y, no y column required', () => {
+        const o = buildPlotOptions(fakePlot, { chart_type: 'histogram', x: 'richness' }, rows);
+        const rect = o.marks.find(m => m.mark === 'rectY');
+        expect(rect.opts.binX).toEqual({ y: 'count' });
+        expect(o.y.label).toBe('count');
+    });
+
+    it('uses explicit axis labels when provided, else the column name', () => {
+        const o = buildPlotOptions(fakePlot, { chart_type: 'bar', x: 'country', y: 'pct', x_label: 'Country', y_label: '% protected' }, rows);
+        expect(o.x.label).toBe('Country');
+        expect(o.y.label).toBe('% protected');
+    });
+
+    it('throws on an unsupported chart type', () => {
+        expect(() => buildPlotOptions(fakePlot, { chart_type: 'pie', x: 'a', y: 'b' }, rows)).toThrow(/Unsupported chart_type/);
+    });
+
+    it('throws when x is missing, or y is missing for a non-histogram', () => {
+        expect(() => buildPlotOptions(fakePlot, { chart_type: 'bar', y: 'v' }, rows)).toThrow(/requires an x/);
+        expect(() => buildPlotOptions(fakePlot, { chart_type: 'bar', x: 'c' }, rows)).toThrow(/requires a y/);
+    });
+});
+
+describe('ChartRenderer', () => {
+    afterEach(() => { delete globalThis.Plot; });
+
+    it('prefers a preloaded global Plot and returns an id (headless: doc=null)', async () => {
+        globalThis.Plot = fakePlot;
+        const cr = new ChartRenderer({ doc: null });
+        const { id } = await cr.render({ chart_type: 'bar', x: 'country', y: 'pct' }, rows);
+        expect(id).toMatch(/^chart-\d+$/);
+    });
+
+    it('propagates buildPlotOptions validation errors', async () => {
+        globalThis.Plot = fakePlot;
+        const cr = new ChartRenderer({ doc: null });
+        await expect(cr.render({ chart_type: 'pie', x: 'a', y: 'b' }, rows)).rejects.toThrow(/Unsupported/);
+    });
+});

--- a/test/chart-renderer.test.js
+++ b/test/chart-renderer.test.js
@@ -70,9 +70,39 @@ describe('ChartRenderer', () => {
         expect(id).toMatch(/^chart-\d+$/);
     });
 
-    it('propagates buildPlotOptions validation errors', async () => {
+    it('propagates validation errors before touching the DOM', async () => {
         globalThis.Plot = fakePlot;
         const cr = new ChartRenderer({ doc: null });
         await expect(cr.render({ chart_type: 'pie', x: 'a', y: 'b' }, rows)).rejects.toThrow(/Unsupported/);
+    });
+
+    it('_drawFigure re-plots sized to the panel body (resize reflow)', () => {
+        const cr = new ChartRenderer({ doc: null });
+        let captured;
+        cr._plot = { ...fakePlot, plot: (o) => { captured = o; return { tag: 'fig' }; } };
+        const replaced = [];
+        const entry = {
+            body: { clientWidth: 500, clientHeight: 400, replaceChildren: (f) => replaced.push(f) },
+            spec: { chart_type: 'bar', x: 'country', y: 'pct' },
+            rows,
+        };
+        cr._drawFigure(entry);
+        expect(captured.width).toBe(500);
+        expect(captured.height).toBe(400);
+        expect(replaced).toEqual([{ tag: 'fig' }]);
+    });
+
+    it('_drawFigure falls back to default size when the body has no layout yet', () => {
+        const cr = new ChartRenderer({ doc: null });
+        let captured;
+        cr._plot = { ...fakePlot, plot: (o) => { captured = o; return {}; } };
+        const entry = {
+            body: { clientWidth: 0, clientHeight: 0, replaceChildren: () => {} },
+            spec: { chart_type: 'scatter', x: 'a', y: 'b' },
+            rows,
+        };
+        cr._drawFigure(entry);
+        expect(captured.width).toBe(400);
+        expect(captured.height).toBe(300);
     });
 });

--- a/test/chart-renderer.test.js
+++ b/test/chart-renderer.test.js
@@ -22,13 +22,17 @@ describe('buildPlotOptions', () => {
         expect(bar.data).toBe(rows);
         expect(bar.opts).toMatchObject({ x: 'country', y: 'pct', fill: 'region' });
         expect(o.marks.some(m => m.mark === 'ruleY')).toBe(true);
-        expect(o.color).toEqual({ legend: true });   // series → legend
+        // series → legend, painted from the fixed categorical range
+        expect(o.color).toMatchObject({ legend: true });
+        expect(Array.isArray(o.color.range)).toBe(true);
     });
 
-    it('scatter → dot with no y=0 baseline', () => {
+    it('scatter → filled dots, no y=0 baseline, no legend without series', () => {
         const o = buildPlotOptions(fakePlot, { chart_type: 'scatter', x: 'carbon', y: 'biodiversity' }, rows);
         expect(o.marks.some(m => m.mark === 'ruleY')).toBe(false);
-        expect(o.marks[0].mark).toBe('dot');
+        const dot = o.marks.find(m => m.mark === 'dot');
+        expect(dot.opts.fill).toBe('#2a78d6');   // bold filled color, not an open circle
+        expect(dot.opts.r).toBeGreaterThanOrEqual(4);
         expect(o.color).toBeUndefined();   // no series → no legend
     });
 

--- a/test/dataset-catalog.test.js
+++ b/test/dataset-catalog.test.js
@@ -313,6 +313,21 @@ describe('DatasetCatalog.extractMapLayers', () => {
         expect(layers[0].sourceLayer).toBe('holdings_layer');
     });
 
+    it('threads a `control` block through to the vector layer record (#147)', () => {
+        const control = { type: 'slider', field: 'YEAR_', min: 1835, max: 2024, mode: 'cumulative' };
+        const layers = cat.extractMapLayers(collectionWithAssets({
+            fires: { type: 'application/vnd.pmtiles', href: 'https://x/fires.pmtiles' },
+        }), {}, [{ key: 'fires', assetId: 'fires', config: { control } }]);
+        expect(layers[0].control).toEqual(control);
+    });
+
+    it('leaves control null when no control block is configured', () => {
+        const layers = cat.extractMapLayers(collectionWithAssets({
+            fires: { type: 'application/vnd.pmtiles', href: 'https://x/fires.pmtiles' },
+        }), {}, [{ key: 'fires', assetId: 'fires', config: {} }]);
+        expect(layers[0].control).toBeNull();
+    });
+
     it('normalizes legend_classes ({label,color}) for a categorical vector layer (issue #118)', () => {
         const layers = cat.extractMapLayers(collectionWithAssets({
             geo: { type: 'application/vnd.pmtiles', href: 'https://x/geo.pmtiles' },

--- a/test/map-manager.filter.test.js
+++ b/test/map-manager.filter.test.js
@@ -48,6 +48,53 @@ describe('MapManager.setFilter empty-filter guard (#243)', () => {
     });
 });
 
+describe('MapManager._applyControlAction (reactive slider, #147)', () => {
+    const setup = (extra = {}) => {
+        const setFilterCalls = [];
+        const queryCalls = { n: 0 };
+        const mm = Object.create(MapManager.prototype);
+        mm.map = {
+            setFilter: (id, f) => setFilterCalls.push({ id, f }),
+            queryRenderedFeatures: () => { queryCalls.n++; return []; },
+        };
+        mm.layers = new Map([
+            ['vec', { type: 'vector', mapLayerId: 'layer-vec', outlineLayerId: 'layer-vec-outline', displayName: 'Vec', ...extra }],
+        ]);
+        mm._setFilterCalls = setFilterCalls;
+        mm._queryCalls = queryCalls;
+        return mm;
+    };
+
+    it('applies the slider expression to the layer and its outline', () => {
+        const mm = setup();
+        mm._applyControlAction('vec', { kind: 'filter', expr: ['<=', ['get', 'YEAR_'], 1990] });
+        expect(mm._setFilterCalls).toEqual([
+            { id: 'layer-vec', f: ['<=', ['get', 'YEAR_'], 1990] },
+            { id: 'layer-vec-outline', f: ['<=', ['get', 'YEAR_'], 1990] },
+        ]);
+    });
+
+    it('does NOT call queryRenderedFeatures (cheap per-frame path, unlike setFilter)', () => {
+        const mm = setup();
+        mm._applyControlAction('vec', { kind: 'filter', expr: ['<=', ['get', 'YEAR_'], 1990] });
+        expect(mm._queryCalls.n).toBe(0);
+    });
+
+    it('composes the slider predicate with the layer base filter so a defaultFilter survives', () => {
+        const base = ['==', ['get', 'severity'], 'high'];
+        const mm = setup({ controlBaseFilter: base });
+        mm._applyControlAction('vec', { kind: 'filter', expr: ['<=', ['get', 'YEAR_'], 1990] });
+        expect(mm._setFilterCalls[0].f).toEqual(['all', base, ['<=', ['get', 'YEAR_'], 1990]]);
+    });
+
+    it('ignores non-filter actions and unknown layers', () => {
+        const mm = setup();
+        mm._applyControlAction('vec', { kind: 'style', paint: {} });
+        mm._applyControlAction('missing', { kind: 'filter', expr: ['<=', ['get', 'x'], 1] });
+        expect(mm._setFilterCalls.length).toBe(0);
+    });
+});
+
 describe('MapManager.setFilter 0-features-in-view', () => {
     it('reports plain success with no failure signal when 0 features are in the viewport', () => {
         // queryRenderedFeatures is viewport-scoped: a valid filter whose matches are

--- a/test/map-tools.test.js
+++ b/test/map-tools.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { extractJsonArray, createMapTools } from '../app/map-tools.js';
+import { extractJsonArray, createMapTools, createRenderChartTool } from '../app/map-tools.js';
 
 describe('extractJsonArray', () => {
     it('parses to_json(array_agg(...)) output', () => {
@@ -297,6 +297,86 @@ describe('set_tooltip / reset_tooltip', () => {
     it('disambiguation nudge stays on layer-targeting tools', () => {
         const { tool } = getTool('set_tooltip');
         expect(tool.description).toMatch(/displayName semantic match/);
+    });
+});
+
+describe('render_chart (#277)', () => {
+    const stubRenderer = () => {
+        const calls = [];
+        return { render: vi.fn(async (spec, rows) => { calls.push({ spec, rows }); return { id: 'chart-1' }; }), _calls: calls };
+    };
+
+    it('renders directly from an inline data array', async () => {
+        const renderer = stubRenderer();
+        const tool = createRenderChartTool(renderer, null);
+        const data = [{ country: 'Brazil', pct: 31 }];
+        const result = JSON.parse(await tool.execute({ chart_type: 'bar', x: 'country', y: 'pct', data }));
+        expect(result.success).toBe(true);
+        expect(result.chart_id).toBe('chart-1');
+        expect(result.points).toBe(1);
+        expect(renderer.render).toHaveBeenCalledOnce();
+        expect(renderer.render.mock.calls[0][1]).toBe(data);
+    });
+
+    it('runs the sql path through MCP and parses rows', async () => {
+        const renderer = stubRenderer();
+        const mcpClient = { callTool: vi.fn(async () => '[{"country":"Brazil","pct":31},{"country":"Peru","pct":22}]') };
+        const tool = createRenderChartTool(renderer, mcpClient);
+        const result = JSON.parse(await tool.execute({ chart_type: 'bar', x: 'country', y: 'pct', sql: 'SELECT country, pct FROM t' }));
+        expect(result.success).toBe(true);
+        expect(result.points).toBe(2);
+        // SQL is wrapped to aggregate rows to a JSON array
+        expect(mcpClient.callTool.mock.calls[0][1].sql_query).toMatch(/to_json\(array_agg/);
+    });
+
+    it('errors when neither data nor sql is provided', async () => {
+        const tool = createRenderChartTool(stubRenderer(), null);
+        const result = JSON.parse(await tool.execute({ chart_type: 'bar', x: 'country', y: 'pct' }));
+        expect(result.success).toBe(false);
+        expect(result.error).toMatch(/No data/);
+    });
+
+    it('errors on the sql path when no MCP client is available', async () => {
+        const tool = createRenderChartTool(stubRenderer(), null);
+        const result = JSON.parse(await tool.execute({ chart_type: 'bar', x: 'c', y: 'v', sql: 'SELECT 1' }));
+        expect(result.success).toBe(false);
+        expect(result.error).toMatch(/MCP client not available/);
+    });
+
+    it('reports a render failure instead of throwing', async () => {
+        const renderer = { render: vi.fn(async () => { throw new Error('boom'); }) };
+        const tool = createRenderChartTool(renderer, null);
+        const result = JSON.parse(await tool.execute({ chart_type: 'bar', x: 'c', y: 'v', data: [{ c: 'a', v: 1 }] }));
+        expect(result.success).toBe(false);
+        expect(result.error).toMatch(/Could not render chart/);
+    });
+
+    it('rejects an invalid spec before running any SQL', async () => {
+        const renderer = stubRenderer();
+        const mcpClient = { callTool: vi.fn() };
+        const tool = createRenderChartTool(renderer, mcpClient);
+        // bar with no y → invalid; must not reach the MCP query
+        const result = JSON.parse(await tool.execute({ chart_type: 'bar', x: 'c', sql: 'SELECT 1' }));
+        expect(result.success).toBe(false);
+        expect(result.error).toMatch(/requires a y/);
+        expect(mcpClient.callTool).not.toHaveBeenCalled();
+    });
+
+    it('reports an empty SQL result as "no rows", not a parse error', async () => {
+        const renderer = stubRenderer();
+        // DuckDB array_agg over zero rows → NULL
+        const mcpClient = { callTool: vi.fn(async () => '| rows |\n|------|\n| NULL |') };
+        const tool = createRenderChartTool(renderer, mcpClient);
+        const result = JSON.parse(await tool.execute({ chart_type: 'bar', x: 'c', y: 'v', sql: 'SELECT c, v FROM t WHERE false' }));
+        expect(result.success).toBe(false);
+        expect(result.error).toMatch(/no rows/i);
+        expect(renderer.render).not.toHaveBeenCalled();
+    });
+
+    it('requires chart_type and x in its schema', () => {
+        const tool = createRenderChartTool(stubRenderer(), null);
+        expect(tool.inputSchema.required).toEqual(['chart_type', 'x']);
+        expect(tool.inputSchema.properties.chart_type.enum).toEqual(['bar', 'line', 'scatter', 'histogram']);
     });
 });
 

--- a/test/map-tools.test.js
+++ b/test/map-tools.test.js
@@ -300,6 +300,38 @@ describe('set_tooltip / reset_tooltip', () => {
     });
 });
 
+describe('create_slider', () => {
+    const stubMapManager = () => ({
+        createSlider: vi.fn((args) => ({ success: true, layer: args.layer_id, field: args.field, min: args.min, max: args.max, mode: args.mode === 'step' ? 'step' : 'cumulative' })),
+        getLayerSummaries: () => [{ id: 'fires', displayName: 'Fires', type: 'vector' }],
+    });
+    const stubCatalog = { records: new Map() };
+
+    const getTool = () => {
+        const mapManager = stubMapManager();
+        const tool = createMapTools(mapManager, stubCatalog).find(t => t.name === 'create_slider');
+        return { tool, mapManager };
+    };
+
+    it('forwards args verbatim to mapManager.createSlider', async () => {
+        const { tool, mapManager } = getTool();
+        const args = { layer_id: 'fires', field: 'YEAR_', min: 1835, max: 2024, step: 1, mode: 'cumulative', animate: true };
+        const result = JSON.parse(await tool.execute(args));
+        expect(result.success).toBe(true);
+        expect(mapManager.createSlider).toHaveBeenCalledWith(args);
+    });
+
+    it('requires layer_id, field, min, and max in its schema', () => {
+        const { tool } = getTool();
+        expect(tool.inputSchema.required).toEqual(['layer_id', 'field', 'min', 'max']);
+    });
+
+    it('constrains mode to cumulative | step', () => {
+        const { tool } = getTool();
+        expect(tool.inputSchema.properties.mode.enum).toEqual(['cumulative', 'step']);
+    });
+});
+
 describe('geocode tool', () => {
     const stubMap = { getLayerSummaries: () => [] };
     const stubCatalog = { records: new Map() };
@@ -397,6 +429,7 @@ describe('createMapTools smoke test', () => {
         expect(names).toEqual([
             'add_hex_tile_layer',
             'clear_filter',
+            'create_slider',
             'fly_to',
             'get_map_state',
             'get_schema',

--- a/test/reactive-control.test.js
+++ b/test/reactive-control.test.js
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi } from 'vitest';
+import { buildControlAction, ReactiveControl } from '../app/reactive-control.js';
+
+describe('buildControlAction', () => {
+    it('cumulative filter binds field <= value', () => {
+        const action = buildControlAction({ bind: 'filter', mode: 'cumulative', field: 'YEAR_' }, 1990);
+        expect(action).toEqual({ kind: 'filter', expr: ['<=', ['get', 'YEAR_'], 1990] });
+    });
+
+    it('step filter binds field == value', () => {
+        const action = buildControlAction({ bind: 'filter', mode: 'step', field: 'YEAR_' }, 1990);
+        expect(action).toEqual({ kind: 'filter', expr: ['==', ['get', 'YEAR_'], 1990] });
+    });
+
+    it('defaults to cumulative when mode is omitted', () => {
+        const action = buildControlAction({ bind: 'filter', field: 'depth' }, 50);
+        expect(action).toEqual({ kind: 'filter', expr: ['<=', ['get', 'depth'], 50] });
+    });
+
+    it('returns null when the filter bind has no field', () => {
+        expect(buildControlAction({ bind: 'filter' }, 5)).toBeNull();
+    });
+
+    it('returns null for unimplemented bind kinds (style/query reserved)', () => {
+        expect(buildControlAction({ bind: 'style', field: 'x' }, 5)).toBeNull();
+        expect(buildControlAction({ bind: 'query', field: 'x' }, 5)).toBeNull();
+    });
+});
+
+describe('ReactiveControl (no-DOM core)', () => {
+    // doc:null skips panel construction so the value→action pipeline can be
+    // tested without faking the DOM. The browser-bound _build / autoplay paths
+    // are verified manually in a deployed app (per the module-coverage policy).
+    const makeControl = (config) => {
+        const actions = [];
+        const ctrl = new ReactiveControl({
+            layerId: 'fires',
+            displayName: 'Fires',
+            config,
+            apply: (a) => actions.push(a),
+            doc: null,
+        });
+        return { ctrl, actions };
+    };
+
+    it('applies an initial action on construction at the default value', () => {
+        const { actions } = makeControl({ field: 'YEAR_', min: 1835, max: 2024, mode: 'cumulative' });
+        // cumulative default = max → reveals everything up front
+        expect(actions).toEqual([{ kind: 'filter', expr: ['<=', ['get', 'YEAR_'], 2024] }]);
+    });
+
+    it('step mode defaults the initial value to min', () => {
+        const { actions } = makeControl({ field: 'YEAR_', min: 1835, max: 2024, mode: 'step' });
+        expect(actions[0]).toEqual({ kind: 'filter', expr: ['==', ['get', 'YEAR_'], 1835] });
+    });
+
+    it('honours an explicit default value', () => {
+        const { actions } = makeControl({ field: 'YEAR_', min: 1835, max: 2024, default: 1990 });
+        expect(actions[0]).toEqual({ kind: 'filter', expr: ['<=', ['get', 'YEAR_'], 1990] });
+    });
+
+    it('setValue recomputes and re-applies the action', () => {
+        const { ctrl, actions } = makeControl({ field: 'YEAR_', min: 1835, max: 2024 });
+        ctrl.setValue(2000);
+        expect(actions.at(-1)).toEqual({ kind: 'filter', expr: ['<=', ['get', 'YEAR_'], 2000] });
+    });
+
+    it('setValue clamps to [min, max]', () => {
+        const { ctrl, actions } = makeControl({ field: 'YEAR_', min: 1835, max: 2024 });
+        ctrl.setValue(5000);
+        expect(actions.at(-1)).toEqual({ kind: 'filter', expr: ['<=', ['get', 'YEAR_'], 2024] });
+        ctrl.setValue(0);
+        expect(actions.at(-1)).toEqual({ kind: 'filter', expr: ['<=', ['get', 'YEAR_'], 1835] });
+    });
+
+    it('throws when min/max are missing', () => {
+        expect(() => makeControl({ field: 'YEAR_' })).toThrow(/min and max/);
+    });
+
+    it('destroy is safe with no DOM panel', () => {
+        const { ctrl } = makeControl({ field: 'YEAR_', min: 1835, max: 2024 });
+        expect(() => ctrl.destroy()).not.toThrow();
+        expect(ctrl.destroyed).toBe(true);
+    });
+});


### PR DESCRIPTION
**Durability PR for the `tweak/charting` work** — this branch was previously live only as a direct commit-SHA pin on the **landscape-frontiers** demo app (`geo-agent@c924d32`). That app has since been bumped to the `@v3.20.0` release; this PR preserves the unmerged refinements so they don't get lost as a dangling commit.

### What's genuinely new here (not yet in `main`)
Three chart-panel UI refinements on top of the already-merged charting primitive:
- `3ce0147` fix(charts): anchor chart panel to the map area, not behind the sidebar
- `e080a11` feat(charts): resizable + pop-out chart panels
- `c924d32` fix(charts): top-left resize grip + bolder, readable default styles

Plus associated tests (`test/chart-renderer.test.js`, `test/reactive-control.test.js`, etc.) and `app/style.css`.

### ⚠️ Needs a rebase before merge
The branch is **5 ahead / 16 behind `main`** and forked before several things landed:
- the **reactive slider (#278)** is already merged into `main`;
- the **`render_chart` primitive (#277 / #279)** is merged, though this branch's version differs slightly.

So a straight merge would re-introduce/overlap already-landed work. Recommend **rebasing onto current `main`** to drop the slider + primitive commits and leave only the 3 refinements above, then de-draft.

Opened as a draft — surfacing/preserving the work, not asserting it's merge-ready.