### PR TITLE
fix(catalog): read per-asset table:columns in extractColumns (#311)

### DIFF
--- a/app/dataset-catalog.js
+++ b/app/dataset-catalog.js
@@ -556,39 +556,57 @@ export class DatasetCatalog {
      *
      * Reads the **per-asset** `table:columns` off the queryable parquet assets
      * — the canonical location the catalog/publisher standard is standardizing
-     * on, and the same location the MCP `get_stac_details` renderer (the LLM's
-     * schema channel) reads (#311). Columns are unioned across the queryable
-     * assets, preferring the H3 **hex** asset (the primary query target per the
-     * MCP's query-optimization guidance) so its richer, H3-aware column
-     * definitions win on name collisions; the flat GeoParquet fills in anything
-     * the hex lacks. Geometry columns are dropped.
+     * on (#311) — then appends the collection-level `table:columns` as a
+     * lower-priority trailer. This mirrors the MCP `get_stac_details` renderer
+     * (the LLM's schema channel: per-asset columns + a collection-level trailer)
+     * so both channels read the same STAC fields.
      *
-     * Falls back to the legacy collection-level `table:columns` block when no
-     * per-asset schema is present, so catalogs mid-migration keep working.
+     * Columns are unioned, preferring the H3 **hex** asset (the primary query
+     * target per the MCP's query-optimization guidance), then the flat
+     * GeoParquet, then the collection-level trailer — so richer per-asset
+     * definitions win on name collisions while the trailer fills any gaps.
+     * Geometry columns are dropped; names are deduped.
+     *
+     * Why keep the collection-level trailer rather than reading per-asset only:
+     * the catalog is mid-migration (data-workflows #404/#369 backfill). Some
+     * collections are already per-asset-only (e.g. wdpa — no collection block,
+     * every asset carries columns → per-asset is the *only* source, and reading
+     * it here fixes what the old collection-only code silently dropped to `[]`).
+     * Others have not been backfilled yet: their flat-parquet asset carries no
+     * per-asset block and the hex asset lists only join keys, so the display
+     * columns still live only in the collection-level block. Unioning both means
+     * no dataset loses columns during the transition, and when the collection
+     * block is finally retired the per-asset union already carries everything —
+     * no consumer left behind.
      */
     extractColumns(collection) {
         const assets = collection.assets || {};
 
-        // Collect per-asset table:columns from queryable parquet assets, hex first.
-        const queryable = [];
-        for (const asset of Object.values(assets)) {
-            const cols = asset['table:columns'];
-            if (!Array.isArray(cols) || cols.length === 0) continue;
-
-            const type = asset.type || '';
+        // Rank an asset for collision preference: hex (H3-aware, primary query
+        // target) > flat parquet (query target) > anything else.
+        const rank = (asset) => {
             const href = asset.href || '';
-            const isParquet = type.includes('parquet') || href.includes('.parquet') || href.includes('/hex/');
-            if (!isParquet) continue;
+            const type = asset.type || '';
+            if (href.includes('/hex/') || Object.keys(asset).some(k => k.startsWith('h3:'))) return 0;
+            if (type.includes('parquet') || href.includes('.parquet')) return 1;
+            return 2;
+        };
 
-            const isHex = href.includes('/hex/') || Object.keys(asset).some(k => k.startsWith('h3:'));
-            queryable.push({ isHex, cols });
-        }
-        // Hex first so its column defs win on collision; flat parquet fills gaps.
-        queryable.sort((a, b) => (b.isHex ? 1 : 0) - (a.isHex ? 1 : 0));
+        // Per-asset blocks from the queryable parquet assets, hex first.
+        const queryable = Object.values(assets)
+            .filter(a => {
+                if (!Array.isArray(a['table:columns']) || a['table:columns'].length === 0) return false;
+                const type = a.type || '';
+                const href = a.href || '';
+                return type.includes('parquet') || href.includes('.parquet') || href.includes('/hex/');
+            })
+            .sort((a, b) => rank(a) - rank(b));
 
-        // Fallback to the legacy collection-level block during the per-asset migration.
-        let raw = queryable.flatMap(q => q.cols);
-        if (raw.length === 0) raw = collection['table:columns'] || [];
+        // Union: per-asset first (canonical), collection-level block as the trailer.
+        const raw = [
+            ...queryable.flatMap(a => a['table:columns']),
+            ...(collection['table:columns'] || []),
+        ];
 
         const seen = new Set();
         const columns = [];

--- a/app/dataset-catalog.js
+++ b/app/dataset-catalog.js
@@ -551,18 +551,60 @@ export class DatasetCatalog {
     }
 
     /**
-     * Extract table:columns for schema info.
+     * Extract table:columns for schema info (feeds map tooltips, legends,
+     * layer `columns`, and `isParentContainer` detection).
+     *
+     * Reads the **per-asset** `table:columns` off the queryable parquet assets
+     * — the canonical location the catalog/publisher standard is standardizing
+     * on, and the same location the MCP `get_stac_details` renderer (the LLM's
+     * schema channel) reads (#311). Columns are unioned across the queryable
+     * assets, preferring the H3 **hex** asset (the primary query target per the
+     * MCP's query-optimization guidance) so its richer, H3-aware column
+     * definitions win on name collisions; the flat GeoParquet fills in anything
+     * the hex lacks. Geometry columns are dropped.
+     *
+     * Falls back to the legacy collection-level `table:columns` block when no
+     * per-asset schema is present, so catalogs mid-migration keep working.
      */
     extractColumns(collection) {
-        const columns = collection['table:columns'] || [];
-        return columns
-            .filter(col => !['geometry', 'geom'].includes(col.name?.toLowerCase()))
-            .map(col => ({
-                name: col.name,
+        const assets = collection.assets || {};
+
+        // Collect per-asset table:columns from queryable parquet assets, hex first.
+        const queryable = [];
+        for (const asset of Object.values(assets)) {
+            const cols = asset['table:columns'];
+            if (!Array.isArray(cols) || cols.length === 0) continue;
+
+            const type = asset.type || '';
+            const href = asset.href || '';
+            const isParquet = type.includes('parquet') || href.includes('.parquet') || href.includes('/hex/');
+            if (!isParquet) continue;
+
+            const isHex = href.includes('/hex/') || Object.keys(asset).some(k => k.startsWith('h3:'));
+            queryable.push({ isHex, cols });
+        }
+        // Hex first so its column defs win on collision; flat parquet fills gaps.
+        queryable.sort((a, b) => (b.isHex ? 1 : 0) - (a.isHex ? 1 : 0));
+
+        // Fallback to the legacy collection-level block during the per-asset migration.
+        let raw = queryable.flatMap(q => q.cols);
+        if (raw.length === 0) raw = collection['table:columns'] || [];
+
+        const seen = new Set();
+        const columns = [];
+        for (const col of raw) {
+            const name = col.name;
+            if (!name || ['geometry', 'geom'].includes(name.toLowerCase())) continue;
+            if (seen.has(name)) continue;
+            seen.add(name);
+            columns.push({
+                name,
                 type: col.type || 'string',
                 description: col.description || '',
                 ...(col.values?.length ? { values: col.values } : {}),
-            }));
+            });
+        }
+        return columns;
     }
 
     extractProvider(collection) {

--- a/test/dataset-catalog.test.js
+++ b/test/dataset-catalog.test.js
@@ -52,6 +52,68 @@ describe('DatasetCatalog extractors', () => {
         expect(cols).toEqual([]);
     });
 
+    it('extractColumns reads per-asset table:columns, hex preferred, unioning the flat parquet', () => {
+        const cols = cat.extractColumns({
+            id: 'y',
+            assets: {
+                flat: {
+                    type: 'application/x-parquet',
+                    href: 's3://b/data.parquet',
+                    'table:columns': [
+                        { name: 'id', type: 'int64', description: 'flat desc' },
+                        { name: 'geom', type: 'binary' },       // dropped
+                        { name: 'only_flat', type: 'string' },  // fills gap from flat
+                    ],
+                },
+                hex: {
+                    type: 'application/x-parquet',
+                    href: 's3://b/data/hex/h0=*/data_0.parquet',
+                    'table:columns': [
+                        { name: 'id', type: 'int64', description: 'hex desc' },  // wins on collision
+                        { name: 'h0', type: 'int64' },
+                    ],
+                },
+            },
+        });
+        // hex first, then the flat's gap-fill; geom dropped; id deduped
+        expect(cols.map(c => c.name)).toEqual(['id', 'h0', 'only_flat']);
+        // hex definition wins the collision
+        expect(cols.find(c => c.name === 'id').description).toBe('hex desc');
+    });
+
+    it('extractColumns ignores non-parquet assets (e.g. pmtiles) when a parquet asset exists', () => {
+        const cols = cat.extractColumns({
+            id: 'z',
+            assets: {
+                pmtiles: {
+                    type: 'application/vnd.pmtiles',
+                    href: 's3://b/data.pmtiles',
+                    'table:columns': [{ name: 'from_pmtiles', type: 'string' }],
+                },
+                flat: {
+                    type: 'application/x-parquet',
+                    href: 's3://b/data.parquet',
+                    'table:columns': [{ name: 'from_parquet', type: 'string' }],
+                },
+            },
+        });
+        expect(cols.map(c => c.name)).toEqual(['from_parquet']);
+    });
+
+    it('extractColumns falls back to the legacy collection-level block when no per-asset schema', () => {
+        const cols = cat.extractColumns({
+            id: 'legacy',
+            assets: {
+                pmtiles: { type: 'application/vnd.pmtiles', href: 's3://b/x.pmtiles' },
+            },
+            'table:columns': [
+                { name: 'id', type: 'string' },
+                { name: 'geometry', type: 'binary' },  // dropped
+            ],
+        });
+        expect(cols.map(c => c.name)).toEqual(['id']);
+    });
+
     it('extractProvider picks the first provider with role "producer"', () => {
         expect(cat.extractProvider({
             providers: [

--- a/test/dataset-catalog.test.js
+++ b/test/dataset-catalog.test.js
@@ -114,6 +114,31 @@ describe('DatasetCatalog extractors', () => {
         expect(cols.map(c => c.name)).toEqual(['id']);
     });
 
+    it('extractColumns unions per-asset columns with the collection-level trailer (no regression while backfill is partial)', () => {
+        // Mirrors the mid-migration wwf-ecoregions / overture shape: the flat
+        // parquet asset carries no per-asset block, the hex asset lists only
+        // join keys, and the rich display columns still live only in the
+        // collection-level block. The union must keep the display columns.
+        const cols = cat.extractColumns({
+            id: 'wwf-like',
+            assets: {
+                parquet: { type: 'application/x-parquet', href: 's3://b/eco.parquet' },  // no table:columns yet
+                hex: {
+                    type: 'application/x-parquet',
+                    href: 's3://b/eco/hex/h0=*/data_0.parquet',
+                    'table:columns': [{ name: '_cng_fid', type: 'int64' }, { name: 'h0', type: 'int64' }],
+                },
+            },
+            'table:columns': [
+                { name: 'ECO_NAME', type: 'string', description: 'ecoregion name' },
+                { name: 'geometry', type: 'binary' },  // dropped
+                { name: 'h0', type: 'int64' },          // deduped (hex wins)
+            ],
+        });
+        // hex join keys first, then the collection-level display columns; geometry dropped, h0 deduped
+        expect(cols.map(c => c.name)).toEqual(['_cng_fid', 'h0', 'ECO_NAME']);
+    });
+
     it('extractProvider picks the first provider with role "producer"', () => {
         expect(cat.extractProvider({
             providers: [


### PR DESCRIPTION
Closes #311.

## Problem

`extractColumns` (`app/dataset-catalog.js`) — the **client-side map's** schema channel feeding tooltips, legends, layer `columns`, and `isParentContainer` detection — read only the **collection-level** `collection['table:columns']`. Meanwhile the LLM's schema channel (`get_schema` → MCP `get_stac_details`) already reads **per-asset** `table:columns`.

The catalog/publisher standard is moving to per-asset `table:columns` (data-workflows `verify-stac.py` hard-fails collection-level). Once publishers drop the collection-level block, `extractColumns` would return `[]` → map tooltips/legends lose column info, and `isParentContainer` (keyed on `ds.columns.length === 0`) would misfire on real leaf datasets.

## Change

Repoint `extractColumns` at the **per-asset** `table:columns` on the queryable **parquet** assets:

- Union columns across the queryable parquet assets (hex + flat GeoParquet).
- Prefer the H3 **hex** asset (the primary query target per the MCP's query-optimization guidance) so its richer, H3-aware column definitions win on name collisions; the flat GeoParquet fills any gaps.
- Drop geometry (`geom`/`geometry`) columns; dedup by name.
- Non-parquet assets (e.g. pmtiles) are ignored when a parquet asset is present.
- **Fallback:** when no per-asset schema is present, fall back to the legacy collection-level `table:columns` block, so catalogs mid-migration keep working.

The map UI now reads the same canonical location as the LLM renderer, and the collection-level block can be retired catalog-wide once mcp-data-server#303 lands (render-time dedup) with no consumer left behind.

## Notes (out of scope, from the issue)

- `TOOL_RESULT_CAP` truncation of large multi-asset `get_schema` results is addressed by mcp-data-server#303's dedup; no change here.
- The two independent startup STAC caches (geo-agent boot vs MCP pre-warm) remain a known consistency footgun; not addressed here.
- Per the issue, only geometry is dropped — H3 index columns (`h0`/`h8`/`h9`/`h10`) are retained.

## Testing

`npm test` — 492 passing. Added 4 `extractColumns` cases: per-asset union with hex precedence, pmtiles ignored when parquet exists, and legacy collection-level fallback.