### PR TITLE
feat(hex): zoom-reactive color legend for hex layers (#316)

### DIFF
--- a/app/map-manager.js
+++ b/app/map-manager.js
@@ -12,7 +12,7 @@
  * No knowledge of LLMs, tools, or chat — pure map operations.
  */
 
-import { extractHashFromUrl, buildFillColorExpression, buildFlatFillColorExpression, rewriteValueColumn } from './hex-layer-helpers.js';
+import { extractHashFromUrl, buildFillColorExpression, buildFlatFillColorExpression, rewriteValueColumn, PALETTES } from './hex-layer-helpers.js';
 import { deriveContinuousLegend } from './legend-helpers.js';
 
 const BASEMAPS = {
@@ -62,6 +62,8 @@ export class MapManager {
         this._legendContent = null;
         this._legendItems = new Map();   // layerId → DOM element
         this._colormapCache = new Map(); // colormap name → CSS gradient string
+        this._hexLegendRefs = new Map(); // layerId → { minSpan, maxSpan, resNote } for zoom-reactive relabeling
+        this._hexLegendReactive = false; // moveend handler registered lazily on first hex legend
         this.titilerUrl = options.titilerUrl || 'https://titiler.nrp-nautilus.io';
         this._maptilerKey = options.maptilerKey || '';
         this._currentBasemap = 'natgeo';
@@ -732,8 +734,14 @@ export class MapManager {
             colormap: null,
             rescale: null,
             legendLabel: null,
-            legendType: null,
+            legendType: 'hex',
             legendClasses: null,
+            // Legend inputs (#316): the per-res value domain + the fixed 3-stop
+            // palette drive a zoom-reactive colorbar. `hexCurrentRes` caches
+            // the resolution last rendered so relabeling has a fallback.
+            hexValueStats: valueStats,
+            hexPalette: palette,
+            hexCurrentRes: null,
         });
 
         this._wireTooltip(layerId, layerId);
@@ -741,6 +749,11 @@ export class MapManager {
         // Surface the layer in the panel with a visibility toggle + remove
         // button, so users can manage it without an LLM round-trip (#318).
         this._addLayerControl(layerId);
+
+        // Show a color legend mirroring the map ramp for the visible
+        // resolution (#316). registerLayer does this for curated layers; hex
+        // layers bypass registerLayer, so trigger it here.
+        this._showLegendIfVisible(layerId);
 
         if (fitBounds && Array.isArray(bounds) && bounds.length === 4) {
             const [w, s, e, n] = bounds;
@@ -784,6 +797,20 @@ export class MapManager {
             const item = this._controlsContainerEl.querySelector(`#layer-item-${layerId.replace(/\//g, '-')}`);
             if (item) item.remove();
             this._refreshCycleBtnState();
+        }
+
+        // Drop its legend entry (#316) and hide the panel if nothing's left.
+        if (this._legendItems) {
+            const legendItem = this._legendItems.get(layerId);
+            if (legendItem) {
+                legendItem.remove();
+                this._legendItems.delete(layerId);
+            }
+            this._hexLegendRefs?.delete(layerId);
+            if (this._legendEl) {
+                const anyVisible = [...this._legendItems.values()].some(el => el.style.display !== 'none');
+                this._legendEl.style.display = anyVisible ? '' : 'none';
+            }
         }
 
         return { success: true, layer_id: layerId };
@@ -1486,7 +1513,75 @@ export class MapManager {
     _hasLegend(state) {
         return state.type === 'raster'
             || (state.legendType === 'categorical' && state.legendClasses?.length > 0)
-            || (state.legendType === 'continuous' && !!this._continuousVectorLegend(state));
+            || (state.legendType === 'continuous' && !!this._continuousVectorLegend(state))
+            || (state.legendType === 'hex' && !!this._hexLegend(state));
+    }
+
+    /**
+     * Determine which H3 resolution a hex layer is currently rendering, so its
+     * legend can show the matching value domain. The server pyramid serves one
+     * resolution per tile keyed off zoom, so we sample the rendered features'
+     * `res` property rather than trying to reproduce the server's zoom→res
+     * formula client-side. Falls back to the cached value, then the finest
+     * resolution, when nothing is rendered yet (e.g. right after add, or for
+     * GeoJSON layers whose features carry no `res`).
+     *
+     * @returns {number|null}
+     */
+    _currentHexRes(state) {
+        const byRes = state.hexValueStats?.by_res || {};
+        const available = Object.keys(byRes).map(Number).sort((a, b) => a - b);
+        if (available.length === 0) return null;
+        if (available.length === 1) return available[0];
+
+        let res = null;
+        try {
+            const feats = this.map.queryRenderedFeatures({ layers: [state.mapLayerId] });
+            const counts = new Map();
+            for (const f of feats) {
+                const r = f?.properties?.res;
+                if (r == null) continue;
+                counts.set(Number(r), (counts.get(Number(r)) || 0) + 1);
+            }
+            let best = -Infinity;
+            for (const [r, c] of counts) {
+                if (c > best) { best = c; res = r; }
+            }
+        } catch {
+            // map not ready / layer not queryable — fall through to fallback
+        }
+
+        if (res == null || byRes[res] == null) {
+            res = (state.hexCurrentRes != null && byRes[state.hexCurrentRes] != null)
+                ? state.hexCurrentRes
+                : available[available.length - 1];
+        }
+        return res;
+    }
+
+    /**
+     * Resolve a hex layer's colorbar for the resolution currently on screen:
+     * the fixed 3-stop palette (min→max) plus that resolution's value domain
+     * from `hexValueStats.by_res`. Mirrors the map's `buildFillColorExpression`
+     * ramp. Returns null only when no resolution stats exist.
+     *
+     * @returns {{ colors: string[], range: [number, number], res: number } | null}
+     */
+    _hexLegend(state) {
+        const byRes = state.hexValueStats?.by_res || {};
+        const res = this._currentHexRes(state);
+        if (res == null) return null;
+        const stats = byRes[res];
+        if (!stats || typeof stats.min !== 'number' || typeof stats.max !== 'number') return null;
+        const colors = PALETTES[state.hexPalette] || PALETTES.viridis;
+        return { colors, range: [stats.min, stats.max], res };
+    }
+
+    /** Format a legend value: grouped integers, floats to 3 significant digits. */
+    _fmtLegendValue(v) {
+        if (typeof v !== 'number' || !isFinite(v)) return String(v);
+        if (Number.isInteger(v)) return v.toLocaleString('en-US');
+        return v.toLocaleString('en-US', { maximumSignificantDigits: 3 });
     }
 
     /**
@@ -1617,6 +1712,36 @@ export class MapManager {
             }
             item.appendChild(bar);
             item.appendChild(labels);
+        } else if (state.legendType === 'hex') {
+            // Hex choropleth (#316): fixed 3-stop palette, min→max, over the
+            // value domain of the resolution currently on screen. Labels update
+            // on zoom via _updateHexLegends (per-res scaling ~7×/step).
+            const hex = this._hexLegend(state);
+            const safe = (hex?.colors || []).map(c => this._safeColorHint(c)).filter(Boolean);
+            const gradient = safe.length >= 2
+                ? `linear-gradient(to right, ${safe.join(', ')})`
+                : 'linear-gradient(to right, #eee, #333)';
+            const unit = state.legendLabel ? ` ${state.legendLabel}` : '';
+            const bar = document.createElement('div');
+            bar.className = 'legend-colorbar';
+            bar.style.background = gradient;
+            const labels = document.createElement('div');
+            labels.className = 'legend-labels';
+            const minSpan = document.createElement('span');
+            const maxSpan = document.createElement('span');
+            minSpan.textContent = `${this._fmtLegendValue(hex?.range[0])}${unit}`;
+            maxSpan.textContent = `${this._fmtLegendValue(hex?.range[1])}${unit}`;
+            labels.appendChild(minSpan);
+            labels.appendChild(maxSpan);
+            const resNote = document.createElement('div');
+            resNote.className = 'legend-hex-res';
+            if (hex) resNote.textContent = `H3 resolution ${hex.res}`;
+            item.appendChild(bar);
+            item.appendChild(labels);
+            item.appendChild(resNote);
+            if (hex) state.hexCurrentRes = hex.res;
+            this._hexLegendRefs.set(layerId, { minSpan, maxSpan, resNote });
+            this._ensureHexLegendReactivity();
         } else {
             const gradient = await this._getColormapGradient(state.colormap || 'reds');
             const [minVal, maxVal] = (state.rescale || '0,1').split(',');
@@ -1646,6 +1771,34 @@ export class MapManager {
         if (this._legendEl) {
             const anyVisible = [...this._legendItems.values()].some(el => el.style.display !== 'none');
             this._legendEl.style.display = anyVisible ? '' : 'none';
+        }
+    }
+
+    /**
+     * Register a single moveend handler that relabels visible hex legends to
+     * the value domain of the resolution now on screen. Lazy — only wired once
+     * a hex legend actually exists.
+     */
+    _ensureHexLegendReactivity() {
+        if (this._hexLegendReactive) return;
+        this._hexLegendReactive = true;
+        this.map.on('moveend', () => this._updateHexLegends());
+    }
+
+    /** Relabel each visible hex legend for the resolution currently rendered. */
+    _updateHexLegends() {
+        for (const [layerId, refs] of this._hexLegendRefs) {
+            const state = this.layers.get(layerId);
+            if (!state || !state.visible) continue;
+            const item = this._legendItems.get(layerId);
+            if (!item || item.style.display === 'none') continue;
+            const hex = this._hexLegend(state);
+            if (!hex) continue;
+            state.hexCurrentRes = hex.res;
+            const unit = state.legendLabel ? ` ${state.legendLabel}` : '';
+            refs.minSpan.textContent = `${this._fmtLegendValue(hex.range[0])}${unit}`;
+            refs.maxSpan.textContent = `${this._fmtLegendValue(hex.range[1])}${unit}`;
+            if (refs.resNote) refs.resNote.textContent = `H3 resolution ${hex.res}`;
         }
     }
 

--- a/app/style.css
+++ b/app/style.css
@@ -412,6 +412,13 @@ details.layer-group:not([open]) .layer-group-title::before {
     margin-bottom: 4px;
 }
 
+/* Hex legend: which H3 resolution the shown value range applies to. */
+.legend-hex-res {
+    font-size: 10px;
+    color: #999;
+    font-style: italic;
+}
+
 .legend-item {
     display: flex;
     align-items: center;

--- a/test/map-manager.hex-legend.test.js
+++ b/test/map-manager.hex-legend.test.js
@@ -1,0 +1,121 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest';
+import { MapManager } from '../app/map-manager.js';
+import { PALETTES } from '../app/hex-layer-helpers.js';
+
+/**
+ * Hex tile layers style with a per-`res` `match` expression that the
+ * continuous-legend deriver doesn't cover, so they historically rendered no
+ * legend (#316). These tests pin the hex-specific, zoom-reactive legend:
+ * palette + the value domain of the resolution actually on screen.
+ */
+
+function hexState(overrides = {}) {
+    return {
+        layerId: 'hex-abc', mapLayerId: 'hex-abc', displayName: 'Population',
+        visible: true, type: 'vector', legendType: 'hex', legendLabel: null,
+        legendClasses: null,
+        hexValueStats: { by_res: { '5': { min: 0, max: 100 }, '6': { min: 0, max: 700 }, '7': { min: 0, max: 4900 } } },
+        hexPalette: 'viridis', hexCurrentRes: null,
+        ...overrides,
+    };
+}
+
+function createManager(state, renderedRes = null) {
+    const handlers = {};
+    const mm = Object.create(MapManager.prototype);
+    mm.layers = new Map([[state.layerId, state]]);
+    mm._legendItems = new Map();
+    mm._hexLegendRefs = new Map();
+    mm._hexLegendReactive = false;
+    mm._legendEl = null;
+    mm._legendContent = null;
+    mm._ensureLegend = function () {
+        if (this._legendEl) return;
+        this._legendEl = document.createElement('div');
+        this._legendContent = document.createElement('div');
+    };
+    let res = renderedRes;
+    mm.map = {
+        on: (ev, cb) => { handlers[ev] = cb; },
+        removeLayer: () => {},
+        removeSource: () => {},
+        queryRenderedFeatures: () => res == null ? [] : [{ properties: { res } }, { properties: { res } }],
+        setRenderedRes: (r) => { res = r; },
+    };
+    return { mm, handlers };
+}
+
+describe('MapManager hex legend (#316)', () => {
+    it('_hasLegend is true for a hex layer with resolution stats', () => {
+        const { mm } = createManager(hexState());
+        expect(mm._hasLegend(hexState())).toBe(true);
+    });
+
+    it('_hasLegend is false for a hex layer with no resolution stats', () => {
+        const { mm } = createManager(hexState());
+        expect(mm._hasLegend(hexState({ hexValueStats: { by_res: {} } }))).toBe(false);
+    });
+
+    it('_currentHexRes picks the dominant rendered resolution', () => {
+        const state = hexState();
+        const { mm } = createManager(state, 6);
+        expect(mm._currentHexRes(state)).toBe(6);
+    });
+
+    it('_currentHexRes falls back to the finest resolution when nothing is rendered', () => {
+        const state = hexState();
+        const { mm } = createManager(state, null);
+        expect(mm._currentHexRes(state)).toBe(7);
+    });
+
+    it('_hexLegend returns the palette + the current resolution domain', () => {
+        const state = hexState();
+        const { mm } = createManager(state, 6);
+        const legend = mm._hexLegend(state);
+        expect(legend.colors).toEqual(PALETTES.viridis);
+        expect(legend.range).toEqual([0, 700]);
+        expect(legend.res).toBe(6);
+    });
+
+    it('_showLegend renders a colorbar, min/max labels, and a resolution note', async () => {
+        const state = hexState();
+        const { mm } = createManager(state, 6);
+        await mm._showLegend('hex-abc');
+        const item = mm._legendItems.get('hex-abc');
+        expect(item.querySelector('.legend-colorbar')).not.toBeNull();
+        const labels = [...item.querySelectorAll('.legend-labels span')].map(s => s.textContent);
+        expect(labels).toEqual(['0', '700']);
+        expect(item.querySelector('.legend-hex-res').textContent).toBe('H3 resolution 6');
+        expect(mm._hexLegendRefs.has('hex-abc')).toBe(true);
+        expect(mm._hexLegendReactive).toBe(true);
+    });
+
+    it('_updateHexLegends relabels to the new resolution domain on zoom', async () => {
+        const state = hexState();
+        const { mm, handlers } = createManager(state, 6);
+        await mm._showLegend('hex-abc');
+        mm.map.setRenderedRes(7);           // user zooms in → finer resolution served
+        handlers.moveend();                 // the registered moveend fires
+        const item = mm._legendItems.get('hex-abc');
+        const labels = [...item.querySelectorAll('.legend-labels span')].map(s => s.textContent);
+        expect(labels).toEqual(['0', '4,900']);
+        expect(item.querySelector('.legend-hex-res').textContent).toBe('H3 resolution 7');
+    });
+
+    it('removeHexTileLayer clears the legend entry and refs', async () => {
+        const state = hexState();
+        const { mm } = createManager(state, 6);
+        await mm._showLegend('hex-abc');
+        mm.removeHexTileLayer('hex-abc');
+        expect(mm._legendItems.has('hex-abc')).toBe(false);
+        expect(mm._hexLegendRefs.has('hex-abc')).toBe(false);
+    });
+
+    it('_fmtLegendValue groups integers and trims floats', () => {
+        const { mm } = createManager(hexState());
+        expect(mm._fmtLegendValue(1234567)).toBe('1,234,567');
+        expect(mm._fmtLegendValue(12.3456)).toBe('12.3');
+        expect(mm._fmtLegendValue(0.0012345)).toBe('0.00123');
+    });
+});


### PR DESCRIPTION
Closes #316.

## Problem
Hex tile layers rendered no legend. Two independent blockers:
1. They bypass `registerLayer` (which wires the legend via `_showLegendIfVisible`), so the legend was never even invoked for them.
2. Even if invoked, `deriveContinuousLegend` only parses a top-level `interpolate`/`step`; hex paint is `['case', …, ['match', ['get','res'], …]]`, so it returns `null`.

## Change — a hex-specific legend path (not a bent continuous deriver)
- `addHexTileLayer` stores `valueStats` + `palette` on the layer state, sets `legendType: 'hex'`, and calls `_showLegendIfVisible()` (mirroring what `registerLayer` does for curated layers).
- `_hexLegend(state)` derives `{colors, range, res}` from the fixed 3-stop `PALETTES` (imported from `hex-layer-helpers.js`, the same source the map ramp uses) and the value domain of the resolution **currently on screen**.
- `_currentHexRes(state)` determines that resolution by sampling the rendered features' `res` property (the server pyramid serves one resolution per tile keyed off zoom, so this is more honest than reproducing the server's zoom→res formula client-side), with a finest-resolution fallback for the moment right after add / for GeoJSON layers whose features carry no `res`.
- `_showLegend` gets a `hex` branch: colorbar + min/max labels + an `H3 resolution N` caption.
- **Zoom-reactive:** a single lazily-wired `moveend` handler (`_updateHexLegends`) relabels every visible hex legend as the on-screen resolution changes. This matters because the per-`res` domain scales ~7×/step, so a static range would mismatch the colors at most zoom levels.
- `removeHexTileLayer` tears down the legend entry.

## Design notes
- Reuses the exported `PALETTES` rather than re-parsing the `case`/`match` paint — the gradient is `[c0,c1,c2]` (min→max), matching `buildFillColorExpression`.
- Values format as grouped integers / 3-significant-digit floats (`_fmtLegendValue`).

## Testing
- New `test/map-manager.hex-legend.test.js` (jsdom, 9 tests): `_hasLegend` for hex; `_currentHexRes` dominant-res sampling + finest fallback; `_hexLegend` palette+domain; `_showLegend` DOM (colorbar/labels/res note); `_updateHexLegends` relabel on zoom; removal cleanup; value formatting.
- Full suite green (525 passed).
- `map-manager.js` is browser-bound; **visual check on a deployed app recommended** (colorbar + label updates while zooming a hex layer).