### PR TITLE
fix(legend): keep the legend truthful after a runtime restyle

### DIFF
--- a/app/legend-helpers.js
+++ b/app/legend-helpers.js
@@ -7,10 +7,29 @@
 
 /**
  * The paint keys that carry a layer's primary data-driven color, in priority
- * order. A fill layer colors via `fill-color`, a line via `line-color`, a
+ * order. A fill layer colors via `fill-color`, an extruded fill via
+ * `fill-extrusion-color` (3D hex layers, #317), a line via `line-color`, a
  * circle via `circle-color`.
  */
-const COLOR_PAINT_KEYS = ['fill-color', 'line-color', 'circle-color'];
+export const COLOR_PAINT_KEYS = ['fill-color', 'fill-extrusion-color', 'line-color', 'circle-color'];
+
+/**
+ * The paint object's primary color value — expression *or* literal — so callers
+ * can tell whether a restyle replaced the color a legend was derived from
+ * (#333). Unlike {@link deriveContinuousLegend} this doesn't skip past a flat
+ * color to find an expression: "the color this layer paints with" is the first
+ * color key present, whatever its form.
+ *
+ * @param {Object} paint - A MapLibre paint object.
+ * @returns {*} The color value, or undefined when the paint carries none.
+ */
+export function primaryColorValue(paint) {
+    if (!paint || typeof paint !== 'object') return undefined;
+    for (const key of COLOR_PAINT_KEYS) {
+        if (paint[key] !== undefined) return paint[key];
+    }
+    return undefined;
+}
 
 /**
  * Derive a continuous legend (gradient + value range) from a vector layer's

--- a/app/map-manager.js
+++ b/app/map-manager.js
@@ -13,7 +13,7 @@
  */
 
 import { extractHashFromUrl, buildFillColorExpression, buildFlatFillColorExpression, rewriteValueColumn, PALETTES, buildHeightExpression, buildFlatHeightExpression, defaultExtrusionMaxHeight } from './hex-layer-helpers.js';
-import { deriveContinuousLegend } from './legend-helpers.js';
+import { deriveContinuousLegend, primaryColorValue } from './legend-helpers.js';
 
 const BASEMAPS = {
     natgeo: {
@@ -979,18 +979,7 @@ export class MapManager {
         }
 
         // Drop its legend entry (#316) and hide the panel if nothing's left.
-        if (this._legendItems) {
-            const legendItem = this._legendItems.get(layerId);
-            if (legendItem) {
-                legendItem.remove();
-                this._legendItems.delete(layerId);
-            }
-            this._hexLegendRefs?.delete(layerId);
-            if (this._legendEl) {
-                const anyVisible = [...this._legendItems.values()].some(el => el.style.display !== 'none');
-                this._legendEl.style.display = anyVisible ? '' : 'none';
-            }
-        }
+        this._dropLegendItem(layerId);
 
         return { success: true, layer_id: layerId };
     }
@@ -1103,11 +1092,15 @@ export class MapManager {
 
     /**
      * Apply paint properties to a layer.
-     * @param {string} layerId 
+     * @param {string} layerId
      * @param {Object} paintProps - e.g. { 'fill-color': 'red', 'fill-opacity': 0.5 }
+     * @param {Object} [opts]
+     * @param {boolean} [opts.promoteLegend=true] - Whether a restyle may give an
+     *   otherwise legend-less vector layer a derived colorbar (#333). resetStyle
+     *   passes false so a reset can't conjure a legend boot never showed.
      * @returns {Object} Result
      */
-    setStyle(layerId, paintProps) {
+    setStyle(layerId, paintProps, opts = {}) {
         const state = this.layers.get(layerId);
         if (!state) return { success: false, error: `Unknown layer: ${layerId}` };
 
@@ -1118,6 +1111,7 @@ export class MapManager {
         // value-bearing `get` to the layer's real column before applying.
         const corrected = new Set();
         const results = [];
+        const applied = {};
         for (const [prop, rawValue] of Object.entries(paintProps)) {
             let value = rawValue;
             if (state.valueColumn) {
@@ -1127,10 +1121,20 @@ export class MapManager {
             }
             try {
                 this.map.setPaintProperty(state.mapLayerId, prop, value);
+                applied[prop] = value;
                 results.push({ property: prop, success: true });
             } catch (error) {
                 results.push({ property: prop, success: false, error: error.message });
             }
+        }
+
+        // Record what's actually on the map, then re-render the legend from it:
+        // legends derive from paint, so without this they keep describing the
+        // ramp the layer was registered with (#333).
+        if (Object.keys(applied).length > 0) {
+            state.currentPaint = { ...this._effectivePaint(state), ...applied };
+            if (opts.promoteLegend !== false) this._promoteLegendType(state);
+            this._refreshLegend(layerId);
         }
 
         const failed = results.filter(r => !r.success).map(r => r.property);
@@ -1155,7 +1159,17 @@ export class MapManager {
     resetStyle(layerId) {
         const state = this.layers.get(layerId);
         if (!state) return { success: false, error: `Unknown layer: ${layerId}` };
-        return this.setStyle(layerId, state.defaultPaint);
+
+        // Drop any legend a restyle promoted into existence before re-applying,
+        // so reset lands back on exactly what boot rendered (#333).
+        if (state.legendTypeAuto) {
+            state.legendType = null;
+            state.legendTypeAuto = false;
+        }
+        const result = this.setStyle(layerId, state.defaultPaint, { promoteLegend: false });
+        state.currentPaint = null;
+        this._refreshLegend(layerId);
+        return result;
     }
 
     // ---- Query ----
@@ -1705,17 +1719,104 @@ export class MapManager {
         state.sourceId = newV.sourceId;
         state.sourceLayer = newV.sourceLayer;
 
-        // Refresh raster legend if visible (tile URL changed)
-        if (state.type === 'raster' && state.visible) {
-            this._hideLegend(layerId);
-            this._legendItems.delete(layerId);   // force re-creation with new source
-            this._showLegend(layerId);
-        }
+        // The version now on screen is a separate MapLibre layer carrying the
+        // registered paint, so any set_style override no longer applies (#333).
+        state.currentPaint = null;
+        this._promoteLegendType(state);
+
+        // Rebuild the legend: raster colorbars are tied to the tile URL, and a
+        // vector layer may have just shed a restyle-derived colorbar. Hidden
+        // layers get theirs dropped too, so re-showing can't resurrect a stale
+        // section built against the old version.
+        this._refreshLegend(layerId);
 
         return { success: true, layer: layerId, version: newV.label };
     }
 
     // ---- Legend ----
+
+    /**
+     * The paint currently on the map for a layer: the registered `defaultPaint`
+     * until a `set_style` overrides it, then the merged result. Legends read
+     * this so they describe what's rendered, not what was registered (#333).
+     */
+    _effectivePaint(state) {
+        return state.currentPaint || state.defaultPaint;
+    }
+
+    /**
+     * Whether a restyle replaced the layer's primary color — the only paint
+     * change a legend can be wrong about. An opacity-only `set_style` leaves the
+     * color expression (and so the legend) intact, and must not be mistaken for
+     * a recolor: doing so would drop hex legends on a `fill-opacity` tweak.
+     */
+    _colorPaintChanged(state) {
+        if (!state.currentPaint) return false;
+        const now = primaryColorValue(state.currentPaint);
+        const before = primaryColorValue(state.defaultPaint);
+        return JSON.stringify(now ?? null) !== JSON.stringify(before ?? null);
+    }
+
+    /**
+     * Give a vector layer restyled into a graduated choropleth a colorbar even
+     * when its config never declared `legend_type` — the agent can build such a
+     * ramp with `set_style` on any layer, and without this it renders with
+     * nothing explaining it (#333). Flagged `legendTypeAuto` so resetStyle and
+     * switchVersion can undo it; layers whose config *does* declare a legend
+     * type are left alone, as are hex layers (`legendType: 'hex'`).
+     */
+    _promoteLegendType(state) {
+        if (state.type !== 'vector') return;
+        if (state.legendType && !state.legendTypeAuto) return;
+        const derivable = this._colorPaintChanged(state)
+            && !!deriveContinuousLegend(this._effectivePaint(state));
+        if (derivable) {
+            state.legendType = 'continuous';
+            state.legendTypeAuto = true;
+        } else if (state.legendTypeAuto) {
+            state.legendType = null;
+            state.legendTypeAuto = false;
+        }
+    }
+
+    /**
+     * Tear down a layer's legend section so the next `_showLegend` rebuilds it
+     * from current state, re-hiding the group wrapper and the panel if that
+     * left nothing visible.
+     */
+    _dropLegendItem(layerId) {
+        if (!this._legendItems) return;
+        const item = this._legendItems.get(layerId);
+        if (item) item.remove();
+        this._legendItems.delete(layerId);
+        this._hexLegendRefs?.delete(layerId);
+
+        const state = this.layers.get(layerId);
+        if (state?.group) {
+            const wrapper = this._legendGroups?.get(state.group);
+            if (wrapper) {
+                const anyMemberVisible = [...wrapper.querySelectorAll('.legend-section')]
+                    .some(el => el.style.display !== 'none');
+                wrapper.style.display = anyMemberVisible ? '' : 'none';
+            }
+        }
+        if (this._legendEl) {
+            const anyVisible = [...this._legendItems.values()].some(el => el.style.display !== 'none');
+            this._legendEl.style.display = anyVisible ? '' : 'none';
+        }
+    }
+
+    /**
+     * Rebuild a layer's legend after something changed what it should say — a
+     * restyle (#333) or a version switch. Sections are built once and cached, so
+     * the stale one has to go before `_showLegend` will re-render. A layer
+     * restyled past what we can describe simply loses its legend rather than
+     * advertising a ramp that's no longer on the map.
+     */
+    _refreshLegend(layerId) {
+        this._dropLegendItem(layerId);
+        this._showLegendIfVisible(layerId);
+    }
 
     /**
      * Whether a layer contributes a legend entry: continuous rasters (colorbar),
@@ -1781,6 +1882,18 @@ export class MapManager {
      * @returns {{ colors: string[], range: [number, number], res: number } | null}
      */
     _hexLegend(state) {
+        // A restyle replaces the per-res `case`/`match` expression this legend
+        // mirrors, so neither the registered palette nor the per-res domain
+        // describes the map any more (#333). Mirror the new expression when it's
+        // a parseable ramp — its stops are now the whole value axis, at every
+        // zoom — and contribute nothing when it isn't (flat color, `match`, …),
+        // rather than showing the palette the layer was added with.
+        if (this._colorPaintChanged(state)) {
+            const derived = deriveContinuousLegend(this._effectivePaint(state));
+            if (!derived) return null;
+            return { colors: derived.gradient, range: derived.range, res: this._currentHexRes(state) };
+        }
+
         const byRes = state.hexValueStats?.by_res || {};
         const res = this._currentHexRes(state);
         if (res == null) return null;
@@ -1803,15 +1916,20 @@ export class MapManager {
      * `interpolate`/`step` color expression. Returns null when neither is
      * available (so the layer simply contributes no legend).
      *
+     * Once a restyle has replaced the color expression, the derived values win
+     * instead: the config gradient/range described the paint the layer shipped
+     * with, and keeping it would caption the new ramp with the old numbers (#333).
+     *
      * @returns {{ colors: string[], range: [number, number] } | null}
      */
     _continuousVectorLegend(state) {
         if (state.type !== 'vector') return null;
-        const derived = deriveContinuousLegend(state.defaultPaint);
-        const colors = (Array.isArray(state.legendGradient) && state.legendGradient.length >= 2)
+        const derived = deriveContinuousLegend(this._effectivePaint(state));
+        const configWins = !this._colorPaintChanged(state);
+        const colors = (configWins && Array.isArray(state.legendGradient) && state.legendGradient.length >= 2)
             ? state.legendGradient
             : derived?.gradient;
-        const range = (Array.isArray(state.legendRange) && state.legendRange.length === 2)
+        const range = (configWins && Array.isArray(state.legendRange) && state.legendRange.length === 2)
             ? state.legendRange
             : derived?.range;
         if (!colors || colors.length < 2 || !range) return null;
@@ -1986,11 +2104,13 @@ export class MapManager {
             labels.appendChild(maxSpan);
             const resNote = document.createElement('div');
             resNote.className = 'legend-hex-res';
-            if (hex) resNote.textContent = `H3 resolution ${hex.res}`;
+            // A restyled hex layer can report a legend with no resolution (its
+            // ramp is now fixed rather than per-res) — leave the note blank.
+            if (hex?.res != null) resNote.textContent = `H3 resolution ${hex.res}`;
             item.appendChild(bar);
             item.appendChild(labels);
             item.appendChild(resNote);
-            if (hex) state.hexCurrentRes = hex.res;
+            if (hex?.res != null) state.hexCurrentRes = hex.res;
             this._hexLegendRefs.set(layerId, { minSpan, maxSpan, resNote });
             this._ensureHexLegendReactivity();
         } else {
@@ -2055,11 +2175,11 @@ export class MapManager {
             if (!item || item.style.display === 'none') continue;
             const hex = this._hexLegend(state);
             if (!hex) continue;
-            state.hexCurrentRes = hex.res;
+            if (hex.res != null) state.hexCurrentRes = hex.res;
             const unit = state.legendLabel ? ` ${state.legendLabel}` : '';
             refs.minSpan.textContent = `${this._fmtLegendValue(hex.range[0])}${unit}`;
             refs.maxSpan.textContent = `${this._fmtLegendValue(hex.range[1])}${unit}`;
-            if (refs.resNote) refs.resNote.textContent = `H3 resolution ${hex.res}`;
+            if (refs.resNote) refs.resNote.textContent = hex.res != null ? `H3 resolution ${hex.res}` : '';
         }
     }
 

--- a/test/legend-helpers.test.js
+++ b/test/legend-helpers.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { deriveContinuousLegend } from '../app/legend-helpers.js';
+import { deriveContinuousLegend, primaryColorValue } from '../app/legend-helpers.js';
 
 describe('deriveContinuousLegend', () => {
     it('derives gradient + range from an interpolate fill-color expression', () => {
@@ -68,5 +68,32 @@ describe('deriveContinuousLegend', () => {
     it('returns null when fewer than two color stops are present', () => {
         const paint = { 'fill-color': ['interpolate', ['linear'], ['get', 'v'], 0, '#000'] };
         expect(deriveContinuousLegend(paint)).toBeNull();
+    });
+
+    it('reads fill-extrusion-color, so 3D hex layers can derive a legend', () => {
+        const paint = {
+            'fill-extrusion-color': ['interpolate', ['linear'], ['get', 'v'], 0, '#000', 30, '#fff'],
+        };
+        expect(deriveContinuousLegend(paint)).toEqual({
+            gradient: ['#000', '#fff'],
+            range: [0, 30],
+        });
+    });
+});
+
+describe('primaryColorValue', () => {
+    it('returns the color value whether it is an expression or a literal', () => {
+        expect(primaryColorValue({ 'fill-color': '#2E7D32' })).toBe('#2E7D32');
+        expect(primaryColorValue({ 'circle-color': ['get', 'c'] })).toEqual(['get', 'c']);
+    });
+
+    it('prefers fill-color over other color keys', () => {
+        const paint = { 'line-color': '#111', 'fill-color': '#222' };
+        expect(primaryColorValue(paint)).toBe('#222');
+    });
+
+    it('returns undefined for paint with no color key', () => {
+        expect(primaryColorValue({ 'fill-opacity': 0.5 })).toBeUndefined();
+        expect(primaryColorValue(null)).toBeUndefined();
     });
 });

--- a/test/map-manager.legend-restyle.test.js
+++ b/test/map-manager.legend-restyle.test.js
@@ -1,0 +1,307 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest';
+import { MapManager } from '../app/map-manager.js';
+import { PALETTES } from '../app/hex-layer-helpers.js';
+
+/**
+ * Legends are derived from paint, but `set_style` used to leave them alone —
+ * so an agent restyle left the colorbar describing the ramp the layer was
+ * registered with, or produced a choropleth with no legend at all (#333).
+ * These tests pin that a legend always describes the paint currently on the map.
+ */
+
+function createManager(states) {
+    const painted = {};
+    const mm = Object.create(MapManager.prototype);
+    mm.layers = new Map(states.map(s => [s.layerId, s]));
+    mm._legendItems = new Map();
+    mm._legendGroups = new Map();
+    mm._hexLegendRefs = new Map();
+    mm._hexLegendReactive = true;   // suppress the lazy moveend wiring
+    mm._legendEl = null;
+    mm._legendContent = null;
+    mm._ensureLegend = function () {
+        if (this._legendEl) return;
+        this._legendEl = document.createElement('div');
+        this._legendContent = document.createElement('div');
+        this._legendEl.appendChild(this._legendContent);
+        document.body.appendChild(this._legendEl);
+    };
+    // Raster colorbars fetch a TiTiler colormap; the restyle path only needs a
+    // deterministic gradient string.
+    mm._getColormapGradient = async () => 'linear-gradient(to right, #eee, #333)';
+    mm.map = {
+        on: () => {},
+        setPaintProperty: (id, prop, value) => { painted[`${id}:${prop}`] = value; },
+        setLayoutProperty: () => {},
+        setFilter: () => {},
+        getLayer: () => ({ type: 'fill' }),
+        queryRenderedFeatures: () => [{ properties: { res: 6 } }],
+    };
+    return { mm, painted };
+}
+
+const ramp = (min, max, lo = '#eee', hi = '#333') =>
+    ['interpolate', ['linear'], ['get', 'v'], min, lo, max, hi];
+
+function vectorState(overrides = {}) {
+    return {
+        layerId: 'A', mapLayerId: 'layer-A', displayName: 'Parcels',
+        visible: true, type: 'vector', group: null,
+        legendType: 'continuous', legendLabel: null, legendClasses: null,
+        legendRange: null, legendGradient: null,
+        defaultPaint: { 'fill-color': ramp(0, 100), 'fill-opacity': 0.7 },
+        ...overrides,
+    };
+}
+
+function hexState(overrides = {}) {
+    return {
+        layerId: 'hex-abc', mapLayerId: 'hex-abc', displayName: 'Population',
+        visible: true, type: 'vector', group: null, valueColumn: 'population',
+        legendType: 'hex', legendLabel: null, legendClasses: null,
+        hexValueStats: { by_res: { '5': { min: 0, max: 100 }, '6': { min: 0, max: 700 } } },
+        hexPalette: 'viridis', hexCurrentRes: null,
+        defaultPaint: {
+            'fill-color': ['case', ['==', ['get', 'population'], null], 'rgba(0,0,0,0)',
+                ['match', ['get', 'res'], 5, ramp(0, 100), 6, ramp(0, 700), 'rgba(0,0,0,0)']],
+            'fill-opacity': 0.8,
+        },
+        ...overrides,
+    };
+}
+
+const labels = (mm, id) =>
+    [...mm._legendItems.get(id).querySelectorAll('.legend-labels span')].map(s => s.textContent);
+const bar = (mm, id) =>
+    mm._legendItems.get(id).querySelector('.legend-colorbar').style.background;
+const resNote = (mm, id) =>
+    mm._legendItems.get(id).querySelector('.legend-hex-res').textContent;
+
+describe('legend follows set_style — continuous vector (#333)', () => {
+    it('relabels the colorbar to the new ramp instead of keeping the registered one', () => {
+        const state = vectorState();
+        const { mm } = createManager([state]);
+        mm._showLegendIfVisible('A');
+        expect(labels(mm, 'A')).toEqual(['0', '100']);
+
+        mm.setStyle('A', { 'fill-color': ramp(0, 500, '#f7fbff', '#08306b') });
+
+        expect(labels(mm, 'A')).toEqual(['0', '500']);
+        expect(bar(mm, 'A')).toBe('linear-gradient(to right, #f7fbff, #08306b)');
+    });
+
+    it('derived values win over config legend_gradient / legend_range once restyled', () => {
+        const state = vectorState({
+            defaultPaint: { 'fill-color': '#2E7D32' },
+            legendGradient: ['#ffffff', '#000000'],
+            legendRange: [0, 10],
+        });
+        const { mm } = createManager([state]);
+        mm._showLegendIfVisible('A');
+        expect(labels(mm, 'A')).toEqual(['0', '10']);
+
+        mm.setStyle('A', { 'fill-color': ramp(0, 900) });
+
+        expect(labels(mm, 'A')).toEqual(['0', '900']);
+    });
+
+    it('drops the legend when restyled to a flat color it can no longer describe', () => {
+        const state = vectorState();
+        const { mm } = createManager([state]);
+        mm._showLegendIfVisible('A');
+        const item = mm._legendItems.get('A');
+
+        mm.setStyle('A', { 'fill-color': '#ff0000' });
+
+        expect(mm._legendItems.has('A')).toBe(false);
+        expect(item.parentNode).toBeNull();          // removed, not just hidden
+        expect(mm._legendEl.style.display).toBe('none');
+    });
+
+    it('leaves the legend alone for an opacity-only restyle', () => {
+        const state = vectorState();
+        const { mm } = createManager([state]);
+        mm._showLegendIfVisible('A');
+
+        mm.setStyle('A', { 'fill-opacity': 0.2 });
+
+        expect(labels(mm, 'A')).toEqual(['0', '100']);
+    });
+});
+
+describe('legend appears for an agent-built choropleth (#333)', () => {
+    it('promotes a legend-less vector layer to a continuous legend', () => {
+        const state = vectorState({ legendType: null, defaultPaint: { 'fill-color': '#2E7D32' } });
+        const { mm } = createManager([state]);
+        mm._showLegendIfVisible('A');
+        expect(mm._legendItems.size).toBe(0);
+
+        mm.setStyle('A', { 'fill-color': ramp(5, 42) });
+
+        expect(state.legendType).toBe('continuous');
+        expect(state.legendTypeAuto).toBe(true);
+        expect(labels(mm, 'A')).toEqual(['5', '42']);
+    });
+
+    it('demotes again when a later restyle is no longer describable', () => {
+        const state = vectorState({ legendType: null, defaultPaint: { 'fill-color': '#2E7D32' } });
+        const { mm } = createManager([state]);
+        mm.setStyle('A', { 'fill-color': ramp(5, 42) });
+        mm.setStyle('A', { 'fill-color': ['match', ['get', 'gap'], '1', '#c1', '#999'] });
+
+        expect(state.legendType).toBeNull();
+        expect(state.legendTypeAuto).toBe(false);
+        expect(mm._legendItems.has('A')).toBe(false);
+    });
+
+    it('does not promote a raster layer', () => {
+        const state = vectorState({ type: 'raster', legendType: null });
+        const { mm } = createManager([state]);
+        mm.setStyle('A', { 'raster-opacity': 0.4 });
+        expect(state.legendType).toBeNull();
+    });
+
+    it('leaves a config-declared legend type untouched', () => {
+        const state = vectorState({ legendType: 'categorical', legendClasses: [{ name: 'a', 'color-hint': '#123456' }, { name: 'b', 'color-hint': '#654321' }] });
+        const { mm } = createManager([state]);
+        mm.setStyle('A', { 'fill-color': ramp(0, 9) });
+
+        expect(state.legendType).toBe('categorical');
+        expect(state.legendTypeAuto).toBeUndefined();
+    });
+});
+
+describe('resetStyle returns the legend to its boot state (#333)', () => {
+    it('removes a legend that only a restyle created', () => {
+        const state = vectorState({ legendType: null, defaultPaint: { 'fill-color': '#2E7D32' } });
+        const { mm, painted } = createManager([state]);
+        mm.setStyle('A', { 'fill-color': ramp(5, 42) });
+        expect(mm._legendItems.has('A')).toBe(true);
+
+        mm.resetStyle('A');
+
+        expect(state.legendType).toBeNull();
+        expect(state.legendTypeAuto).toBe(false);
+        expect(state.currentPaint).toBeNull();
+        expect(mm._legendItems.has('A')).toBe(false);
+        expect(painted['layer-A:fill-color']).toBe('#2E7D32');
+    });
+
+    it('restores the registered ramp on a config-declared legend', () => {
+        const state = vectorState();
+        const { mm } = createManager([state]);
+        mm._showLegendIfVisible('A');
+        mm.setStyle('A', { 'fill-color': ramp(0, 500) });
+        expect(labels(mm, 'A')).toEqual(['0', '500']);
+
+        mm.resetStyle('A');
+
+        expect(labels(mm, 'A')).toEqual(['0', '100']);
+    });
+});
+
+describe('legend follows set_style — hex layers (#333)', () => {
+    it('keeps the per-res palette legend for an opacity-only restyle', () => {
+        const state = hexState();
+        const { mm } = createManager([state]);
+        mm._showLegendIfVisible('hex-abc');
+        expect(labels(mm, 'hex-abc')).toEqual(['0', '700']);
+
+        mm.setStyle('hex-abc', { 'fill-opacity': 0.4 });
+
+        expect(labels(mm, 'hex-abc')).toEqual(['0', '700']);
+        expect(bar(mm, 'hex-abc')).toBe(`linear-gradient(to right, ${PALETTES.viridis.join(', ')})`);
+    });
+
+    it('mirrors a fixed ramp that replaced the per-res expression', () => {
+        const state = hexState();
+        const { mm } = createManager([state]);
+        mm._showLegendIfVisible('hex-abc');
+
+        mm.setStyle('hex-abc', {
+            'fill-color': ['interpolate', ['linear'], ['get', 'population'], 0, '#ffffcc', 1200, '#800026'],
+        });
+
+        expect(labels(mm, 'hex-abc')).toEqual(['0', '1,200']);
+        expect(bar(mm, 'hex-abc')).toBe('linear-gradient(to right, #ffffcc, #800026)');
+        expect(resNote(mm, 'hex-abc')).toBe('H3 resolution 6');
+    });
+
+    it('omits the resolution note when a restyled layer has no per-res stats', () => {
+        const state = hexState({ hexValueStats: { by_res: {} } });
+        const { mm } = createManager([state]);
+
+        mm.setStyle('hex-abc', {
+            'fill-color': ['interpolate', ['linear'], ['get', 'population'], 1, '#000000', 8, '#ffffff'],
+        });
+
+        expect(labels(mm, 'hex-abc')).toEqual(['1', '8']);
+        expect(resNote(mm, 'hex-abc')).toBe('');
+    });
+
+    it('drops the legend when recolored categorically', () => {
+        const state = hexState();
+        const { mm } = createManager([state]);
+        mm._showLegendIfVisible('hex-abc');
+
+        mm.setStyle('hex-abc', {
+            'fill-color': ['match', ['get', 'population'], 1, '#111111', '#999999'],
+        });
+
+        expect(mm._legendItems.has('hex-abc')).toBe(false);
+        expect(mm._hexLegendRefs.has('hex-abc')).toBe(false);
+    });
+});
+
+describe('legend refresh housekeeping (#333)', () => {
+    it('hides a group wrapper once its last member loses its legend', () => {
+        const state = vectorState({ group: 'Monuments' });
+        const { mm } = createManager([state]);
+        mm._showLegendIfVisible('A');
+        const wrapper = mm._legendGroups.get('Monuments');
+        expect(wrapper.querySelectorAll('.legend-section')).toHaveLength(1);
+
+        mm.setStyle('A', { 'fill-color': '#ff0000' });
+
+        expect(wrapper.querySelectorAll('.legend-section')).toHaveLength(0);
+        expect(wrapper.style.display).toBe('none');
+    });
+
+    it('a hidden layer restyled then shown renders the new ramp', () => {
+        const state = vectorState({ visible: false });
+        const { mm } = createManager([state]);
+        mm._showLegendIfVisible('A');
+        expect(mm._legendItems.size).toBe(0);
+
+        mm.setStyle('A', { 'fill-color': ramp(0, 250) });
+        state.visible = true;
+        mm._showLegendIfVisible('A');
+
+        expect(labels(mm, 'A')).toEqual(['0', '250']);
+    });
+
+    it('switchVersion discards a restyle-derived legend and the stale section', () => {
+        const state = vectorState({
+            legendType: null,
+            defaultPaint: { 'fill-color': '#2E7D32' },
+            versions: [
+                { label: 'L3', mapLayerId: 'v0', outlineLayerId: null, sourceId: 's0', sourceLayer: null },
+                { label: 'L4', mapLayerId: 'v1', outlineLayerId: null, sourceId: 's1', sourceLayer: null },
+            ],
+            activeVersionIndex: 0,
+            filter: null,
+        });
+        const { mm } = createManager([state]);
+        mm.setStyle('A', { 'fill-color': ramp(0, 42) });
+        const item = mm._legendItems.get('A');
+        expect(item).toBeTruthy();
+
+        mm.switchVersion('A', 1);
+
+        expect(state.currentPaint).toBeNull();
+        expect(state.legendType).toBeNull();
+        expect(mm._legendItems.has('A')).toBe(false);
+        expect(item.parentNode).toBeNull();
+    });
+});


### PR DESCRIPTION
Fixes #333.

Legends were resolved from config and construction-time paint only, and nothing in the styling path refreshed them. Since `set_style` is agent-reachable, that left three different lies on screen.

## What was wrong

| Layer | Before | After |
|---|---|---|
| Continuous vector (`legend_type: continuous`) | Colorbar keeps the **registered** colors *and* value range — `_continuousVectorLegend` derives from `defaultPaint` | Derives from the paint actually applied |
| Plain vector (no `legend_*` config) | **No legend at all** — `_hasLegend` gates on a `legendType` that only came from static config, so the documented "data-driven gradient" `set_style` example rendered a choropleth with nothing explaining it | Gains a derived colorbar |
| Hex (`add_hex_tile_layer`) | Keeps the palette registered at add time | Mirrors the new ramp, or drops the legend if it can't be described |

## Approach

- **`state.currentPaint`** records what was actually applied (successful `setPaintProperty` calls only); `_effectivePaint()` is `currentPaint || defaultPaint`, and every legend resolver reads it. Initialized lazily in `setStyle` rather than at the five registration sites, so no branch can miss it.
- **`_refreshLegend(layerId)`** = drop the cached section, re-render if the layer still contributes one. Sections are built once and cached, so the stale one has to go before `_showLegend` will rebuild.
- **Silence over stale**: a layer restyled past what `deriveContinuousLegend` can parse (flat color, `match`) loses its legend rather than captioning a ramp that's no longer on the map. Derived values also now beat explicit `legend_gradient` / `legend_range` config *once restyled* — that config described the paint the layer shipped with.
- **`_promoteLegendType`** gives a legend-less vector layer a colorbar when a restyle makes one derivable, flagged `legendTypeAuto` so `resetStyle` and `switchVersion` undo it. Config-declared legend types and hex layers are left alone. This is the one behavior change beyond bug-fixing — #333 flagged it as a judgment call, and gating it on "the agent restyled it" (never boot) keeps apps that deliberately ship legend-less vector layers unaffected until something restyles them.
- **Colour-change detection** (`_colorPaintChanged` + new `primaryColorValue` helper) is deliberate, not incidental: without it an opacity-only `set_style` would read as a recolor and drop hex legends on a `fill-opacity` tweak.

## Incidental fixes

Both fell out of routing every legend rebuild through one path:

- The version-switch raster path called `_hideLegend` then deleted the map entry — the old DOM node was **never removed**, just hidden forever, and hidden layers kept a section built against the old tile URL that `showLayer` would happily re-show.
- `deriveContinuousLegend` now reads `fill-extrusion-color`, so 3D hex layers (#317) can derive a legend at all.

## Testing

`npm test`: **598 passed** (33 files), up from 577.

- `test/map-manager.legend-restyle.test.js` (new, 17 tests) — relabel, drop-when-undescribable, opacity-only no-op, promotion + demotion, `resetStyle` round-trip, hex per-res vs. fixed ramp, group-wrapper hiding, hidden-then-shown, `switchVersion`.
- `test/legend-helpers.test.js` (+4) — `fill-extrusion-color` derivation, `primaryColorValue`.
- `app/legend-helpers.js` is at 100% coverage; `app/map-manager.js` 64.4%.

**Not verified in a browser.** The jsdom harness covers the legend logic and DOM, but real MapLibre `setPaintProperty` / `queryRenderedFeatures` behavior is unexercised — per AGENTS.md this module is "verify visually in a deployed app". Worth a manual pass on a graduated-choropleth app: restyle a layer, confirm the colorbar follows; `reset_style`, confirm it returns; restyle a hex layer's ramp and confirm the bar and labels track it.

## Follow-up

#334 (agent-addressable legends) is the feature side of this and listed #333 as a prerequisite; this PR is only about the existing legend staying truthful. One thing deliberately left out: `set_style`'s result says nothing about the legend having appeared or vanished, so the agent can't tell. Adding a field is cheap but costs tokens on every call — better decided in #334.
