### PR TITLE
feat(hex): optional 3D extrusion styling for hex layers (#317)

### DIFF
--- a/app/hex-layer-helpers.js
+++ b/app/hex-layer-helpers.js
@@ -181,3 +181,93 @@ export function buildFlatFillColorExpression(valueColumn, stats, palette) {
         branch,
     ];
 }
+
+/**
+ * Pick a sensible default max extrusion height (metres) for a hex layer from
+ * its bounding box: ~8% of the smaller ground span, so full-value hexes read
+ * as visible towers without dwarfing a regional map or vanishing on a global
+ * one. Falls back to a fixed value when bounds are unusable.
+ *
+ * @param {number[]} bounds - [w, s, e, n] in degrees.
+ * @returns {number} metres.
+ */
+export function defaultExtrusionMaxHeight(bounds) {
+    const FALLBACK = 50000;
+    if (!Array.isArray(bounds) || bounds.length !== 4) return FALLBACK;
+    const [w, s, e, n] = bounds;
+    if (![w, s, e, n].every(v => typeof v === 'number' && isFinite(v))) return FALLBACK;
+    const midLatRad = ((s + n) / 2) * Math.PI / 180;
+    const widthM = Math.abs(e - w) * 111320 * Math.cos(midLatRad);
+    const heightM = Math.abs(n - s) * 110540;
+    const span = Math.min(widthM, heightM);
+    if (!(span > 0)) return FALLBACK;
+    return Math.max(1000, span * 0.08);
+}
+
+/**
+ * Build a MapLibre `fill-extrusion-height` expression mirroring
+ * {@link buildFillColorExpression}: a per-`res` `match` whose branches
+ * interpolate each resolution's value domain onto [0, maxHeight]. This encodes
+ * the same value as height that the fill-color encodes as hue, over the same
+ * domain, so colour and height stay in lockstep.
+ *
+ * Null values → height 0; a collapsed range (min == max) → half height;
+ * unknown resolutions → 0.
+ *
+ * @param {string} valueColumn - MVT feature property to encode.
+ * @param {{by_res: Object<string, {min: number, max: number}>}} valueStats
+ * @param {number} maxHeight - metres at the top of each resolution's domain.
+ * @returns {Array} MapLibre expression.
+ */
+export function buildHeightExpression(valueColumn, valueStats, maxHeight) {
+    const byRes = valueStats && valueStats.by_res;
+    if (!byRes || Object.keys(byRes).length === 0) {
+        throw new Error('value_stats.by_res must contain at least one resolution');
+    }
+    const resKeys = Object.keys(byRes).sort((a, b) => Number(a) - Number(b));
+
+    const branches = [];
+    for (const resStr of resKeys) {
+        const { min, max } = byRes[resStr];
+        const res = Number(resStr);
+        const branch = (min < max)
+            ? ['interpolate', ['linear'], ['get', valueColumn], min, 0, max, maxHeight]
+            : maxHeight / 2;
+        branches.push(res, branch);
+    }
+
+    return [
+        'case',
+        ['==', ['get', valueColumn], null],
+        0,
+        ['match', ['get', 'res'], ...branches, 0],
+    ];
+}
+
+/**
+ * Flat single-resolution `fill-extrusion-height` expression — the GeoJSON
+ * analogue of {@link buildHeightExpression}, matching
+ * {@link buildFlatFillColorExpression}. Features carry no `res`, so interpolate
+ * directly over one `{min, max}`.
+ *
+ * @param {string} valueColumn - Feature property to encode.
+ * @param {{min: number, max: number}} stats - Single-resolution value range.
+ * @param {number} maxHeight - metres at the top of the domain.
+ * @returns {Array} MapLibre expression.
+ */
+export function buildFlatHeightExpression(valueColumn, stats, maxHeight) {
+    if (!stats || stats.min == null || stats.max == null) {
+        throw new Error('stats must contain numeric min and max');
+    }
+    const { min, max } = stats;
+    const branch = (min < max)
+        ? ['interpolate', ['linear'], ['get', valueColumn], min, 0, max, maxHeight]
+        : maxHeight / 2;
+
+    return [
+        'case',
+        ['==', ['get', valueColumn], null],
+        0,
+        branch,
+    ];
+}

--- a/app/map-manager.js
+++ b/app/map-manager.js
@@ -12,7 +12,7 @@
  * No knowledge of LLMs, tools, or chat — pure map operations.
  */
 
-import { extractHashFromUrl, buildFillColorExpression, buildFlatFillColorExpression, rewriteValueColumn, PALETTES } from './hex-layer-helpers.js';
+import { extractHashFromUrl, buildFillColorExpression, buildFlatFillColorExpression, rewriteValueColumn, PALETTES, buildHeightExpression, buildFlatHeightExpression, defaultExtrusionMaxHeight } from './hex-layer-helpers.js';
 import { deriveContinuousLegend } from './legend-helpers.js';
 
 const BASEMAPS = {
@@ -631,8 +631,9 @@ export class MapManager {
      * @returns {{success: boolean, layer_id?: string, error?: string}}
      */
     addHexTileLayer(opts) {
-        const { tileUrl, valueColumn, valueStats, bounds, palette, opacity, displayName, fitBounds, layerName, resolution, format, geojsonUrl } = opts;
+        const { tileUrl, valueColumn, valueStats, bounds, palette, opacity, displayName, fitBounds, layerName, resolution, format, geojsonUrl, extrude, extrudeMaxHeight } = opts;
         const isGeoJson = format === 'geojson';
+        const is3D = extrude === true;
         const sourceLayer = isGeoJson ? null : (layerName || 'layer');
 
         // The hash always comes from tile_url_template (returned by
@@ -669,7 +670,14 @@ export class MapManager {
             return { success: false, error: `resolution ${resolution} not in value_stats.by_res — available: ${availableRes.join(', ')}` };
         }
 
+        const maxHeight = is3D
+            ? (typeof extrudeMaxHeight === 'number' && extrudeMaxHeight > 0
+                ? extrudeMaxHeight
+                : defaultExtrusionMaxHeight(bounds))
+            : null;
+
         let fillColor;
+        let heightExpr;
         try {
             if (isGeoJson) {
                 // Single-resolution: GeoJSON features carry no `res`, so the
@@ -677,18 +685,29 @@ export class MapManager {
                 // flat ramp over the finest (largest) resolution's stats.
                 const finestRes = availableRes[availableRes.length - 1];
                 fillColor = buildFlatFillColorExpression(valueColumn, valueStats.by_res[finestRes], palette);
+                if (is3D) heightExpr = buildFlatHeightExpression(valueColumn, valueStats.by_res[finestRes], maxHeight);
             } else {
                 fillColor = buildFillColorExpression(valueColumn, valueStats, palette);
+                if (is3D) heightExpr = buildHeightExpression(valueColumn, valueStats, maxHeight);
             }
         } catch (err) {
             return { success: false, error: err.message };
         }
 
-        const paint = {
-            'fill-color': fillColor,
-            'fill-opacity': opacity,
-            'fill-outline-color': 'rgba(0,0,0,0.15)',
-        };
+        // 3D opt-in (#317): encode value as extrusion height as well as colour,
+        // over the same per-res domain. fill-extrusion has no outline property.
+        const paint = is3D
+            ? {
+                'fill-extrusion-color': fillColor,
+                'fill-extrusion-opacity': opacity,
+                'fill-extrusion-height': heightExpr,
+                'fill-extrusion-base': 0,
+            }
+            : {
+                'fill-color': fillColor,
+                'fill-opacity': opacity,
+                'fill-outline-color': 'rgba(0,0,0,0.15)',
+            };
 
         // No filter on `res`: the server pyramid serves one resolution per
         // tile keyed off zoom (target_res = clamp(z + zoom_offset, min_res,
@@ -704,7 +723,7 @@ export class MapManager {
         }
         this.map.addLayer({
             id: layerId,
-            type: 'fill',
+            type: is3D ? 'fill-extrusion' : 'fill',
             source: layerId,
             // GeoJSON sources have no source-layer; omit it for that branch.
             ...(isGeoJson ? {} : { 'source-layer': sourceLayer }),
@@ -742,6 +761,7 @@ export class MapManager {
             hexValueStats: valueStats,
             hexPalette: palette,
             hexCurrentRes: null,
+            extruded: is3D,
         });
 
         this._wireTooltip(layerId, layerId);
@@ -759,6 +779,10 @@ export class MapManager {
             const [w, s, e, n] = bounds;
             this.map.fitBounds([[w, s], [e, n]], { padding: 40, duration: 800 });
         }
+
+        // Tilt the camera so the extrusion reads as 3D. Only when the map is
+        // still flat, so we don't fight a pitch the user already set (#317).
+        if (is3D) this.tiltForExtrusion();
 
         return {
             success: true,
@@ -989,6 +1013,36 @@ export class MapManager {
         if (zoom !== undefined) options.zoom = zoom;
         this.map.flyTo(options);
         return { success: true, center, zoom: zoom ?? this.map.getZoom() };
+    }
+
+    /**
+     * Tilt the camera to a pitch (degrees), clamped to the map's maxPitch.
+     * @param {number} pitch
+     * @param {{animate?: boolean}} [opts]
+     * @returns {number} the applied pitch
+     */
+    setPitch(pitch, { animate = true } = {}) {
+        const maxPitch = (typeof this.map.getMaxPitch === 'function' ? this.map.getMaxPitch() : 75);
+        const p = Math.max(0, Math.min(Number(pitch) || 0, maxPitch));
+        if (animate && typeof this.map.easeTo === 'function') {
+            this.map.easeTo({ pitch: p, duration: 600 });
+        } else if (typeof this.map.setPitch === 'function') {
+            this.map.setPitch(p);
+        } else if (typeof this.map.jumpTo === 'function') {
+            this.map.jumpTo({ pitch: p });
+        }
+        return p;
+    }
+
+    /**
+     * Tilt to a 3D-friendly pitch when adding an extruded layer — but only if
+     * the map is still (near) flat, so a pitch the user already dialed in is
+     * left alone. Default 45°.
+     */
+    tiltForExtrusion(pitch = 45) {
+        const current = (typeof this.map.getPitch === 'function') ? this.map.getPitch() : 0;
+        if (current > 1) return current;
+        return this.setPitch(pitch);
     }
 
     getMapState() {

--- a/app/map-tools.js
+++ b/app/map-tools.js
@@ -474,6 +474,7 @@ Flow:
 Optional inputs:
   - value_column          which value_columns entry to color by (default: first; "count" for agg=COUNT)
   - palette / opacity / display_name / fit_bounds    styling (see below)
+  - extrude               true → 3D extruded hexes (value → height + color) and a tilted camera (default false)
   - value_stats / bounds / layer_name    accepted as explicit overrides, but normally OMIT — they are fetched
   - format                ← format ("geojson" or "vector"; defaults to "vector")
   - geojson_url           ← geojson_url (REQUIRED when format="geojson"; ignored otherwise)
@@ -514,6 +515,8 @@ The returned layer_id can be used with show_layer / hide_layer / set_style / set
                     },
                     opacity: { type: 'number', description: 'Fill opacity 0..1 (default 0.7)' },
                     fit_bounds: { type: 'boolean', description: 'Fly the camera to fit bounds (default true)' },
+                    extrude: { type: 'boolean', description: 'Render as 3D extruded hexes — value encoded as height as well as color — and tilt the camera. Default false (flat 2D fill). Use when the user asks for a 3D / extruded / "height" view.' },
+                    extrude_max_height: { type: 'number', description: 'Optional height (metres) of the tallest hex when extrude=true. Omit for an auto default scaled to the data extent.' },
                 },
                 required: ['tile_url'],
             },
@@ -533,6 +536,8 @@ The returned layer_id can be used with show_layer / hide_layer / set_style / set
                     layerName: meta.layerName,
                     format: args.format,
                     geojsonUrl: args.geojson_url,
+                    extrude: args.extrude === true,
+                    extrudeMaxHeight: args.extrude_max_height,
                 });
                 return JSON.stringify(result);
             },

--- a/test/hex-layer-helpers.test.js
+++ b/test/hex-layer-helpers.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { extractHashFromUrl, rewriteValueColumn, metadataUrlFromTileUrl } from '../app/hex-layer-helpers.js';
+import { extractHashFromUrl, rewriteValueColumn, metadataUrlFromTileUrl, buildHeightExpression, buildFlatHeightExpression, defaultExtrusionMaxHeight } from '../app/hex-layer-helpers.js';
 
 describe('extractHashFromUrl', () => {
   it('extracts hash from a valid MCP tile URL template', () => {
@@ -208,5 +208,69 @@ describe('metadataUrlFromTileUrl (#276)', () => {
   it('returns null for non-string input', () => {
     expect(metadataUrlFromTileUrl(null)).toBeNull();
     expect(metadataUrlFromTileUrl(undefined)).toBeNull();
+  });
+});
+
+describe('buildHeightExpression (#317)', () => {
+  it('mirrors the color match: per-res interpolate onto [0, maxHeight]', () => {
+    const stats = { by_res: { '3': { min: 1, max: 100 }, '4': { min: 1, max: 20 } } };
+    const expr = buildHeightExpression('count', stats, 1000);
+
+    expect(expr[0]).toBe('case');
+    expect(expr[1]).toEqual(['==', ['get', 'count'], null]);
+    expect(expr[2]).toBe(0); // null value → zero height
+
+    const match = expr[3];
+    expect(match[0]).toBe('match');
+    expect(match[1]).toEqual(['get', 'res']);
+    expect(match[2]).toBe(3);
+    expect(match[3]).toEqual(['interpolate', ['linear'], ['get', 'count'], 1, 0, 100, 1000]);
+    expect(match[4]).toBe(4);
+    expect(match[5]).toEqual(['interpolate', ['linear'], ['get', 'count'], 1, 0, 20, 1000]);
+    expect(match).toHaveLength(7);
+    expect(match[6]).toBe(0); // unknown res → zero height
+  });
+
+  it('collapses a min == max resolution to half height', () => {
+    const stats = { by_res: { '5': { min: 1, max: 1 } } };
+    const match = buildHeightExpression('count', stats, 1000)[3];
+    expect(match[3]).toBe(500);
+  });
+
+  it('throws when by_res is empty', () => {
+    expect(() => buildHeightExpression('count', { by_res: {} }, 1000)).toThrow();
+  });
+});
+
+describe('buildFlatHeightExpression (#317)', () => {
+  it('interpolates a single domain onto [0, maxHeight]', () => {
+    const expr = buildFlatHeightExpression('count', { min: 0, max: 50 }, 800);
+    expect(expr[0]).toBe('case');
+    expect(expr[2]).toBe(0);
+    expect(expr[3]).toEqual(['interpolate', ['linear'], ['get', 'count'], 0, 0, 50, 800]);
+  });
+
+  it('collapses min == max to half height', () => {
+    const expr = buildFlatHeightExpression('count', { min: 5, max: 5 }, 800);
+    expect(expr[3]).toBe(400);
+  });
+});
+
+describe('defaultExtrusionMaxHeight (#317)', () => {
+  it('scales to ~8% of the smaller ground span', () => {
+    // ~1° lat ≈ 110.54 km; a 1°×1° box near the equator → span ~110 km → ~8.8 km.
+    const h = defaultExtrusionMaxHeight([0, 0, 1, 1]);
+    expect(h).toBeGreaterThan(8000);
+    expect(h).toBeLessThan(10000);
+  });
+
+  it('falls back to a fixed height for unusable bounds', () => {
+    expect(defaultExtrusionMaxHeight(null)).toBe(50000);
+    expect(defaultExtrusionMaxHeight([0, 0, 1])).toBe(50000);
+    expect(defaultExtrusionMaxHeight([0, 0, 'x', 1])).toBe(50000);
+  });
+
+  it('never returns below the 1 km floor for a tiny extent', () => {
+    expect(defaultExtrusionMaxHeight([0, 0, 0.0001, 0.0001])).toBe(1000);
   });
 });

--- a/test/map-manager.hex.test.js
+++ b/test/map-manager.hex.test.js
@@ -35,10 +35,16 @@ function createMockMap() {
         on() {},
         off() {},
         fitBounds(bounds, options) { fitBoundsCalls.push({ bounds, options }); },
+        // Camera (pitch) — records tilts for extrusion assertions
+        getPitch() { return this._pitch; },
+        getMaxPitch() { return 75; },
+        easeTo(opts) { this._easeToCalls.push(opts); if (opts.pitch != null) this._pitch = opts.pitch; },
         // Introspection helpers (not real MapLibre API)
         _sources: sources,
         _layers: layers,
         _fitBoundsCalls: fitBoundsCalls,
+        _pitch: 0,
+        _easeToCalls: [],
     };
 }
 
@@ -91,6 +97,81 @@ describe('MapManager.addHexTileLayer', () => {
         expect(mm.layers.get('hex-abc123').displayName).toBe('Density');
         expect(mm.layers.get('hex-abc123').type).toBe('vector');
         expect(mm.layers.get('hex-abc123').sourceLayer).toBe('layer');
+    });
+
+    it('renders a fill-extrusion layer and tilts the camera when extrude=true (#317)', () => {
+        const result = mm.addHexTileLayer({
+            tileUrl: 'https://example.com/tiles/hex/e3d/{z}/{x}/{y}.pbf',
+            valueColumn: 'count',
+            valueStats: { by_res: { '6': { min: 0, max: 100 } } },
+            bounds: [-125, 31, -102, 49],
+            palette: 'viridis',
+            opacity: 0.7,
+            displayName: '3D',
+            fitBounds: false,
+            extrude: true,
+        });
+        expect(result.success).toBe(true);
+
+        const layer = mm.map._layers.get('hex-e3d');
+        expect(layer.type).toBe('fill-extrusion');
+        expect(layer.paint['fill-extrusion-color']).toBeDefined();
+        expect(layer.paint['fill-extrusion-height']).toBeDefined();
+        expect(layer.paint['fill-extrusion-base']).toBe(0);
+        expect(layer.paint['fill-color']).toBeUndefined();
+
+        expect(mm.layers.get('hex-e3d').extruded).toBe(true);
+        // Camera tilted off flat
+        expect(mm.map._easeToCalls.length).toBe(1);
+        expect(mm.map._easeToCalls[0].pitch).toBe(45);
+    });
+
+    it('honors an explicit extrude_max_height at the top of the ramp (#317)', () => {
+        mm.addHexTileLayer({
+            tileUrl: 'https://example.com/tiles/hex/eh/{z}/{x}/{y}.pbf',
+            valueColumn: 'count',
+            valueStats: { by_res: { '6': { min: 0, max: 100 } } },
+            bounds: [0, 0, 1, 1],
+            palette: 'viridis',
+            opacity: 0.7,
+            displayName: '3D',
+            fitBounds: false,
+            extrude: true,
+            extrudeMaxHeight: 2500,
+        });
+        const height = mm.map._layers.get('hex-eh').paint['fill-extrusion-height'];
+        // case → match → res 6 branch → interpolate ... max stop → 2500
+        const branch = height[3][3];
+        expect(branch[branch.length - 1]).toBe(2500);
+    });
+
+    it('leaves an already-tilted camera alone when adding an extruded layer (#317)', () => {
+        mm.map._pitch = 30; // user already tilted
+        mm.addHexTileLayer({
+            tileUrl: 'https://example.com/tiles/hex/tilted/{z}/{x}/{y}.pbf',
+            valueColumn: 'count',
+            valueStats: { by_res: { '6': { min: 0, max: 100 } } },
+            bounds: [0, 0, 1, 1],
+            palette: 'viridis', opacity: 0.7, displayName: '3D', fitBounds: false,
+            extrude: true,
+        });
+        expect(mm.map._easeToCalls.length).toBe(0);
+    });
+
+    it('does not tilt or extrude by default', () => {
+        mm.addHexTileLayer({
+            tileUrl: 'https://example.com/tiles/hex/flat/{z}/{x}/{y}.pbf',
+            valueColumn: 'count',
+            valueStats: { by_res: { '6': { min: 0, max: 100 } } },
+            bounds: [0, 0, 1, 1],
+            palette: 'viridis',
+            opacity: 0.7,
+            displayName: 'flat',
+            fitBounds: false,
+        });
+        expect(mm.map._layers.get('hex-flat').type).toBe('fill');
+        expect(mm.layers.get('hex-flat').extruded).toBe(false);
+        expect(mm.map._easeToCalls.length).toBe(0);
     });
 
     it('defaults source-layer to "layer" when layerName is omitted', () => {


### PR DESCRIPTION
Closes #317.

## Change
Adds an `extrude` opt-in to `add_hex_tile_layer` that renders hex layers as MapLibre `fill-extrusion` — value encoded as **height** as well as color — and tilts the camera so the 3D reads.

Per the design decision, the client **builds the height expression itself** (the same approach it already takes for color) rather than parsing mcp-data-server's `fill-extrusion` recipe. This keeps a single code path and avoids a new dependency on the recipe shape the client doesn't currently read.

### `hex-layer-helpers.js`
- `buildHeightExpression(valueColumn, valueStats, maxHeight)` mirrors `buildFillColorExpression`: a per-`res` `match` whose branches interpolate each resolution's domain onto `[0, maxHeight]`, so height and hue encode the same value over the same domain. Null → 0, collapsed range → half height, unknown res → 0.
- `buildFlatHeightExpression` is the GeoJSON (single-resolution) analogue.
- `defaultExtrusionMaxHeight(bounds)` picks a sensible default: ~8% of the bounding box's smaller ground span (so towers are visible on a regional map without dwarfing it or vanishing on a global one), with a fixed fallback for unusable bounds and a 1 km floor.

### `map-manager.js`
- `addHexTileLayer` honors `extrude` / `extrudeMaxHeight`: emits a `fill-extrusion` layer with `fill-extrusion-color`/`-height`/`-base`/`-opacity` (note: extrusion has no outline property) and records `extruded` on the layer state.
- New `setPitch(pitch, {animate})` (clamped to `maxPitch`) and `tiltForExtrusion(45)` — the tilt fires **only when the map is still flat**, so a pitch the user already set is left alone.

### `map-tools.js`
- `extrude` (bool) and `extrude_max_height` (metres) args on `add_hex_tile_layer`, plus a description line steering the model to use it when the user asks for a 3D / extruded / height view.

## Known limitation (follow-up)
`set_style`'s `rewriteValueColumn` targets `fill-color`, so recoloring an *extruded* layer through the LLM won't repoint `fill-extrusion-color`. Out of scope here; noted for a follow-up.

## Testing
- `test/hex-layer-helpers.test.js` (+ height builders, default-height scaling/fallback/floor).
- `test/map-manager.hex.test.js` (+ extrusion layer type & paint, custom max height at ramp top, camera tilt from flat, respects an existing user pitch, flat-by-default).
- Full suite green (528 passed).
- `map-manager.js` is browser-bound; **visual check on a deployed app recommended** (extruded hexes + tilt, and that height tracks value across zoom/resolution).