### PR TITLE
feat(upload): opt-in GeoJSON upload as an agent-addressable layer (#325)

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -158,6 +158,26 @@ async function main() {
         }
     }
 
+    /* ── 3c-bis. GeoJSON upload (optional — requires upload_enabled) ─── */
+    // Off by default. `upload_enabled: true` uses defaults; an object customizes
+    // the bucket/prefix/caps/ingest link (see upload-manager.js). The upload
+    // goes browser → S3 directly; only the resulting URL reaches the agent, via
+    // the get_uploaded_dataset tool below (geo-agent#325).
+    let uploadManager = null;
+    if (appConfig.upload_enabled) {
+        try {
+            const { UploadManager } = await import('./upload-manager.js');
+            const uploadCfg = (appConfig.upload_enabled && typeof appConfig.upload_enabled === 'object')
+                ? appConfig.upload_enabled
+                : (appConfig.upload || {});
+            uploadManager = new UploadManager(mapManager, uploadCfg);
+            uploadManager.init();
+            console.log('[main] Upload tool ready');
+        } catch (err) {
+            console.warn('[main] Failed to load upload module:', err.message);
+        }
+    }
+
     /* ── 3d. Geolocation (optional — "where am I?") ──────────────────── */
     // Two independently opt-in surfaces, both off by default:
     //   • locate-me button (UI)        — geolocate.button
@@ -264,6 +284,47 @@ async function main() {
                     hint: 'To filter by this region, UNNEST h3_polygon_wkt_to_cells(wkt, resolution) and JOIN on the dataset H3 column. ' +
                           'Example: FROM UNNEST(h3_polygon_wkt_to_cells(\'<wkt>\', <res>)) AS t(cell) JOIN data ON data.h3_col = t.cell. ' +
                           'suggested_h3_resolution is a ceiling — pick the dataset H3 column closest to but not exceeding it.',
+                });
+            },
+        });
+    }
+
+    // Register uploaded-dataset tool (if upload is enabled and loaded). Returns
+    // only the S3 URL(s) of user-uploaded boundaries — the geometry itself never
+    // enters the model's context. The agent reads the file server-side via the
+    // spatial `query` tool and uses it as a mask (geo-agent#325).
+    if (uploadManager) {
+        toolRegistry.registerLocal({
+            name: 'get_uploaded_dataset',
+            description:
+                'Get the polygon boundary/boundaries the user uploaded to the map, as public GeoJSON URL(s). ' +
+                'The agent does NOT receive the geometry — read it server-side in the query tool with ' +
+                'ST_Read(url) and use it as an area-of-interest mask. ' +
+                'Call this when the user refers to "the uploaded file", "my boundary", "the shape I added", ' +
+                '"this area", or asks a spatial question about an uploaded region. Returns success:false if nothing is uploaded.',
+            inputSchema: { type: 'object', properties: {} },
+            execute: () => {
+                const uploads = uploadManager.getUploads();
+                if (!uploads.length) {
+                    return JSON.stringify({ success: false, error: 'No uploaded dataset. Ask the user to upload a polygon GeoJSON first.' });
+                }
+                return JSON.stringify({
+                    success: true,
+                    datasets: uploads.map(u => ({
+                        url: u.url,
+                        display_name: u.displayName,
+                        geometry_type: u.geometryType,
+                        feature_count: u.featureCount,
+                        property_keys: u.propertyKeys,
+                    })),
+                    hint:
+                        "Read a boundary server-side, never inline its geometry. For a spatial mask: " +
+                        "WITH aoi AS (SELECT ST_Union_Agg(geom) AS g FROM ST_Read('<url>')) " +
+                        "SELECT ... FROM data, aoi WHERE ST_Within(data.geom, aoi.g). " +
+                        "For an H3-indexed dataset, convert once to cells and JOIN: " +
+                        "WITH aoi AS (SELECT ST_AsText(ST_Union_Agg(geom)) AS wkt FROM ST_Read('<url>')) " +
+                        "SELECT d.* FROM aoi, UNNEST(h3_polygon_wkt_to_cells(aoi.wkt, <res>)) AS t(cell) JOIN data d ON d.<h3_col> = t.cell. " +
+                        "Pick <res> to keep cell counts reasonable (coarser for large areas).",
                 });
             },
         });
@@ -417,6 +478,23 @@ async function main() {
             replaceDrawMessage(
                 '[The user has cleared the drawn region from the map.]',
             );
+        });
+    }
+
+    // Upload event → chat notification + a nudge so the agent knows an
+    // uploaded boundary is available (it fetches the URL via get_uploaded_dataset).
+    if (uploadManager) {
+        window.addEventListener('geojson-uploaded', (e) => {
+            const name = e.detail?.displayName || 'a boundary';
+            ui.addMessage('system', `Uploaded "${name}" to the map. Ask me anything about this area.`);
+            agent.messages.push({
+                role: 'user',
+                content: '[The user has uploaded a polygon boundary to the map. ' +
+                    'Use the get_uploaded_dataset tool to retrieve its URL when answering spatial queries about this area.]',
+            });
+        });
+        window.addEventListener('geojson-upload-error', (e) => {
+            ui.addMessage('system', `Upload failed: ${e.detail?.message || 'unknown error'}`);
         });
     }
 

--- a/app/map-manager.js
+++ b/app/map-manager.js
@@ -601,6 +601,130 @@ export class MapManager {
         return { success: true, layer: layerId, displayName: state.displayName, visible: false };
     }
 
+    // ---- Uploaded Layers (client-side GeoJSON, opt-in — see upload-manager.js) ----
+
+    /**
+     * Add a user-uploaded GeoJSON polygon layer from an in-memory FeatureCollection.
+     *
+     * Unlike catalog and hex layers, the geometry lives inline in the map's
+     * `geojson` source (no tiles, no remote fetch on render) — the file was
+     * already parsed client-side. The parallel copy in S3 is what the agent
+     * queries; this method only draws it. Idempotent by id.
+     *
+     * @param {Object} opts
+     * @param {string} opts.id - stable id (content hash); layerId becomes `upload-<id>`
+     * @param {Object} opts.geojson - parsed GeoJSON FeatureCollection/Feature (inline data)
+     * @param {string} opts.displayName
+     * @param {string} [opts.fillColor='#3b82f6']
+     * @param {string} [opts.outlineColor='#1e3a8a']
+     * @param {number} [opts.opacity=0.35]
+     * @param {string[]} [opts.tooltipFields] - feature property keys to show on hover
+     * @param {[number,number,number,number]} [opts.bounds] - [w,s,e,n] for fitBounds
+     * @param {boolean} [opts.fitBounds=true]
+     * @returns {{success: boolean, layer_id?: string, already_exists?: boolean, error?: string}}
+     */
+    addUploadedLayer(opts) {
+        const {
+            id, geojson, displayName,
+            fillColor = '#3b82f6', outlineColor = '#1e3a8a', opacity = 0.35,
+            tooltipFields = null, bounds, fitBounds = true,
+        } = opts;
+
+        if (!id) return { success: false, error: 'addUploadedLayer requires an id' };
+        if (!geojson || typeof geojson !== 'object') {
+            return { success: false, error: 'addUploadedLayer requires a parsed geojson object' };
+        }
+        const layerId = `upload-${id}`;
+        const outlineLayerId = `${layerId}-outline`;
+
+        // Idempotency: same content hash → same layer → no re-add.
+        if (this.layers.has(layerId)) {
+            const state = this.layers.get(layerId);
+            return { success: true, layer_id: layerId, display_name: state.displayName, already_exists: true };
+        }
+
+        this.map.addSource(layerId, { type: 'geojson', data: geojson });
+        this.map.addLayer({
+            id: layerId,
+            type: 'fill',
+            source: layerId,
+            layout: { visibility: 'visible' },
+            paint: { 'fill-color': fillColor, 'fill-opacity': opacity },
+        });
+        this.map.addLayer({
+            id: outlineLayerId,
+            type: 'line',
+            source: layerId,
+            layout: { visibility: 'visible' },
+            paint: { 'line-color': outlineColor, 'line-width': 1.5 },
+        });
+
+        this.layers.set(layerId, {
+            layerId,
+            mapLayerId: layerId,
+            outlineLayerId,
+            sourceId: layerId,
+            datasetId: null,
+            group: null,
+            groupCollapsed: false,
+            displayName,
+            type: 'vector',
+            sourceLayer: null,
+            columns: [],
+            visible: true,
+            filter: null,
+            defaultFilter: null,
+            defaultPaint: { 'fill-color': fillColor, 'fill-opacity': opacity },
+            tooltipFields,
+            defaultTooltipFields: tooltipFields,
+            colormap: null,
+            rescale: null,
+            legendLabel: null,
+            legendType: null,
+            legendClasses: null,
+        });
+
+        this._wireTooltip(layerId, layerId);
+        this._addLayerControl(layerId);
+
+        if (fitBounds && Array.isArray(bounds) && bounds.length === 4) {
+            const [w, s, e, n] = bounds;
+            this.map.fitBounds([[w, s], [e, n]], { padding: 40, duration: 800 });
+        }
+
+        return { success: true, layer_id: layerId, display_name: displayName, already_exists: false };
+    }
+
+    /**
+     * Remove a user-uploaded layer previously added via addUploadedLayer.
+     * Refuses any layer_id not starting with `upload-` so curated/hex layers
+     * can't be destroyed through this path. Mirrors removeHexTileLayer.
+     *
+     * @param {string} layerId - e.g. "upload-abc123"
+     * @returns {{success: boolean, layer_id?: string, error?: string}}
+     */
+    removeUploadedLayer(layerId) {
+        if (typeof layerId !== 'string' || !layerId.startsWith('upload-')) {
+            return { success: false, error: `layer_id '${layerId}' is not an uploaded layer (must start with 'upload-')` };
+        }
+        const state = this.layers.get(layerId);
+        if (!state) {
+            const uploads = [...this.layers.keys()].filter(id => id.startsWith('upload-'));
+            return { success: false, error: `Unknown uploaded layer '${layerId}'. Registered: [${uploads.join(', ')}]` };
+        }
+        if (state.outlineLayerId && this.map.getLayer(state.outlineLayerId)) this.map.removeLayer(state.outlineLayerId);
+        if (this.map.getLayer(layerId)) this.map.removeLayer(layerId);
+        if (this.map.getSource(layerId)) this.map.removeSource(layerId);
+        this.layers.delete(layerId);
+
+        if (this._controlsContainerEl) {
+            const item = this._controlsContainerEl.querySelector(`#layer-item-${layerId.replace(/\//g, '-')}`);
+            if (item) item.remove();
+            this._refreshCycleBtnState();
+        }
+        return { success: true, layer_id: layerId };
+    }
+
     // ---- Hex Tile Layers (dynamic MVT from MCP register_hex_tiles) ----
 
     /**
@@ -1447,10 +1571,13 @@ export class MapManager {
             wrapper.appendChild(select);
         }
 
-        // Remove button — only for dynamically-added hex layers, which have a
-        // backing removeHexTileLayer(). Curated layers can't be removed (only
-        // hidden), so they get no button.
-        if (layerId.startsWith('hex-')) {
+        // Remove button — only for dynamically-added layers that have a backing
+        // remove method: hex layers (removeHexTileLayer) and uploaded layers
+        // (removeUploadedLayer). Curated layers can't be removed (only hidden),
+        // so they get no button.
+        const isHex = layerId.startsWith('hex-');
+        const isUpload = layerId.startsWith('upload-');
+        if (isHex || isUpload) {
             wrapper.classList.add('has-remove');
             const removeBtn = document.createElement('button');
             removeBtn.className = 'layer-remove-btn';
@@ -1460,7 +1587,8 @@ export class MapManager {
             removeBtn.textContent = '×';
             removeBtn.addEventListener('click', (e) => {
                 e.preventDefault();
-                this.removeHexTileLayer(layerId);
+                if (isHex) this.removeHexTileLayer(layerId);
+                else this.removeUploadedLayer(layerId);
             });
             wrapper.appendChild(removeBtn);
         }

--- a/app/style.css
+++ b/app/style.css
@@ -272,6 +272,46 @@ details.layer-group:not([open]) .layer-group-title::before {
     cursor: pointer;
 }
 
+/* Uploaded-GeoJSON control (opt-in — see upload-manager.js) */
+.upload-btn {
+    display: block;
+    width: 100%;
+    margin: 4px 0 6px;
+    padding: 5px 8px;
+    font-size: 12px;
+    color: #404040;
+    background: rgba(0, 0, 0, 0.03);
+    border: 1px dashed rgba(0, 0, 0, 0.25);
+    border-radius: 4px;
+    cursor: pointer;
+}
+
+.upload-btn:hover {
+    background: rgba(0, 0, 0, 0.06);
+    border-color: rgba(0, 0, 0, 0.4);
+}
+
+.upload-status {
+    font-size: 11px;
+    color: #606060;
+    margin: 0 0 6px;
+    min-height: 0;
+    line-height: 1.35;
+}
+
+.upload-status:empty {
+    display: none;
+}
+
+.upload-status.is-error {
+    color: #c0392b;
+}
+
+.upload-dragover {
+    outline: 3px dashed rgba(59, 130, 246, 0.7);
+    outline-offset: -3px;
+}
+
 .layer-toggle input[type="checkbox"] {
     margin: 0 6px 0 0;
     cursor: pointer;

--- a/app/upload-manager.js
+++ b/app/upload-manager.js
@@ -1,0 +1,262 @@
+/**
+ * UploadManager — user-uploaded GeoJSON polygons as agent-addressable layers
+ *
+ * Opt-in only (never loaded unless `upload_enabled` is set in config). Lets a
+ * user drop a small polygon GeoJSON on the map. The file is:
+ *   1. parsed + validated + size/feature-capped entirely in the browser,
+ *   2. PUT directly to the public-output S3 bucket (browser → S3, a plain
+ *      fetch PUT — NOT an SDK chunked upload, which the anonymous endpoint
+ *      corrupts), and
+ *   3. drawn inline on the map.
+ *
+ * The upload payload never passes through the LLM — only the resulting URL is
+ * exposed to the agent (via the `get_uploaded_dataset` tool wired in main.js),
+ * which reads it back with DuckDB `ST_Read(...)` in the existing `query` tool.
+ * See geo-agent#325. Large/complex/non-polygon data is out of scope by design;
+ * the size cap steers those users to a data-ingest request.
+ */
+
+const DEFAULTS = {
+    bucketUrl: 'https://s3-west.nrp-nautilus.io/public-output',
+    prefix: 'uploads',
+    maxBytes: 5 * 1024 * 1024, // 5 MB — inline geojson stays snappy below this
+    maxFeatures: 1000,
+    ingestUrl: null,
+};
+
+/* ── Pure helpers (unit-tested in test/upload-manager.test.js) ─────────────── */
+
+/**
+ * Validate that a parsed object is a polygon GeoJSON within limits.
+ * @returns {{ok: boolean, error?: string, features?: Array, geometryTypes?: string[]}}
+ */
+export function validatePolygonGeoJSON(obj, { maxFeatures = DEFAULTS.maxFeatures } = {}) {
+    if (!obj || typeof obj !== 'object') return { ok: false, error: 'Not valid JSON.' };
+    let features;
+    if (obj.type === 'FeatureCollection') features = Array.isArray(obj.features) ? obj.features : [];
+    else if (obj.type === 'Feature') features = [obj];
+    else return { ok: false, error: 'Expected a GeoJSON Feature or FeatureCollection.' };
+
+    if (features.length === 0) return { ok: false, error: 'GeoJSON contains no features.' };
+    if (features.length > maxFeatures) {
+        return { ok: false, error: `Too many features (${features.length} > ${maxFeatures}). Please file a data-ingest request for large datasets.` };
+    }
+
+    const geometryTypes = [];
+    for (const f of features) {
+        const t = f?.geometry?.type;
+        if (!t) return { ok: false, error: 'A feature is missing geometry.' };
+        if (t !== 'Polygon' && t !== 'MultiPolygon') {
+            return { ok: false, error: `Only Polygon/MultiPolygon boundaries are supported here (found ${t}). File a data-ingest request for other data.` };
+        }
+        if (!geometryTypes.includes(t)) geometryTypes.push(t);
+    }
+    return { ok: true, features, geometryTypes };
+}
+
+/**
+ * Compute [w, s, e, n] bounds over all coordinates of a polygon GeoJSON.
+ * @returns {[number,number,number,number]|null}
+ */
+export function computeBounds(geojson) {
+    let w = Infinity, s = Infinity, e = -Infinity, n = -Infinity;
+    const visit = (coords) => {
+        if (typeof coords[0] === 'number') {
+            const [lon, lat] = coords;
+            if (lon < w) w = lon; if (lon > e) e = lon;
+            if (lat < s) s = lat; if (lat > n) n = lat;
+        } else {
+            for (const c of coords) visit(c);
+        }
+    };
+    const features = geojson.type === 'FeatureCollection' ? geojson.features : [geojson];
+    for (const f of features) {
+        if (f?.geometry?.coordinates) visit(f.geometry.coordinates);
+    }
+    return Number.isFinite(w) ? [w, s, e, n] : null;
+}
+
+/**
+ * Union of property keys across features, capped, for hover tooltips.
+ * @returns {string[]}
+ */
+export function pickTooltipFields(features, max = 8) {
+    const keys = [];
+    for (const f of features) {
+        const props = f?.properties;
+        if (!props || typeof props !== 'object') continue;
+        for (const k of Object.keys(props)) {
+            if (!keys.includes(k)) keys.push(k);
+            if (keys.length >= max) return keys;
+        }
+    }
+    return keys;
+}
+
+/** Public object URL for an uploaded file. */
+export function buildObjectUrl(bucketUrl, prefix, hash) {
+    return `${bucketUrl.replace(/\/$/, '')}/${prefix}/${hash}/data.geojson`;
+}
+
+/** SHA-256 → first 16 hex chars, a short content-addressed id. */
+export async function contentHash(text) {
+    const bytes = new TextEncoder().encode(text);
+    const digest = await crypto.subtle.digest('SHA-256', bytes);
+    const hex = [...new Uint8Array(digest)].map(b => b.toString(16).padStart(2, '0')).join('');
+    return hex.slice(0, 16);
+}
+
+/* ── DOM / network glue (browser-only, verified manually) ──────────────────── */
+
+export class UploadManager {
+    /**
+     * @param {import('./map-manager.js').MapManager} mapManager
+     * @param {Object} [config] - options object (or {} for defaults)
+     */
+    constructor(mapManager, config = {}) {
+        this.mapManager = mapManager;
+        this.map = mapManager.map;
+        this.cfg = {
+            bucketUrl: config.bucket_url || DEFAULTS.bucketUrl,
+            prefix: config.prefix || DEFAULTS.prefix,
+            maxBytes: config.max_bytes || DEFAULTS.maxBytes,
+            maxFeatures: config.max_features || DEFAULTS.maxFeatures,
+            ingestUrl: config.ingest_url || DEFAULTS.ingestUrl,
+        };
+        /** @type {Array<{url,layerId,displayName,geometryType,propertyKeys,featureCount}>} */
+        this.uploads = [];
+        this._input = null;
+    }
+
+    /** Inject the upload button + hidden file input, and wire map drag-drop. */
+    init() {
+        const controls = document.getElementById('layer-controls-container');
+        if (!controls || !controls.parentNode) {
+            console.warn('[upload] layer panel not found — upload UI not mounted');
+            return;
+        }
+
+        const input = document.createElement('input');
+        input.type = 'file';
+        input.accept = '.geojson,.json,application/geo+json,application/json';
+        input.style.display = 'none';
+        input.addEventListener('change', () => {
+            if (input.files && input.files[0]) this.handleFile(input.files[0]);
+            input.value = ''; // allow re-selecting the same file
+        });
+        this._input = input;
+
+        const btn = document.createElement('button');
+        btn.type = 'button';
+        btn.className = 'upload-btn';
+        btn.textContent = '+ Upload GeoJSON';
+        btn.title = 'Upload a polygon GeoJSON to show on the map and query';
+        btn.addEventListener('click', () => input.click());
+
+        this._status = document.createElement('div');
+        this._status.className = 'upload-status';
+
+        // Sit just above the layer list, inside the Overlays section.
+        controls.parentNode.insertBefore(btn, controls);
+        controls.parentNode.insertBefore(input, controls);
+        controls.parentNode.insertBefore(this._status, controls);
+
+        this._wireDragDrop();
+        console.log('[upload] ready');
+    }
+
+    _wireDragDrop() {
+        const el = this.map.getContainer();
+        const stop = (e) => { e.preventDefault(); e.stopPropagation(); };
+        el.addEventListener('dragover', (e) => {
+            if (e.dataTransfer && [...e.dataTransfer.types].includes('Files')) { stop(e); el.classList.add('upload-dragover'); }
+        });
+        el.addEventListener('dragleave', () => el.classList.remove('upload-dragover'));
+        el.addEventListener('drop', (e) => {
+            if (!e.dataTransfer || !e.dataTransfer.files || !e.dataTransfer.files.length) return;
+            stop(e);
+            el.classList.remove('upload-dragover');
+            this.handleFile(e.dataTransfer.files[0]);
+        });
+    }
+
+    _setStatus(msg, isError = false) {
+        if (this._status) {
+            this._status.textContent = msg;
+            this._status.classList.toggle('is-error', isError);
+        }
+        if (isError) console.warn('[upload]', msg); else console.log('[upload]', msg);
+    }
+
+    _fail(msg) {
+        this._setStatus(msg, true);
+        window.dispatchEvent(new CustomEvent('geojson-upload-error', { detail: { message: msg } }));
+        return { success: false, error: msg };
+    }
+
+    /**
+     * Parse → validate → hash → PUT to S3 → draw → announce.
+     * @param {File} file
+     */
+    async handleFile(file) {
+        if (file.size > this.cfg.maxBytes) {
+            const mb = (this.cfg.maxBytes / 1024 / 1024).toFixed(0);
+            return this._fail(
+                `File is too large (${(file.size / 1024 / 1024).toFixed(1)} MB > ${mb} MB limit). ` +
+                (this.cfg.ingestUrl ? `Please file a data-ingest request: ${this.cfg.ingestUrl}` : 'Please file a data-ingest request for large datasets.'),
+            );
+        }
+
+        let text;
+        try { text = await file.text(); } catch { return this._fail('Could not read the file.'); }
+
+        let parsed;
+        try { parsed = JSON.parse(text); } catch { return this._fail('File is not valid JSON/GeoJSON.'); }
+
+        const v = validatePolygonGeoJSON(parsed, { maxFeatures: this.cfg.maxFeatures });
+        if (!v.ok) return this._fail(v.error);
+
+        this._setStatus(`Uploading "${file.name}"…`);
+        const hash = await contentHash(text);
+        const url = buildObjectUrl(this.cfg.bucketUrl, this.cfg.prefix, hash);
+
+        try {
+            const res = await fetch(url, {
+                method: 'PUT',
+                headers: { 'Content-Type': 'application/geo+json' },
+                body: text, // plain PUT — anonymous endpoint corrupts SDK-chunked bodies
+            });
+            if (!res.ok) return this._fail(`Upload failed (HTTP ${res.status}).`);
+        } catch (err) {
+            return this._fail(`Upload failed: ${err.message}`);
+        }
+
+        const displayName = file.name.replace(/\.(geo)?json$/i, '') || 'Uploaded layer';
+        const bounds = computeBounds(parsed);
+        const propertyKeys = pickTooltipFields(v.features);
+
+        const added = this.mapManager.addUploadedLayer({
+            id: hash, geojson: parsed, displayName, tooltipFields: propertyKeys, bounds,
+        });
+        if (!added.success) return this._fail(added.error || 'Could not add layer to map.');
+
+        const record = {
+            url, layerId: added.layer_id, displayName,
+            geometryType: v.geometryTypes.join('+'),
+            propertyKeys, featureCount: v.features.length,
+        };
+        // Keep one record per url (idempotent re-upload).
+        this.uploads = this.uploads.filter(u => u.url !== url);
+        this.uploads.push(record);
+
+        this._setStatus(`Added "${displayName}" (${record.featureCount} feature${record.featureCount === 1 ? '' : 's'}).`);
+        window.dispatchEvent(new CustomEvent('geojson-uploaded', { detail: record }));
+        return { success: true, ...record };
+    }
+
+    /** All uploaded datasets, most recent last. */
+    getUploads() { return this.uploads.slice(); }
+
+    /** Most recently uploaded dataset, or null. */
+    getLatest() { return this.uploads.length ? this.uploads[this.uploads.length - 1] : null; }
+}

--- a/app/upload-manager.js
+++ b/app/upload-manager.js
@@ -156,10 +156,9 @@ export class UploadManager {
         this._status = document.createElement('div');
         this._status.className = 'upload-status';
 
-        // Sit just above the layer list, inside the Overlays section.
-        controls.parentNode.insertBefore(btn, controls);
-        controls.parentNode.insertBefore(input, controls);
-        controls.parentNode.insertBefore(this._status, controls);
+        // Sit at the bottom of the Overlays section, below the layer list
+        // (uploaded rows append into the list above, so the button stays last).
+        controls.after(btn, input, this._status);
 
         this._wireDragDrop();
         console.log('[upload] ready');

--- a/test/map-manager.upload.test.js
+++ b/test/map-manager.upload.test.js
@@ -1,0 +1,108 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest';
+import { MapManager } from '../app/map-manager.js';
+
+/**
+ * Uploaded GeoJSON layers (geo-agent#325) are added at runtime like hex layers:
+ * an inline `geojson` source + fill + outline, a panel row with a remove button,
+ * and a guarded teardown. These pin that behavior with a minimal map stub.
+ */
+
+function createManager(layers = []) {
+    const calls = { addSource: [], addLayer: [], removeLayer: [], removeSource: [], fitBounds: [] };
+    // MapLibre namespaces layers and sources separately (a source and a layer
+    // may share an id, as they do here), so track them apart.
+    const layersPresent = new Set();
+    const sourcesPresent = new Set();
+    const mm = Object.create(MapManager.prototype);
+    mm.layers = new Map(layers);
+    mm._controlsContainerEl = document.createElement('div');
+    mm._refreshCycleBtnState = () => {};
+    mm._tooltip = document.createElement('div');
+    mm.map = {
+        addSource: (id, s) => { calls.addSource.push({ id, s }); sourcesPresent.add(id); },
+        addLayer: (def) => { calls.addLayer.push(def); layersPresent.add(def.id); },
+        removeLayer: (id) => { calls.removeLayer.push(id); layersPresent.delete(id); },
+        removeSource: (id) => { calls.removeSource.push(id); sourcesPresent.delete(id); },
+        getLayer: (id) => (layersPresent.has(id) ? { id } : undefined),
+        getSource: (id) => (sourcesPresent.has(id) ? { id } : undefined),
+        fitBounds: (b, o) => calls.fitBounds.push({ b, o }),
+        on: () => {},
+    };
+    return { mm, calls };
+}
+
+const FC = {
+    type: 'FeatureCollection',
+    features: [{
+        type: 'Feature', properties: { name: 'AOI' },
+        geometry: { type: 'Polygon', coordinates: [[[-1, -1], [1, -1], [1, 1], [-1, 1], [-1, -1]]] },
+    }],
+};
+
+describe('MapManager.addUploadedLayer', () => {
+    it('adds an inline geojson source, fill + outline, and a panel row', () => {
+        const { mm, calls } = createManager();
+        const r = mm.addUploadedLayer({ id: 'abc', geojson: FC, displayName: 'My AOI', bounds: [-1, -1, 1, 1] });
+
+        expect(r.success).toBe(true);
+        expect(r.layer_id).toBe('upload-abc');
+        // inline data, not a URL
+        expect(calls.addSource[0].s).toEqual({ type: 'geojson', data: FC });
+        const ids = calls.addLayer.map(l => l.id);
+        expect(ids).toEqual(['upload-abc', 'upload-abc-outline']);
+        expect(calls.addLayer[0].type).toBe('fill');
+        expect(calls.addLayer[1].type).toBe('line');
+        expect(calls.fitBounds).toHaveLength(1);
+
+        const state = mm.layers.get('upload-abc');
+        expect(state.type).toBe('vector');
+        expect(state.outlineLayerId).toBe('upload-abc-outline');
+        expect(state.tooltipFields).toBeNull(); // not passed → default null
+        const row = mm._controlsContainerEl.querySelector('#layer-item-upload-abc');
+        expect(row).not.toBeNull();
+        expect(row.querySelector('.layer-remove-btn')).not.toBeNull();
+    });
+
+    it('is idempotent by id', () => {
+        const { mm, calls } = createManager();
+        mm.addUploadedLayer({ id: 'abc', geojson: FC, displayName: 'A' });
+        const again = mm.addUploadedLayer({ id: 'abc', geojson: FC, displayName: 'A' });
+        expect(again.already_exists).toBe(true);
+        expect(calls.addSource).toHaveLength(1);
+    });
+
+    it('validates required inputs', () => {
+        const { mm } = createManager();
+        expect(mm.addUploadedLayer({ geojson: FC, displayName: 'x' }).success).toBe(false);
+        expect(mm.addUploadedLayer({ id: 'a', displayName: 'x' }).success).toBe(false);
+    });
+});
+
+describe('MapManager.removeUploadedLayer', () => {
+    it('tears down fill, outline, source, state, and panel row', () => {
+        const { mm, calls } = createManager();
+        mm.addUploadedLayer({ id: 'abc', geojson: FC, displayName: 'A' });
+        const r = mm.removeUploadedLayer('upload-abc');
+
+        expect(r.success).toBe(true);
+        expect(calls.removeLayer).toEqual(['upload-abc-outline', 'upload-abc']);
+        expect(calls.removeSource).toEqual(['upload-abc']);
+        expect(mm.layers.has('upload-abc')).toBe(false);
+        expect(mm._controlsContainerEl.querySelector('#layer-item-upload-abc')).toBeNull();
+    });
+
+    it('refuses non-upload ids so curated/hex layers are safe', () => {
+        const { mm } = createManager([['hex-x', { displayName: 'h', visible: true }]]);
+        expect(mm.removeUploadedLayer('hex-x').success).toBe(false);
+        expect(mm.removeUploadedLayer('cpad/holdings').success).toBe(false);
+    });
+
+    it('clicking the row remove button removes the uploaded layer', () => {
+        const { mm } = createManager();
+        mm.addUploadedLayer({ id: 'abc', geojson: FC, displayName: 'A' });
+        const row = mm._controlsContainerEl.querySelector('#layer-item-upload-abc');
+        row.querySelector('.layer-remove-btn').click();
+        expect(mm.layers.has('upload-abc')).toBe(false);
+    });
+});

--- a/test/upload-manager.test.js
+++ b/test/upload-manager.test.js
@@ -1,0 +1,112 @@
+import { describe, it, expect } from 'vitest';
+import {
+    validatePolygonGeoJSON,
+    computeBounds,
+    pickTooltipFields,
+    buildObjectUrl,
+    contentHash,
+} from '../app/upload-manager.js';
+
+const poly = (coords, props = {}) => ({
+    type: 'Feature', properties: props,
+    geometry: { type: 'Polygon', coordinates: coords },
+});
+const SQUARE = [[[-122.3, 37.8], [-122.2, 37.8], [-122.2, 37.9], [-122.3, 37.9], [-122.3, 37.8]]];
+
+describe('validatePolygonGeoJSON', () => {
+    it('accepts a FeatureCollection of polygons', () => {
+        const r = validatePolygonGeoJSON({ type: 'FeatureCollection', features: [poly(SQUARE)] });
+        expect(r.ok).toBe(true);
+        expect(r.geometryTypes).toEqual(['Polygon']);
+        expect(r.features).toHaveLength(1);
+    });
+
+    it('accepts a bare Feature and a MultiPolygon', () => {
+        expect(validatePolygonGeoJSON(poly(SQUARE)).ok).toBe(true);
+        const mp = { type: 'Feature', properties: {}, geometry: { type: 'MultiPolygon', coordinates: [SQUARE] } };
+        const r = validatePolygonGeoJSON(mp);
+        expect(r.ok).toBe(true);
+        expect(r.geometryTypes).toEqual(['MultiPolygon']);
+    });
+
+    it('rejects non-objects and wrong top-level types', () => {
+        expect(validatePolygonGeoJSON(null).ok).toBe(false);
+        expect(validatePolygonGeoJSON({ type: 'Point' }).ok).toBe(false);
+    });
+
+    it('rejects empty collections', () => {
+        expect(validatePolygonGeoJSON({ type: 'FeatureCollection', features: [] }).ok).toBe(false);
+    });
+
+    it('rejects non-polygon geometry, steering to data-ingest', () => {
+        const pt = { type: 'Feature', properties: {}, geometry: { type: 'Point', coordinates: [0, 0] } };
+        const r = validatePolygonGeoJSON(pt);
+        expect(r.ok).toBe(false);
+        expect(r.error).toMatch(/data-ingest/i);
+    });
+
+    it('rejects a feature missing geometry', () => {
+        const r = validatePolygonGeoJSON({ type: 'Feature', properties: {} });
+        expect(r.ok).toBe(false);
+        expect(r.error).toMatch(/missing geometry/i);
+    });
+
+    it('enforces the feature cap', () => {
+        const many = { type: 'FeatureCollection', features: Array.from({ length: 5 }, () => poly(SQUARE)) };
+        const r = validatePolygonGeoJSON(many, { maxFeatures: 3 });
+        expect(r.ok).toBe(false);
+        expect(r.error).toMatch(/too many features/i);
+    });
+});
+
+describe('computeBounds', () => {
+    it('computes [w,s,e,n] over polygon coordinates', () => {
+        expect(computeBounds(poly(SQUARE))).toEqual([-122.3, 37.8, -122.2, 37.9]);
+    });
+
+    it('spans multiple features', () => {
+        const other = [[[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]];
+        const fc = { type: 'FeatureCollection', features: [poly(SQUARE), poly(other)] };
+        expect(computeBounds(fc)).toEqual([-122.3, 0, 1, 37.9]);
+    });
+
+    it('returns null when there are no coordinates', () => {
+        expect(computeBounds({ type: 'FeatureCollection', features: [] })).toBeNull();
+    });
+});
+
+describe('pickTooltipFields', () => {
+    it('unions property keys across features', () => {
+        const feats = [poly(SQUARE, { a: 1, b: 2 }), poly(SQUARE, { b: 3, c: 4 })];
+        expect(pickTooltipFields(feats)).toEqual(['a', 'b', 'c']);
+    });
+
+    it('caps the number of keys', () => {
+        const feats = [poly(SQUARE, { a: 1, b: 2, c: 3, d: 4 })];
+        expect(pickTooltipFields(feats, 2)).toEqual(['a', 'b']);
+    });
+
+    it('tolerates features without properties', () => {
+        expect(pickTooltipFields([{ geometry: {} }])).toEqual([]);
+    });
+});
+
+describe('buildObjectUrl', () => {
+    it('builds a stable public URL and tolerates a trailing slash', () => {
+        expect(buildObjectUrl('https://s3.example/bucket', 'uploads', 'abc123'))
+            .toBe('https://s3.example/bucket/uploads/abc123/data.geojson');
+        expect(buildObjectUrl('https://s3.example/bucket/', 'uploads', 'abc123'))
+            .toBe('https://s3.example/bucket/uploads/abc123/data.geojson');
+    });
+});
+
+describe('contentHash', () => {
+    it('is deterministic, 16 hex chars, and content-addressed', async () => {
+        const a = await contentHash('{"hello":"world"}');
+        const b = await contentHash('{"hello":"world"}');
+        const c = await contentHash('{"hello":"there"}');
+        expect(a).toBe(b);
+        expect(a).not.toBe(c);
+        expect(a).toMatch(/^[0-9a-f]{16}$/);
+    });
+});


### PR DESCRIPTION
Closes #325 (Phase 1).

## What this does

Adds an **opt-in** mechanism (`upload_enabled`, off by default) that lets a user drop a **small polygon GeoJSON** on the map, see it drawn, and have the **agent compute against it** — the hand-drawn-polygon use case, from a user file.

The design principle here is **don't mediate the upload through the LLM**: the browser PUTs the GeoJSON straight to the `public-output` S3 bucket, and only the resulting **URL** is exposed to the agent. The agent reads it back server-side with `ST_Read(...)` in the existing `query` tool and uses it as an area-of-interest mask. The geometry never enters the model's context.

This is a **single-repo change** — no mcp-data-server work — because the bucket's anonymous write + the spatial `query` tool already exist (verified end-to-end against the live bucket; see #325).

## Flow

1. Opt-in flag `upload_enabled` (`true` for defaults, or an object to customize bucket/prefix/caps/ingest link) lazy-loads `upload-manager.js`.
2. User picks/drops a `.geojson`; it's parsed, validated (Polygon/MultiPolygon only), and **size/feature-capped** client-side. Over the cap → blocked with a message steering to a data-ingest request.
3. Content-hashed and **plain-PUT** to `s3://public-output/uploads/<hash>/data.geojson` (plain fetch, *not* an SDK chunked upload — the anonymous endpoint corrupts chunked bodies).
4. Drawn inline as a `geojson` source (fill + outline), with a panel row + remove button.
5. `get_uploaded_dataset` returns the URL(s) + schema + a SQL hint; the agent masks datasets with `ST_Within` / `h3_polygon_wkt_to_cells` — geometry stays server-side.

## Scope (deliberate)

In: small polygon GeoJSON (EPSG:4326). Out → data-ingest request: shapefiles, non-polygon data, large/complex datasets. The client cap is the hand-off point.

## Retention

Handled by the bucket's **existing lifecycle expiration**. No anonymous delete (shared bucket also holds hex tiles); client "remove" is a map-layer removal only, and content-hash keying makes an expired re-upload idempotent.

## Files

- `app/upload-manager.js` — new opt-in module: pure helpers (validate/bounds/tooltip-fields/hash/url) + DOM/network glue
- `app/map-manager.js` — `addUploadedLayer` / `removeUploadedLayer`; remove-button now covers `upload-` layers
- `app/main.js` — opt-in gate, `get_uploaded_dataset` tool, upload→chat event bridge
- `app/style.css` — upload button / status / drag-over styles
- `test/upload-manager.test.js`, `test/map-manager.upload.test.js` — 21 new tests

## Testing

- `npm test` green: **563 passed** (21 new). Pure helpers + MapManager add/remove/panel behavior covered.
- Browser-bound glue in `upload-manager.js` (FileReader / crypto.subtle / fetch / drag-drop) is manual-verify per the repo's coverage policy — **not yet exercised in a live app**.

## Verify before merge

- [ ] Live smoke test on a downstream app with `upload_enabled: true`: upload a polygon, confirm it draws, and confirm the agent answers a "how much X inside this boundary" query via `ST_Read`.
- [ ] Confirm the MCP server's DuckDB `ST_Read` reaches the upload at the **https** bucket URL from inside the cluster (verified from JupyterLab; re-confirm from the server pod). If s3:// is preferred, adjust the URL form in `get_uploaded_dataset`.
- [ ] Confirm the `uploads/` prefix is covered by the bucket lifecycle rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
