### PR TITLE
feat(raster): pass source-level bounds/minzoom/maxzoom to COG layers

### DIFF
--- a/app/dataset-catalog.js
+++ b/app/dataset-catalog.js
@@ -30,6 +30,43 @@ function normalizeLegendClasses(raw) {
     }));
 }
 
+/**
+ * Validate an asset's `bounds` config into a MapLibre source `bounds` array.
+ * MapLibre silently falls back to the whole world for anything that isn't
+ * [west, south, east, north] in degrees, which looks identical to the
+ * unscoped raster the author was trying to clip — so warn instead.
+ * @param {*} raw
+ * @param {string} assetKey - asset key, for the warning message
+ * @returns {Array<number>|null}
+ */
+function normalizeBounds(raw, assetKey) {
+    if (raw == null) return null;
+    const ok = Array.isArray(raw) && raw.length === 4 && raw.every(n => Number.isFinite(n))
+        && raw[1] >= -90 && raw[3] <= 90 && raw[1] < raw[3];
+    if (!ok) {
+        console.warn(`[dataset-catalog] Ignoring invalid "bounds" for asset "${assetKey}" — expected [west, south, east, north] in degrees, got:`, raw);
+        return null;
+    }
+    return raw;
+}
+
+/**
+ * Optional MapLibre source-level culling keys, read off a map-layer record.
+ * Omitted entirely when unset so sources that don't use them keep their
+ * current shape. `bounds` culls whole tiles (not pixels), so a fringe of
+ * neighbouring territory survives along the edge — pair it with `minzoom`,
+ * since at low zoom a single tile can span several states.
+ * @param {Object} ml - map-layer record from extractMapLayers()
+ * @returns {Object}
+ */
+function sourceCulling(ml) {
+    return {
+        ...(ml.bounds != null ? { bounds: ml.bounds } : {}),
+        ...(ml.minzoom != null ? { minzoom: ml.minzoom } : {}),
+        ...(ml.maxzoom != null ? { maxzoom: ml.maxzoom } : {}),
+    };
+}
+
 export class DatasetCatalog {
     constructor() {
         /** @type {Map<string, DatasetEntry>} keyed by collection ID */
@@ -363,6 +400,9 @@ export class DatasetCatalog {
                         colormap: config.colormap || options.colormap || 'reds',
                         rescale: config.rescale || options.rescale || null,
                         paint: config.paint || null,
+                        bounds: normalizeBounds(config.bounds, key),
+                        minzoom: config.minzoom ?? null,
+                        maxzoom: config.maxzoom ?? null,
                         legendLabel: config.legend_label || null,
                         legendType: config.legend_type || null,
                         legendClasses: normalizeLegendClasses(config.legend_classes),
@@ -416,6 +456,9 @@ export class DatasetCatalog {
                         colormap: config.colormap || options.colormap || 'reds',
                         rescale: config.rescale || options.rescale || null,
                         paint: config.paint || null,
+                        bounds: normalizeBounds(config.bounds, key),
+                        minzoom: config.minzoom ?? null,
+                        maxzoom: config.maxzoom ?? null,
                         legendLabel: config.legend_label || null,
                         legendType: config.legend_type || null,
                         legendClasses: band0?.['classification:classes'] || null,
@@ -902,7 +945,7 @@ export class DatasetCatalog {
                                 label: v.label,
                                 type: 'raster',
                                 sourceId: `src-${ds.id.replace(/[^a-zA-Z0-9]/g, '-')}-${v.assetId.replace(/[^a-zA-Z0-9]/g, '-')}`,
-                                source: { type: 'raster', tiles: [tilesUrl], tileSize: 256 },
+                                source: { type: 'raster', tiles: [tilesUrl], tileSize: 256, ...sourceCulling(ml) },
                             };
                         }
                     });
@@ -1010,6 +1053,7 @@ export class DatasetCatalog {
                             type: 'raster',
                             tiles: [tilesUrl],
                             tileSize: 256,
+                            ...sourceCulling(ml),
                         },
                         paint: ml.paint || { 'raster-opacity': 0.7 },
                         columns: [], // rasters don't have filterable columns

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -138,6 +138,37 @@ Use `legend_range` and/or `legend_gradient` only to override the derived values 
 | `nodata` | number\|string | Pixel value to render transparent (e.g., `0` to mask ocean/no-data). If unset, falls back to the STAC `raster:bands[0].nodata` value; omit both to leave all pixels opaque. |
 | `legend_label` | string | Label shown next to the color legend. |
 | `legend_type` | string | `"categorical"` to use STAC `classification:classes` color codes for a discrete legend. |
+| `paint` | object | MapLibre [raster paint properties](https://maplibre.org/maplibre-style-spec/layers/#raster) (e.g. `{"raster-opacity": 0.7}`). Zoom expressions are allowed. |
+| `bounds` | `[w, s, e, n]` | Restrict tile requests to this box, in degrees. See below. |
+| `minzoom` | number | Hide the layer below this zoom level. |
+| `maxzoom` | number | Highest zoom level with real tiles. Above it MapLibre overzooms the coarser tiles rather than dropping the layer. |
+
+### Scoping a raster to a region
+
+Vector layers narrow their extent with `default_filter`, but that is an attribute expression and a
+raster has no attributes — so a national COG paints the whole country even in an app scoped to one
+state. `bounds` and `minzoom` are passed straight through to the MapLibre raster **source**, which
+culls tile requests outside the box and below the zoom, with no clipped copy of the data:
+
+```json
+{
+  "id": "species-richness-all-cog",
+  "display_name": "Imperiled species richness · NatureServe 2023",
+  "colormap": "viridis",
+  "rescale": "0,10",
+  "bounds": [-114.05, 36.99, -109.04, 42.00],
+  "minzoom": 5
+}
+```
+
+`bounds` culls whole **tiles**, not pixels, so a fringe of neighbouring territory survives along the
+edge — and at very low zoom a single tile can span several states, so `bounds` alone still spills.
+Pairing it with `minzoom` is what makes the scoping tight. Malformed `bounds` (anything that isn't
+four finite degrees with `south < north`) is ignored with a console warning rather than silently
+falling back to the whole world.
+
+These keys also work on [versioned assets](#versioned-assets), where they apply uniformly to every
+version.
 
 ## Asset config — GeoJSON
 

--- a/test/dataset-catalog.test.js
+++ b/test/dataset-catalog.test.js
@@ -605,6 +605,71 @@ describe('DatasetCatalog.extractMapLayers', () => {
         expect(layers[0].colormap).toBe('viridis');
     });
 
+    it('extracts bounds/minzoom/maxzoom onto a raster layer record (issue #331)', () => {
+        const layers = cat.extractMapLayers(collectionWithAssets({
+            cog: { type: 'image/tiff; application=geotiff', href: 'https://x/cog.tif' },
+        }), {}, [{
+            key: 'cog',
+            assetId: 'cog',
+            config: { bounds: [-114.05, 36.99, -109.04, 42.0], minzoom: 0, maxzoom: 12 },
+        }]);
+
+        expect(layers[0].bounds).toEqual([-114.05, 36.99, -109.04, 42.0]);
+        expect(layers[0].minzoom).toBe(0);   // 0 is meaningful — must not be coerced to null
+        expect(layers[0].maxzoom).toBe(12);
+    });
+
+    it('leaves bounds/minzoom/maxzoom null on a raster layer when unconfigured', () => {
+        const layers = cat.extractMapLayers(collectionWithAssets({
+            cog: { type: 'image/tiff; application=geotiff', href: 'https://x/cog.tif' },
+        }), {}, [{ key: 'cog', assetId: 'cog', config: {} }]);
+
+        expect(layers[0].bounds).toBeNull();
+        expect(layers[0].minzoom).toBeNull();
+        expect(layers[0].maxzoom).toBeNull();
+    });
+
+    it.each([
+        ['too few entries', [-114.05, 36.99, -109.04]],
+        ['non-numeric entries', [-114.05, 36.99, -109.04, 'north']],
+        ['south above north', [-114.05, 42.0, -109.04, 36.99]],
+        ['latitude out of range', [-114.05, -95, -109.04, 42.0]],
+        ['not an array', { west: -114.05 }],
+    ])('drops invalid raster bounds (%s) with a warning', (_label, bad) => {
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        const layers = cat.extractMapLayers(collectionWithAssets({
+            cog: { type: 'image/tiff; application=geotiff', href: 'https://x/cog.tif' },
+        }), {}, [{ key: 'cog', assetId: 'cog', config: { bounds: bad } }]);
+
+        expect(layers[0].bounds).toBeNull();
+        expect(warn).toHaveBeenCalledWith(expect.stringContaining('cog'), bad);
+        warn.mockRestore();
+    });
+
+    it('extracts bounds/minzoom/maxzoom onto a versioned raster layer record', () => {
+        const layers = cat.extractMapLayers(collectionWithAssets({
+            y2020: { type: 'image/tiff; application=geotiff', href: 'https://x/2020.tif' },
+            y2021: { type: 'image/tiff; application=geotiff', href: 'https://x/2021.tif' },
+        }), {}, [{
+            key: 'lc',
+            assetId: 'lc',
+            config: {
+                bounds: [-114.05, 36.99, -109.04, 42.0],
+                minzoom: 5,
+                maxzoom: 12,
+                versions: [
+                    { label: '2020', asset_id: 'y2020' },
+                    { label: '2021', asset_id: 'y2021' },
+                ],
+            },
+        }]);
+
+        expect(layers[0].versions).toHaveLength(2);
+        expect(layers[0].bounds).toEqual([-114.05, 36.99, -109.04, 42.0]);
+        expect(layers[0].minzoom).toBe(5);
+        expect(layers[0].maxzoom).toBe(12);
+    });
+
     it('extracts a versioned asset producing a single layer with versions[]', () => {
         const layers = cat.extractMapLayers(collectionWithAssets({
             l3: { type: 'application/vnd.pmtiles', href: 'https://x/l3.pmtiles' },
@@ -861,6 +926,96 @@ describe('DatasetCatalog.getMapLayerConfigs', () => {
         const [c] = cat.getMapLayerConfigs();
         expect(c.versions[0].type).toBe('raster');
         expect(c.versions[0].source.tiles[0]).toContain('colormap_name=viridis');
+    });
+
+    it('passes bounds/minzoom/maxzoom onto the raster source so MapLibre culls tiles (issue #331)', () => {
+        cat.titilerUrl = 'https://titiler.example';
+        cat.datasets.set('cogds', {
+            id: 'cogds', title: 'C', columns: [],
+            mapLayers: [{
+                assetId: 'cog', layerType: 'raster', title: 'C',
+                cogUrl: 'https://x/cog.tif',
+                colormap: 'viridis',
+                bounds: [-114.05, 36.99, -109.04, 42.0],
+                minzoom: 5,
+                maxzoom: 12,
+            }],
+        });
+        const [c] = cat.getMapLayerConfigs();
+        expect(c.source).toMatchObject({
+            type: 'raster',
+            tileSize: 256,
+            bounds: [-114.05, 36.99, -109.04, 42.0],
+            minzoom: 5,
+            maxzoom: 12,
+        });
+    });
+
+    it('keeps minzoom: 0 on the raster source (falsy but meaningful)', () => {
+        cat.titilerUrl = 'https://titiler.example';
+        cat.datasets.set('cogds', {
+            id: 'cogds', title: 'C', columns: [],
+            mapLayers: [{
+                assetId: 'cog', layerType: 'raster', title: 'C',
+                cogUrl: 'https://x/cog.tif', colormap: 'viridis', minzoom: 0,
+            }],
+        });
+        const [c] = cat.getMapLayerConfigs();
+        expect(c.source.minzoom).toBe(0);
+    });
+
+    it('omits bounds/minzoom/maxzoom from the raster source when unconfigured', () => {
+        cat.titilerUrl = 'https://titiler.example';
+        cat.datasets.set('cogds', {
+            id: 'cogds', title: 'C', columns: [],
+            mapLayers: [{
+                assetId: 'cog', layerType: 'raster', title: 'C',
+                cogUrl: 'https://x/cog.tif', colormap: 'viridis',
+            }],
+        });
+        const [c] = cat.getMapLayerConfigs();
+        expect(c.source).toEqual({ type: 'raster', tiles: [c.source.tiles[0]], tileSize: 256 });
+    });
+
+    it('passes bounds/minzoom/maxzoom onto every version of a versioned raster layer', () => {
+        cat.titilerUrl = 'https://titiler.example';
+        cat.datasets.set('vr', {
+            id: 'vr', title: 'V', columns: [],
+            mapLayers: [{
+                assetId: 'lc', layerType: 'raster', title: 'Landcover',
+                colormap: 'viridis',
+                bounds: [-114.05, 36.99, -109.04, 42.0],
+                minzoom: 5,
+                maxzoom: 12,
+                versions: [
+                    { label: '2020', assetId: 'v2020', layerType: 'raster', cogUrl: 'https://x/2020.tif' },
+                    { label: '2021', assetId: 'v2021', layerType: 'raster', cogUrl: 'https://x/2021.tif' },
+                ],
+                defaultVersionIndex: 0,
+            }],
+        });
+        const [c] = cat.getMapLayerConfigs();
+        for (const v of c.versions) {
+            expect(v.source).toMatchObject({
+                bounds: [-114.05, 36.99, -109.04, 42.0],
+                minzoom: 5,
+                maxzoom: 12,
+            });
+        }
+    });
+
+    it('leaves vector sources untouched when a sibling raster uses bounds', () => {
+        cat.titilerUrl = 'https://titiler.example';
+        cat.datasets.set('mixed', {
+            id: 'mixed', title: 'M', columns: [],
+            mapLayers: [
+                { assetId: 'pm', layerType: 'vector', title: 'V', url: 'https://x/x.pmtiles', sourceLayer: 'x', bounds: [-1, -1, 1, 1] },
+                { assetId: 'cog', layerType: 'raster', title: 'R', cogUrl: 'https://x/cog.tif', colormap: 'viridis', bounds: [-1, -1, 1, 1] },
+            ],
+        });
+        const [vec, ras] = cat.getMapLayerConfigs();
+        expect(vec.source).toEqual({ type: 'vector', url: 'pmtiles://https://x/x.pmtiles' });
+        expect(ras.source.bounds).toEqual([-1, -1, 1, 1]);
     });
 
     it('passes legendType/legendClasses through to a vector layer config (issue #118)', () => {


### PR DESCRIPTION
Refs #331 — a partial fix, not a close. Source `bounds` culls whole tiles, so it does not deliver the pixel-exact clip #331 now tracks; see [that thread](https://github.com/boettiger-lab/geo-agent/issues/331#issuecomment-5076022253) for measurements.

## Problem

A COG layer can't be geographically scoped from `layers-input.json`. Vector layers have `default_filter`, but that's a MapLibre attribute expression and a raster has no attributes; TiTiler's XYZ endpoint has no polygon mask (cropping lives on `/cog/bbox` and `/cog/feature`, which return single images rather than tile pyramids). So a national raster paints the whole country even in an app scoped to one state, and the only real workaround is mirroring a clipped copy of the raster — a lot of duplicated storage for a display concern.

MapLibre raster **sources** already support `bounds`, `minzoom` and `maxzoom`, which cull tile requests outside a box or zoom range with no data copy. The framework just didn't expose them.

## Change

`bounds` / `minzoom` / `maxzoom` are now raster asset config keys:

```json
{
  "id": "species-richness-all-cog",
  "display_name": "Imperiled species richness · NatureServe 2023",
  "colormap": "viridis",
  "rescale": "0,10",
  "bounds": [-114.05, 36.99, -109.04, 42.00],
  "minzoom": 5
}
```

They're read onto the map-layer record alongside the existing `colormap` / `rescale` / `paint`, and spread onto both raster source literals — the standard branch and the versioned branch — through a new `sourceCulling()` helper. `maxzoom` comes along for the ride since it's the same one-line pattern (and the `BASEMAPS` sources in `map-manager.js` already use it); it lets a coarse COG overzoom instead of vanishing at high zoom.

Notes:

- `minzoom` uses `??`, not a truthy check, so a meaningful `0` isn't silently dropped.
- `normalizeBounds()` warns on malformed `bounds` rather than letting MapLibre fall back to the whole world — that fallback looks exactly like the unscoped raster the author was trying to clip, with no clue why.
- On versioned layers the keys live on the parent asset and apply uniformly to every version, matching the documented contract for the other per-asset options.

## Compatibility

- Keys are **omitted** from the source object when unset, so every existing layer emits a byte-identical source literal (there's a test asserting exactly this).
- **No `MapManager` change.** `registerLayer` passes `source` to `map.addSource()` verbatim and never destructures it; `switchVersion` toggles visibility on already-added sources rather than rebuilding one; there's no `map.setStyle()` or `setTiles()` anywhere in the repo.
- Nothing in `map-tools.js` touches sources, so the LLM tool surface is unchanged — the agent can still `set_style` these layers as before.
- Chat-log export serializes `map.getStyle()`, so the new keys ride along automatically.

## Tests

11 new cases in `test/dataset-catalog.test.js`: extraction onto standard and versioned raster records, passthrough onto the standard and per-version source objects, an omission guard (`toEqual` on the exact current shape), a `minzoom: 0` regression guard, a table-driven set of invalid-`bounds` inputs asserting the warn-and-drop path, and a mixed vector/raster case confirming vector sources are untouched.

`npm test` — 590 passed / 32 files. `dataset-catalog.js` coverage 89% → 91.9%.

## Docs

`docs/guide/configuration.md` gains the three table rows plus a "Scoping a raster to a region" section with the worked example and the `bounds`-culls-whole-tiles-not-pixels caveat (pair it with `minzoom`). Also documents `paint`, which was supported but had never been written down.
