### PR TITLE
feat(hex): layer-panel toggle + remove control for hex layers (#318)

### DIFF
--- a/app/map-manager.js
+++ b/app/map-manager.js
@@ -738,6 +738,10 @@ export class MapManager {
 
         this._wireTooltip(layerId, layerId);
 
+        // Surface the layer in the panel with a visibility toggle + remove
+        // button, so users can manage it without an LLM round-trip (#318).
+        this._addLayerControl(layerId);
+
         if (fitBounds && Array.isArray(bounds) && bounds.length === 4) {
             const [w, s, e, n] = bounds;
             this.map.fitBounds([[w, s], [e, n]], { padding: 40, duration: 800 });
@@ -773,6 +777,15 @@ export class MapManager {
         this.map.removeLayer(layerId);
         this.map.removeSource(layerId);
         this.layers.delete(layerId);
+
+        // Drop its panel row (added by _addLayerControl). Guarded so a
+        // headless/no-DOM caller doesn't throw.
+        if (this._controlsContainerEl) {
+            const item = this._controlsContainerEl.querySelector(`#layer-item-${layerId.replace(/\//g, '-')}`);
+            if (item) item.remove();
+            this._refreshCycleBtnState();
+        }
+
         return { success: true, layer_id: layerId };
     }
 
@@ -1263,6 +1276,9 @@ export class MapManager {
             container = document.getElementById(container);
         }
         if (!container) return;
+        // Remember the resolved element so runtime-added layers (hex tiles)
+        // can append their own control without a full re-render.
+        this._controlsContainerEl = container;
         container.innerHTML = '';
 
         // Group layers by their group name (null → ungrouped)
@@ -1293,50 +1309,100 @@ export class MapManager {
             }
 
             for (const [layerId, state] of entries) {
-                const wrapper = document.createElement('div');
-                wrapper.className = 'layer-item';
-
-                const label = document.createElement('label');
-                label.className = 'layer-toggle';
-
-                const checkbox = document.createElement('input');
-                checkbox.type = 'checkbox';
-                checkbox.id = `toggle-${layerId.replace(/\//g, '-')}`;
-                checkbox.checked = state.visible;
-                checkbox.addEventListener('change', () => {
-                    if (checkbox.checked) this.showLayer(layerId);
-                    else this.hideLayer(layerId);
-                    this._refreshCycleBtnState();
-                });
-
-                const span = document.createElement('span');
-                span.textContent = state.displayName;
-
-                label.appendChild(checkbox);
-                label.appendChild(span);
-                wrapper.appendChild(label);
-
-                // Version selector dropdown for versioned layers
-                if (state.versions && state.versions.length > 1) {
-                    const select = document.createElement('select');
-                    select.className = 'version-select';
-                    select.id = `version-${layerId.replace(/\//g, '-')}`;
-                    for (let i = 0; i < state.versions.length; i++) {
-                        const opt = document.createElement('option');
-                        opt.value = i;
-                        opt.textContent = state.versions[i].label;
-                        if (i === state.activeVersionIndex) opt.selected = true;
-                        select.appendChild(opt);
-                    }
-                    select.addEventListener('change', () => {
-                        this.switchVersion(layerId, parseInt(select.value, 10));
-                    });
-                    wrapper.appendChild(select);
-                }
-
-                itemContainer.appendChild(wrapper);
+                itemContainer.appendChild(this._createLayerItem(layerId, state));
             }
         }
+    }
+
+    /**
+     * Build one layer-panel row (checkbox + optional version dropdown +
+     * optional remove button). Shared by generateControls (boot) and
+     * _addLayerControl (runtime hex layers).
+     * @param {string} layerId
+     * @param {Object} state - entry from this.layers
+     * @returns {HTMLElement} the `.layer-item` wrapper
+     */
+    _createLayerItem(layerId, state) {
+        const safeId = layerId.replace(/\//g, '-');
+        const wrapper = document.createElement('div');
+        wrapper.className = 'layer-item';
+        wrapper.id = `layer-item-${safeId}`;
+
+        const label = document.createElement('label');
+        label.className = 'layer-toggle';
+
+        const checkbox = document.createElement('input');
+        checkbox.type = 'checkbox';
+        checkbox.id = `toggle-${safeId}`;
+        checkbox.checked = state.visible;
+        checkbox.addEventListener('change', () => {
+            if (checkbox.checked) this.showLayer(layerId);
+            else this.hideLayer(layerId);
+            this._refreshCycleBtnState();
+        });
+
+        const span = document.createElement('span');
+        span.textContent = state.displayName;
+
+        label.appendChild(checkbox);
+        label.appendChild(span);
+        wrapper.appendChild(label);
+
+        // Version selector dropdown for versioned layers
+        if (state.versions && state.versions.length > 1) {
+            const select = document.createElement('select');
+            select.className = 'version-select';
+            select.id = `version-${safeId}`;
+            for (let i = 0; i < state.versions.length; i++) {
+                const opt = document.createElement('option');
+                opt.value = i;
+                opt.textContent = state.versions[i].label;
+                if (i === state.activeVersionIndex) opt.selected = true;
+                select.appendChild(opt);
+            }
+            select.addEventListener('change', () => {
+                this.switchVersion(layerId, parseInt(select.value, 10));
+            });
+            wrapper.appendChild(select);
+        }
+
+        // Remove button — only for dynamically-added hex layers, which have a
+        // backing removeHexTileLayer(). Curated layers can't be removed (only
+        // hidden), so they get no button.
+        if (layerId.startsWith('hex-')) {
+            wrapper.classList.add('has-remove');
+            const removeBtn = document.createElement('button');
+            removeBtn.className = 'layer-remove-btn';
+            removeBtn.type = 'button';
+            removeBtn.title = 'Remove this layer';
+            removeBtn.setAttribute('aria-label', `Remove ${state.displayName}`);
+            removeBtn.textContent = '×';
+            removeBtn.addEventListener('click', (e) => {
+                e.preventDefault();
+                this.removeHexTileLayer(layerId);
+            });
+            wrapper.appendChild(removeBtn);
+        }
+
+        return wrapper;
+    }
+
+    /**
+     * Append a control row for a single runtime-added layer to the panel,
+     * without rebuilding the whole panel (which would reset user-toggled
+     * group collapse state). No-op if the panel hasn't been built yet or the
+     * row already exists.
+     * @param {string} layerId
+     */
+    _addLayerControl(layerId) {
+        const container = this._controlsContainerEl;
+        if (!container) return;
+        const safeId = layerId.replace(/\//g, '-');
+        if (container.querySelector(`#layer-item-${safeId}`)) return;
+        const state = this.layers.get(layerId);
+        if (!state) return;
+        container.appendChild(this._createLayerItem(layerId, state));
+        this._refreshCycleBtnState();
     }
 
     /**

--- a/app/style.css
+++ b/app/style.css
@@ -230,6 +230,40 @@ details.layer-group:not([open]) .layer-group-title::before {
     margin-bottom: 0;
 }
 
+/* Layers with a remove button lay the toggle + button out in a row. */
+.layer-item.has-remove {
+    display: flex;
+    align-items: center;
+}
+
+.layer-item.has-remove .layer-toggle {
+    flex: 1;
+    min-width: 0;
+}
+
+.layer-remove-btn {
+    flex: 0 0 auto;
+    margin-left: 6px;
+    padding: 0;
+    width: 18px;
+    height: 18px;
+    line-height: 16px;
+    font-size: 16px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: transparent;
+    border: none;
+    border-radius: 3px;
+    color: #808080;
+    cursor: pointer;
+}
+
+.layer-remove-btn:hover {
+    background: rgba(0, 0, 0, 0.08);
+    color: #c0392b;
+}
+
 .layer-toggle {
     display: flex;
     align-items: center;

--- a/test/map-manager.hex-panel.test.js
+++ b/test/map-manager.hex-panel.test.js
@@ -1,0 +1,73 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest';
+import { MapManager } from '../app/map-manager.js';
+
+/**
+ * Hex tile layers are added at runtime, after the layer panel is built at
+ * boot. These tests pin the #318 behavior: a hex layer gets its own panel row
+ * with a visibility toggle and a remove button, curated layers get no remove
+ * button, and removing a hex layer drops both the map layer and its row.
+ */
+
+function createPanelManager(layers = []) {
+    const removed = { layers: [], sources: [] };
+    const mm = Object.create(MapManager.prototype);
+    mm.layers = new Map(layers);
+    mm._controlsContainerEl = document.createElement('div');
+    mm._refreshCycleBtnState = () => {};
+    mm.map = {
+        removeLayer: (id) => removed.layers.push(id),
+        removeSource: (id) => removed.sources.push(id),
+    };
+    return { mm, removed };
+}
+
+const hexState = (displayName = 'Population density') => ({
+    displayName, visible: true, versions: null,
+});
+
+describe('MapManager hex panel controls (#318)', () => {
+    it('gives a hex layer a remove button; a curated layer none', () => {
+        const { mm } = createPanelManager();
+        const hexRow = mm._createLayerItem('hex-abc123', hexState());
+        const curatedRow = mm._createLayerItem('cpad/holdings', { displayName: 'CPAD', visible: true });
+
+        expect(hexRow.querySelector('.layer-remove-btn')).not.toBeNull();
+        expect(hexRow.classList.contains('has-remove')).toBe(true);
+        expect(curatedRow.querySelector('.layer-remove-btn')).toBeNull();
+    });
+
+    it('renders a visibility checkbox reflecting state.visible', () => {
+        const { mm } = createPanelManager();
+        const shown = mm._createLayerItem('hex-a', { ...hexState(), visible: true });
+        const hidden = mm._createLayerItem('hex-b', { ...hexState(), visible: false });
+        expect(shown.querySelector('input[type="checkbox"]').checked).toBe(true);
+        expect(hidden.querySelector('input[type="checkbox"]').checked).toBe(false);
+    });
+
+    it('_addLayerControl appends one row and is idempotent', () => {
+        const { mm } = createPanelManager([['hex-abc123', hexState()]]);
+        mm._addLayerControl('hex-abc123');
+        mm._addLayerControl('hex-abc123'); // second call must not duplicate
+        expect(mm._controlsContainerEl.querySelectorAll('.layer-item')).toHaveLength(1);
+        expect(mm._controlsContainerEl.querySelector('#layer-item-hex-abc123')).not.toBeNull();
+    });
+
+    it('_addLayerControl is a no-op before the panel is built', () => {
+        const { mm } = createPanelManager([['hex-abc123', hexState()]]);
+        mm._controlsContainerEl = null;
+        expect(() => mm._addLayerControl('hex-abc123')).not.toThrow();
+    });
+
+    it('clicking remove tears down the map layer and its panel row', () => {
+        const { mm, removed } = createPanelManager([['hex-abc123', hexState()]]);
+        mm._addLayerControl('hex-abc123');
+        const row = mm._controlsContainerEl.querySelector('#layer-item-hex-abc123');
+        row.querySelector('.layer-remove-btn').click();
+
+        expect(removed.layers).toEqual(['hex-abc123']);
+        expect(removed.sources).toEqual(['hex-abc123']);
+        expect(mm.layers.has('hex-abc123')).toBe(false);
+        expect(mm._controlsContainerEl.querySelector('#layer-item-hex-abc123')).toBeNull();
+    });
+});


### PR DESCRIPTION
Closes #318.

## Problem
Hex tile layers are added at runtime (`add_hex_tile_layer` → `addHexTileLayer`), *after* `generateControls()` builds the layer panel once at boot (`main.js:99`). They land in the same `this.layers` registry as curated layers, but the panel is never re-rendered, so a hex layer never gets a panel row. The only way to hide or clear one was to ask the LLM.

## Change
- Factor the per-layer row creation out of `generateControls()` into `_createLayerItem(layerId, state)`, shared by boot rendering and a new `_addLayerControl(layerId)` that appends a **single** row incrementally. Incremental append (rather than a full `generateControls()` re-render) avoids resetting user-toggled group-collapse state.
- `addHexTileLayer()` now calls `_addLayerControl()`. The row carries the same visibility checkbox as every other layer, plus a **remove (×) button**.
- The remove button is **hex-only**: it wires to the existing `removeHexTileLayer()`. Curated layers have no remove path (only hide), so they get no button — this mirrors the existing backend guard rather than inventing a destroy path for curated layers.
- `removeHexTileLayer()` now also removes the panel row.

## Notes / scope
- Covers both asks in the issue: hide/show (existing checkbox, now surfaced) and remove (new button).
- A general "remove" for curated layers is intentionally **out of scope** — they have no backing remove method and destroying them is a separate product decision.

## Testing
- New `test/map-manager.hex-panel.test.js` (jsdom, 5 tests): hex row gets a remove button, curated row doesn't; checkbox reflects `visible`; `_addLayerControl` appends once and is idempotent + no-op before panel build; clicking remove tears down the map layer, source, registry entry, and panel row.
- Full suite green (521 passed).
- `map-manager.js` is browser-bound; **visual/interaction check on a deployed app still recommended** (panel styling, × button placement in light/dark).