### PR TITLE
fix(agent): recover per-arg tool-call dialect leaks + short-circuit identical failing calls (#313)

### DIFF
--- a/app/agent.js
+++ b/app/agent.js
@@ -175,6 +175,14 @@ export class Agent {
         // produce a parseable call falls through to its text rather than looping.
         let parseRetries = 0;
         const MAX_PARSE_RETRIES = 2;
+        // Repeated-failure short-circuit (#313). A model re-issuing the
+        // byte-identical tool call(s) that just failed is not making progress.
+        // We nudge it once, then checkpoint — rather than burning the whole
+        // localOnlyStreak cap on ~15 identical failures (observed live: glm-5.2
+        // looping a corrupted add_hex_tile_layer call). Tracks the signature of
+        // the last all-failed round and how many times it has repeated since.
+        let repeatedFailureStreak = 0;
+        let lastFailedRoundSig = null;
 
         try {
         while (true) {
@@ -297,6 +305,31 @@ export class Agent {
 
                 // Show results
                 this.onToolResults(results, iterations);
+
+                // Repeated-failure short-circuit (#313): if this round re-issued
+                // the identical call(s) that just failed, and every call failed
+                // again, the model is stuck. Steer it once; if it still repeats,
+                // checkpoint instead of looping to the localOnlyStreak cap.
+                const roundSig = JSON.stringify(calls.map(c => [c.function?.name, c.function?.arguments]));
+                const roundFailed = results.length > 0 && results.every(r => this._isFailedResult(r));
+                repeatedFailureStreak = (roundFailed && roundSig === lastFailedRoundSig)
+                    ? repeatedFailureStreak + 1
+                    : 0;
+                lastFailedRoundSig = roundFailed ? roundSig : null;
+                if (repeatedFailureStreak === 1) {
+                    const errText = (results.find(r => this._isFailedResult(r))?.result || '').slice(0, 300);
+                    turnMessages.push({
+                        role: 'user',
+                        content: 'That tool call just failed with the same error as the previous attempt'
+                            + (errText ? `:\n${errText}\n` : '. ')
+                            + 'Repeating the identical call will not help. Call it differently, use a '
+                            + 'different tool, or reply to the user in plain text explaining the problem.',
+                    });
+                    continue;
+                }
+                if (repeatedFailureStreak >= 2) {
+                    return await this._checkpoint(endpoint, modelConfig, turnMessages, sqlQueries, iterations);
+                }
 
                 // Continue loop — LLM will see the results
                 continue;
@@ -935,6 +968,7 @@ export class Agent {
      * (#288, failure mode 2). A malformed `arguments` string left verbatim in the
      * assistant message poisons the next upstream request. We parse leniently and
      * re-serialize; anything unrecoverable becomes `{}` so history stays valid.
+     * Also recovers per-argument dialect leaks (#313, see scrubArgDialectLeaks).
      * Mutates the message in place.
      */
     normalizeToolCallArguments(message) {
@@ -942,14 +976,66 @@ export class Agent {
         for (const tc of message.tool_calls) {
             if (!tc.function) continue;
             const raw = tc.function.arguments;
-            if (typeof raw !== 'string') {
-                // Some backends hand back an object — canonicalize to a string.
-                tc.function.arguments = JSON.stringify(raw ?? {});
+            // A string is parsed leniently (recovers the #288 extra-brace case);
+            // some backends hand back an object directly. Anything unrecoverable
+            // becomes {}. Scrub arg-dialect leaks out of the parsed object before
+            // re-serializing, so both history and execution see the real values.
+            const parsed = typeof raw === 'string'
+                ? (this.parseLenientJSON(raw) ?? {})
+                : (raw ?? {});
+            tc.function.arguments = JSON.stringify(this.scrubArgDialectLeaks(parsed));
+        }
+    }
+
+    /**
+     * Recover a per-argument tool-call dialect leak (#313). Some backends
+     * (observed live on `z-ai/glm-5.2`) serialize a structured argument's *value*
+     * in an XML arg dialect — `<arg_key>NAME</arg_key> <arg_value>{…}</arg_value>`
+     * (or `<parameter=NAME>…</parameter>`) — which arrives as a JSON *string*
+     * rather than the parsed object. The outer `arguments` blob is otherwise valid
+     * JSON, so the parse in normalizeToolCallArguments succeeds and the leak reaches
+     * the tool as a string that fails its schema (e.g. add_hex_tile_layer rejecting
+     * a `value_stats` string). The real payload is intact inside the wrapper — this
+     * unwraps it. Defense-in-depth: the durable fix normalizes the dialect at the
+     * server/proxy (see docs/design/tool-call-parsing.md and open-llm-proxy#85).
+     *
+     * Only string values carrying an `<arg_value>` / `<parameter …>` marker are
+     * touched: the payload after the marker is parsed as JSON when it's an
+     * object/array, else taken as a plain scalar (trailing close tag stripped).
+     * A missing/mismatched close tag is tolerated, matching parseEmbeddedToolCalls.
+     * Values with no marker are left byte-for-byte unchanged. Mutates and returns.
+     */
+    scrubArgDialectLeaks(args) {
+        if (!args || typeof args !== 'object' || Array.isArray(args)) return args;
+        for (const key of Object.keys(args)) {
+            const v = args[key];
+            if (typeof v !== 'string') continue;
+            const marker = v.match(/<(?:arg_value|parameter\b[^>]*)>/i);
+            if (!marker) continue;
+            const after = v.slice(marker.index + marker[0].length);
+            const parsed = this.parseLenientJSON(after);
+            if (parsed && typeof parsed === 'object') {
+                args[key] = parsed;
                 continue;
             }
-            const parsed = this.parseLenientJSON(raw);
-            tc.function.arguments = JSON.stringify(parsed ?? {});
+            const scalar = after.replace(/<\/(?:arg_value|parameter)>\s*$/i, '').trim();
+            if (scalar) args[key] = scalar;
         }
+        return args;
+    }
+
+    /**
+     * Whether a tool-execution result represents a failure (#313). Covers a
+     * registry-level error / unknown tool (`source: 'error'`), a local tool's
+     * logical-failure envelope (`{"success": false, …}` — note the registry marks
+     * `success: true` whenever the tool didn't *throw*, so the flag alone is not
+     * enough), and the invalid-JSON sentinel pushed for an unparseable args blob.
+     */
+    _isFailedResult(r) {
+        if (!r) return false;
+        if (r.source === 'error') return true;
+        const s = typeof r.result === 'string' ? r.result : '';
+        return /^\s*Error\b/.test(s) || /"success"\s*:\s*false/.test(s);
     }
 
     /**

--- a/test/agent-tool-parse.test.js
+++ b/test/agent-tool-parse.test.js
@@ -427,3 +427,161 @@ describe('agent loop — malformed-call recovery (#288 failure mode 1/3)', () =>
         expect(global.fetch.mock.calls.length).toBe(1);
     });
 });
+
+// #313: a per-argument dialect leak — the model emits a *well-formed* native
+// tool call whose one nested-object argument value is wrapped in its XML arg
+// dialect. Observed live on z-ai/glm-5.2 (ca-30x30, 2026-07-14): value_stats
+// arrived as "<arg_key>value_stats</arg_key> <arg_value>{…}</arg_value>", the
+// data intact inside the wrapper, and add_hex_tile_layer rejected the string.
+const GLM_LEAK = '<arg_key>value_stats</arg_key> <arg_value>{"by_res": {"2": {"min": 0.46, "max": 9.45}}}';
+
+describe('scrubArgDialectLeaks (#313)', () => {
+    it('unwraps an <arg_value>-wrapped object back into structured JSON', () => {
+        const out = agentFor().scrubArgDialectLeaks({ value_column: 'x', value_stats: GLM_LEAK });
+        expect(out.value_stats).toEqual({ by_res: { '2': { min: 0.46, max: 9.45 } } });
+        expect(out.value_column).toBe('x'); // sibling scalar untouched
+    });
+
+    it('tolerates a present closing </arg_value> tag', () => {
+        const out = agentFor().scrubArgDialectLeaks({ v: `<arg_value>{"a":1}</arg_value>` });
+        expect(out.v).toEqual({ a: 1 });
+    });
+
+    it('unwraps a <parameter=NAME> scalar payload, stripping the close tag', () => {
+        const out = agentFor().scrubArgDialectLeaks({ sql: '<parameter=sql>SELECT 1</parameter>' });
+        expect(out.sql).toBe('SELECT 1');
+    });
+
+    it('leaves marker-free values byte-for-byte unchanged (incl. the empty string)', () => {
+        const obj = { value_stats: '', palette: 'viridis', n: 3, arr: [1, 2] };
+        expect(agentFor().scrubArgDialectLeaks(obj)).toEqual(
+            { value_stats: '', palette: 'viridis', n: 3, arr: [1, 2] });
+    });
+
+    it('is a no-op on non-objects', () => {
+        const a = agentFor();
+        expect(a.scrubArgDialectLeaks(null)).toBe(null);
+        expect(a.scrubArgDialectLeaks('str')).toBe('str');
+    });
+
+    it('recovers the leak end-to-end through normalizeToolCallArguments', () => {
+        const a = agentFor();
+        const argsStr = JSON.stringify({
+            tile_url: 'https://h/tiles/hex/abc/{z}/{x}/{y}.pbf',
+            value_column: 'conserved_hw_frac',
+            value_stats: GLM_LEAK,
+        });
+        const message = { role: 'assistant', tool_calls: [
+            { id: 'c1', type: 'function', function: { name: 'add_hex_tile_layer', arguments: argsStr } }] };
+        a.normalizeToolCallArguments(message);
+        const parsed = JSON.parse(message.tool_calls[0].function.arguments);
+        expect(parsed.value_stats).toEqual({ by_res: { '2': { min: 0.46, max: 9.45 } } });
+        expect(parsed.value_column).toBe('conserved_hw_frac');
+    });
+});
+
+describe('_isFailedResult (#313)', () => {
+    const a = agentFor();
+    it('flags registry-level errors and unknown tools', () => {
+        expect(a._isFailedResult({ source: 'error', result: 'Unknown tool: x' })).toBe(true);
+    });
+    it('flags a local tool logical-failure envelope', () => {
+        expect(a._isFailedResult({ source: 'local', result: '{"success":false,"error":"boom"}' })).toBe(true);
+    });
+    it('flags an "Error:" result string', () => {
+        expect(a._isFailedResult({ source: 'remote', result: 'Error: bad SQL' })).toBe(true);
+    });
+    it('does not flag a successful result', () => {
+        expect(a._isFailedResult({ source: 'local', result: '{"success":true,"layer_id":"hex-abc"}' })).toBe(false);
+    });
+    it('does not flag null / empty', () => {
+        expect(a._isFailedResult(null)).toBe(false);
+        expect(a._isFailedResult({ source: 'local', result: '' })).toBe(false);
+    });
+});
+
+describe('agent loop — dialect-leak recovery + repeated-failure short-circuit (#313)', () => {
+    afterEach(() => { vi.restoreAllMocks(); });
+
+    const okToolCall = (name, argsStr) => ({
+        ok: true,
+        json: async () => ({ choices: [{ message: {
+            role: 'assistant', content: null,
+            tool_calls: [{ id: 'c1', type: 'function', function: { name, arguments: argsStr } }],
+        } }] }),
+    });
+
+    it('recovers a leaked value_stats so the tool executes with a real object', async () => {
+        const argsStr = JSON.stringify({
+            tile_url: 'https://h/tiles/hex/abc/{z}/{x}/{y}.pbf',
+            value_column: 'conserved_hw_frac',
+            value_stats: GLM_LEAK,
+        });
+        global.fetch = vi.fn()
+            .mockResolvedValueOnce(okToolCall('add_hex_tile_layer', argsStr))
+            .mockResolvedValueOnce(okText('Added the hex layer.'));
+        const captured = [];
+        const agent = agentFor({
+            isLocal: () => true, has: () => true,
+            execute: async (name, args) => {
+                captured.push(args);
+                return { success: true, name, result: '{"success":true,"layer_id":"hex-abc"}', source: 'local' };
+            },
+        });
+        agent.autoApprove = true;
+
+        const { response } = await agent.processMessage('map protected hardwood');
+
+        expect(captured).toHaveLength(1);
+        expect(captured[0].value_stats).toEqual({ by_res: { '2': { min: 0.46, max: 9.45 } } });
+        expect(response).toBe('Added the hex layer.');
+    });
+
+    it('nudges once then checkpoints when a failing call is repeated identically', async () => {
+        const argsStr = JSON.stringify({ tile_url: 'https://h/tiles/hex/abc/{z}/{x}/{y}.pbf', value_stats: '' });
+        // Model emits the identical failing call every round (glm-5.2's value_stats:"" flail).
+        global.fetch = vi.fn()
+            .mockResolvedValueOnce(okToolCall('add_hex_tile_layer', argsStr)) // round 1: fail, record sig
+            .mockResolvedValueOnce(okToolCall('add_hex_tile_layer', argsStr)) // round 2: repeat → nudge
+            .mockResolvedValueOnce(okToolCall('add_hex_tile_layer', argsStr)) // round 3: repeat → checkpoint
+            .mockResolvedValueOnce(okText('Checkpoint: the hex call keeps failing.')); // _checkpoint summary
+        const agent = agentFor({
+            isLocal: () => true, has: () => true,
+            execute: async (name) => ({
+                success: true, name, source: 'local',
+                result: '{"success":false,"error":"value_stats.by_res must contain at least one resolution"}',
+            }),
+        });
+        agent.autoApprove = true;
+
+        const result = await agent.processMessage('map it');
+
+        // 3 identical failing rounds + 1 checkpoint-summary call — NOT the 15 the
+        // blunt localOnlyStreak cap would have allowed.
+        expect(global.fetch.mock.calls.length).toBe(4);
+        expect(result.checkpoint).toBe(true);
+        expect(result.response).toBe('Checkpoint: the hex call keeps failing.');
+    });
+
+    it('does not short-circuit when the model recovers after the nudge', async () => {
+        const failArgs = JSON.stringify({ tile_url: 'https://h/tiles/hex/abc/{z}/{x}/{y}.pbf', value_stats: '' });
+        global.fetch = vi.fn()
+            .mockResolvedValueOnce(okToolCall('add_hex_tile_layer', failArgs)) // round 1: fail
+            .mockResolvedValueOnce(okToolCall('add_hex_tile_layer', failArgs)) // round 2: repeat → nudge
+            .mockResolvedValueOnce(okText('OK, I cannot build that layer — here is the number instead: 12%.'));
+        const agent = agentFor({
+            isLocal: () => true, has: () => true,
+            execute: async (name) => ({
+                success: true, name, source: 'local',
+                result: '{"success":false,"error":"value_stats.by_res must contain at least one resolution"}',
+            }),
+        });
+        agent.autoApprove = true;
+
+        const result = await agent.processMessage('map it');
+
+        expect(result.checkpoint).toBeFalsy();
+        expect(result.response).toContain('12%');
+        expect(global.fetch.mock.calls.length).toBe(3);
+    });
+});


### PR DESCRIPTION
Closes #313.

## What
Two model/tool-agnostic harness defenses, motivated by the live ca-30x30 `z-ai/glm-5.2` failure this morning (2026-07-14, *"what fraction of ca hardwood is protected?"*).

**1. Per-argument dialect scrub** (`scrubArgDialectLeaks`, wired into `normalizeToolCallArguments`)
GLM emitted a **well-formed native** `add_hex_tile_layer` call whose `value_stats` *value* was its XML arg dialect leaked in as a string:
```
"value_stats": "<arg_key>value_stats</arg_key> <arg_value>{...intact JSON...}</arg_value>"
```
The existing `parseEmbeddedToolCalls` recovery misses this: it only runs when there are **zero** native tool calls (`agent.js:219`), and here the outer `arguments` blob is valid JSON so `JSON.parse` succeeds. The scrub unwraps `<arg_value>`/`<parameter …>` markers out of string-valued args and re-parses the payload — the data is intact inside the wrapper, so this call now **succeeds** instead of failing. Runs inside `normalizeToolCallArguments` so both conversation history and execution see the recovered value.

**2. Repeated-failure short-circuit** (agent loop)
After the leak, GLM degraded to `value_stats: ""` and looped the **byte-identical** failing call ~15× until the blunt `localOnlyStreak` cap (=`maxToolCalls`, 15) stopped it. Now: when a round re-issues the identical call(s) that just failed and all fail again, the loop **nudges once, then checkpoints** — cutting ~15 wasted rounds to ~3.

## Scope
Defense-in-depth per `docs/design/tool-call-parsing.md`. This is the client-side net; the **root fix** (normalize GLM-5.2's dialect at the proxy) is boettiger-lab/open-llm-proxy#85, and the **architecture fix** (stop transcribing `value_stats` through the LLM; fetch by hash) is #276 + boettiger-lab/mcp-data-server#316.

## Tests
16 new tests in `test/agent-tool-parse.test.js`: `scrubArgDialectLeaks` (incl. the exact GLM leak, `<parameter=>` scalars, marker-free no-op), `_isFailedResult`, and three loop-level tests (leak recovered end-to-end so the tool executes with a real object; nudge-then-checkpoint on repeat; no short-circuit when the model recovers after the nudge). Full agent suite green (146 tests); no changes to browser-bound modules.