### PR TITLE
feat(legend): `set_legend` / `reset_legend` + legend state in `get_map_state` (#334)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ Core library for map-based applications with LLM-powered data analysis. Interact
 - `main.js` — Bootstrap: loads config, initializes catalog → map → tools → agent → UI
 - `dataset-catalog.js` — Fetches STAC collections, builds unified records
 - `map-manager.js` — Creates MapLibre map, manages layers/filters/styles
-- `map-tools.js` — 9 local tools the LLM agent can call
+- `map-tools.js` — the local tools the LLM agent can call (map control, styling, legends, geocoding)
 - `tool-registry.js` — Unified dispatch for local + remote (MCP) tools
 - `mcp-client.js` — MCP transport wrapper (connect once, lazy reconnect)
 - `agent.js` — LLM orchestration loop (agentic tool-use cycle)

--- a/app/map-manager.js
+++ b/app/map-manager.js
@@ -1088,6 +1088,131 @@ export class MapManager {
         return { success: true, layer: layerId, displayName: state.displayName, tooltipFields: state.tooltipFields };
     }
 
+    // ---- Legend ----
+
+    /**
+     * Set the parts of a legend that cannot be derived from the map: what the
+     * classes are called, what the layer is called, the unit on a colorbar's end
+     * values, and whether the section shows at all (#334).
+     *
+     * Colors and value ranges are deliberately not settable — those come from
+     * the paint, so a legend cannot be made to disagree with what's rendered
+     * (the staleness #333 removed). What the agent supplies is the semantics it
+     * alone knows: it wrote the SQL that turned "Amphibians" into the integer 1,
+     * and nothing on the client can recover that mapping from the tiles.
+     *
+     * @param {string} layerId
+     * @param {Object} opts
+     * @param {Object<string,string>} [opts.labels] - value → class name, for
+     *   categorical legends. Merged with any labels already set.
+     * @param {string} [opts.title] - Layer heading, in the legend and the layer panel.
+     * @param {string} [opts.units] - Unit suffix on colorbar end values.
+     * @param {boolean} [opts.visible] - false suppresses the section.
+     * @returns {Object} Result, including the legend as it now reads.
+     */
+    setLegend(layerId, opts = {}) {
+        const state = this.layers.get(layerId);
+        if (!state) return { success: false, error: `Unknown layer: ${layerId}` };
+
+        const { labels, title, units, visible } = opts;
+
+        if (labels !== undefined) {
+            if (labels === null || typeof labels !== 'object' || Array.isArray(labels)) {
+                return { success: false, error: 'labels must be an object mapping class values to names' };
+            }
+            const bad = Object.entries(labels).find(([, v]) => typeof v !== 'string');
+            if (bad) return { success: false, error: `label for "${bad[0]}" must be a string` };
+            // Merge: labelling classes one call at a time shouldn't drop earlier names.
+            state.legendLabels = { ...(state.legendLabels || {}), ...labels };
+        }
+
+        if (title !== undefined) {
+            if (typeof title !== 'string' || !title.trim()) {
+                return { success: false, error: 'title must be a non-empty string' };
+            }
+            // Capture once, so reset lands on the name boot rendered rather than
+            // on whatever an earlier setLegend left behind.
+            if (state.defaultDisplayName === undefined) state.defaultDisplayName = state.displayName;
+            state.displayName = title;
+            this._renameLayerControl(layerId, title);
+        }
+
+        if (units !== undefined) {
+            if (units !== null && typeof units !== 'string') {
+                return { success: false, error: 'units must be a string (or null to clear)' };
+            }
+            if (state.defaultLegendLabel === undefined) state.defaultLegendLabel = state.legendLabel ?? null;
+            state.legendLabel = units || null;
+        }
+
+        if (visible !== undefined) {
+            if (typeof visible !== 'boolean') return { success: false, error: 'visible must be a boolean' };
+            state.legendHidden = !visible;
+        }
+
+        this._refreshLegend(layerId);
+        return { success: true, layer: layerId, ...this.describeLegend(layerId) };
+    }
+
+    /**
+     * Drop agent-supplied legend labels, title, units, and suppression, leaving
+     * the legend as config declared it. Mirrors resetStyle / resetTooltip; does
+     * not touch paint, so a legend derived from a restyle stays derived.
+     */
+    resetLegend(layerId) {
+        const state = this.layers.get(layerId);
+        if (!state) return { success: false, error: `Unknown layer: ${layerId}` };
+
+        state.legendLabels = null;
+        state.legendHidden = false;
+        if (state.defaultDisplayName !== undefined) {
+            state.displayName = state.defaultDisplayName;
+            this._renameLayerControl(layerId, state.displayName);
+        }
+        if (state.defaultLegendLabel !== undefined) state.legendLabel = state.defaultLegendLabel;
+
+        this._refreshLegend(layerId);
+        return { success: true, layer: layerId, ...this.describeLegend(layerId) };
+    }
+
+    /**
+     * How a layer's legend currently reads — the resolved type, whether it's on
+     * screen, and for a categorical legend the class values with their labels,
+     * so the agent can see which are still bare codes.
+     */
+    describeLegend(layerId) {
+        const state = this.layers.get(layerId);
+        if (!state) return { error: `Unknown layer: ${layerId}` };
+
+        const type = this._resolvedLegendType(state);
+        const categorical = type === 'categorical' ? this._categoricalLegend(state) : null;
+        return {
+            displayName: state.displayName,
+            legend: {
+                type,
+                rendered: !!type && state.visible && !state.legendHidden,
+                ...(state.legendLabel && { units: state.legendLabel }),
+                ...(categorical && {
+                    classes: categorical.classes.map(c => ({
+                        ...(c.value !== undefined && { value: c.value }),
+                        label: c.name ?? `Class ${c.value}`,
+                    })),
+                }),
+            },
+        };
+    }
+
+    /** Update a layer's row in the layer panel after a rename. */
+    _renameLayerControl(layerId, name) {
+        const safeId = layerId.replace(/\//g, '-');
+        const row = document.getElementById(`layer-item-${safeId}`);
+        if (!row) return;
+        const span = row.querySelector('label span');
+        if (span) span.textContent = name;
+        const removeBtn = row.querySelector('.layer-remove-btn');
+        if (removeBtn) removeBtn.setAttribute('aria-label', `Remove ${name}`);
+    }
+
     // ---- Styling ----
 
     /**
@@ -1228,6 +1353,10 @@ export class MapManager {
                 // Hex layers color by a single dynamic column; expose it so the
                 // agent styles against the real property, not a guess (#259).
                 ...(state.valueColumn && { valueColumn: state.valueColumn }),
+                // What the legend currently says. Without this the agent is
+                // blind to the one part of the map it can't see, and reads a
+                // "the colors are wrong" complaint as a paint bug (#334).
+                legend: this.describeLegend(id).legend,
             };
         }
         return { success: true, layers };
@@ -1840,10 +1969,26 @@ export class MapManager {
      * declared `continuous` or which is a hex layer.
      */
     _hasLegend(state) {
-        return state.type === 'raster'
-            || !!this._categoricalLegend(state)
-            || (state.legendType === 'continuous' && !!this._continuousVectorLegend(state))
-            || (state.legendType === 'hex' && !!this._hexLegend(state));
+        return !state.legendHidden && !!this._resolvedLegendType(state);
+    }
+
+    /**
+     * What a layer's legend actually renders as *now* — as opposed to
+     * `state.legendType`, which is what config declared. They diverge whenever a
+     * restyle has recolored the layer past its declared type (a hex layer
+     * recolored with `match` resolves 'categorical'), and `get_map_state`
+     * reports this one so the agent can see the legend it's being asked about
+     * (#334).
+     *
+     * @returns {'raster'|'categorical'|'continuous'|'hex'|null} null when the
+     *   layer contributes no legend.
+     */
+    _resolvedLegendType(state) {
+        if (state.type === 'raster') return 'raster';
+        if (this._categoricalLegend(state)) return 'categorical';
+        if (state.legendType === 'continuous' && this._continuousVectorLegend(state)) return 'continuous';
+        if (state.legendType === 'hex' && this._hexLegend(state)) return 'hex';
+        return null;
     }
 
     /**
@@ -1868,20 +2013,37 @@ export class MapManager {
             if (!derived) return null;
             const classes = derived.classes.map(c => ({
                 value: c.value,
-                // No name exists to show: the tiles carry the code, and what it
-                // means lives in the SQL that produced it. Label with the value
-                // itself — honest and discrete, and `set_legend` can name it.
-                name: Array.isArray(c.value)
-                    ? c.value.map(v => this._fmtLegendValue(v)).join(', ')
-                    : this._fmtLegendValue(c.value),
+                // Nothing on the client knows what the code means — the tiles
+                // carry the code, and its meaning lives in the SQL that produced
+                // it. Fall back to the value itself, which `set_legend` labels.
+                name: this._legendClassLabel(state, c.value)
+                    ?? (Array.isArray(c.value)
+                        ? c.value.map(v => this._fmtLegendValue(v)).join(', ')
+                        : this._fmtLegendValue(c.value)),
                 'color-hint': c.color,
             }));
             return { classes, derived: true };
         }
 
-        return (state.legendType === 'categorical' && state.legendClasses?.length > 0)
-            ? { classes: state.legendClasses, derived: false }
-            : null;
+        if (!(state.legendType === 'categorical' && state.legendClasses?.length > 0)) return null;
+        // Author-declared classes, with any agent-supplied label taking priority
+        // (the agent is renaming what the user is looking at right now).
+        const classes = state.legendClasses.map(cls => {
+            const label = this._legendClassLabel(state, cls.value);
+            return label == null ? cls : { ...cls, name: label };
+        });
+        return { classes, derived: false };
+    }
+
+    /**
+     * An agent-supplied label for one legend class, or null. Values arrive from
+     * the model as strings even when the paint matches numbers, so compare
+     * stringified (and join array-valued match arms the way they render).
+     */
+    _legendClassLabel(state, value) {
+        if (!state.legendLabels) return null;
+        const key = Array.isArray(value) ? value.join(',') : String(value);
+        return state.legendLabels[key] ?? null;
     }
 
     /**

--- a/app/map-tools.js
+++ b/app/map-tools.js
@@ -306,6 +306,63 @@ ${pickLayerNudge}`,
         },
 
         {
+            name: 'set_legend',
+            description: `Label a layer's legend. Use after you build a map whose meaning isn't visible from the tiles — above all after styling a layer with a \`match\` expression over codes you invented in SQL.
+
+The legend already mirrors the map's colors automatically: a \`match\` recolor renders one swatch per category, a gradient recolor renders a colorbar. What it cannot know is what your codes MEAN. If your SQL emitted \`CASE WHEN ... THEN 1\` for amphibians, the legend shows a swatch labelled "1" until you name it here.
+
+So: whenever you post a color key in chat, call this instead — that key belongs on the map.
+
+  set_legend { "layer_id": "hex-1a66…",
+               "labels": { "1": "Amphibians", "2": "Reptiles", "3": "Birds", "4": "Mammals", "5": "Plants" } }
+
+Fields (all optional except layer_id):
+  labels    class value → name, for a categorical/swatch legend. Keys are the values in
+            your \`match\` expression, as strings. Merged with labels already set.
+  title     heading for the layer, in both the legend and the layer panel.
+  units     unit shown after a colorbar's end values (e.g. "observations", "kg/ha").
+  visible   false hides this layer's legend section; true brings it back.
+
+Colors and value ranges are NOT settable — they are read from the layer's paint, so the legend can never disagree with the map. To change the colors, call set_style; the legend follows.
+
+Call get_map_state to see what a legend currently says (its \`legend.type\`, and \`legend.classes\` with the label each class shows now). Use reset_legend to return to the app's own labels.`,
+            inputSchema: {
+                type: 'object',
+                properties: {
+                    layer_id: { type: 'string', description: 'Layer ID whose legend to label' },
+                    labels: {
+                        type: 'object',
+                        description: 'Class value → display name, e.g. {"1": "Amphibians", "2": "Reptiles"}. Keys are the values from the layer\'s `match` expression, as strings.',
+                        additionalProperties: { type: 'string' },
+                    },
+                    title: { type: 'string', description: 'Heading for this layer in the legend and layer panel' },
+                    units: { type: 'string', description: 'Unit suffix for a colorbar\'s end values, e.g. "species"' },
+                    visible: { type: 'boolean', description: 'false hides this layer\'s legend section' },
+                },
+                required: ['layer_id'],
+            },
+            execute: (args) => JSON.stringify(mapManager.setLegend(args.layer_id, {
+                labels: args.labels,
+                title: args.title,
+                units: args.units,
+                visible: args.visible,
+            })),
+        },
+
+        {
+            name: 'reset_legend',
+            description: `Discard legend labels, title, units, and hiding you set with set_legend, returning the layer to the app's own legend. Does not change the map's colors — a legend derived from a restyle stays derived. Use when the user asks to "reset the legend" or "put the labels back".`,
+            inputSchema: {
+                type: 'object',
+                properties: {
+                    layer_id: { type: 'string', description: 'Layer ID whose legend to reset' },
+                },
+                required: ['layer_id'],
+            },
+            execute: (args) => JSON.stringify(mapManager.resetLegend(args.layer_id)),
+        },
+
+        {
             name: 'set_style',
             description: `Update a layer's paint/style properties. Provide MapLibre paint properties — every property name carries a layer-type prefix (\`fill-\`, \`line-\`, \`circle-\`, \`raster-\`).
 
@@ -322,6 +379,8 @@ Examples:
   Data-driven categorical: { "fill-color": ["match", ["get", "PROP"], "val1", "#c1", "val2", "#c2", "#default"] }
   Data-driven gradient: { "fill-color": ["interpolate", ["linear"], ["get", "PROP"], 0, "#low", 100, "#high"] }
   Stepped: { "fill-color": ["step", ["get", "PROP"], "#c1", 10, "#c2", 50, "#c3"] }
+
+After a \`match\` recolor over codes you defined in SQL, the legend shows one swatch per code labelled with the bare number — call set_legend with \`labels\` to name them, rather than writing the color key out in chat.
 
 For dynamic hex layers (\`hex-…\` ids from add_hex_tile_layer), \`PROP\` is the layer's value column (the \`value_column\` you passed to add_hex_tile_layer, e.g. "species_richness") — NOT "count" unless that is literally the column. If unsure, call get_map_state to read the layer's \`valueColumn\`.
 

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -138,6 +138,8 @@ A layer with no `legend_type` at all gains a legend when the agent recolors it i
 
 Swatches derived from a `match` are labelled with the matched value itself (`1`, `2`, …), because the vector tiles carry only the code — what the code *means* usually lives in the SQL that produced the layer. Author-supplied `legend_classes` labels are used whenever the layer has not been recolored past them.
 
+The agent closes that last gap with `set_legend`, which names the classes (`{"1": "Amphibians"}`), retitles the layer, adds a colorbar unit, or hides the section. It cannot set colors or value ranges — those stay derived from the paint, so a legend can't be made to contradict the map. `reset_legend` restores the labels configured here. Nothing in this file needs to change to allow it; `set_legend` overrides `legend_label` and `legend_classes` names for the session only.
+
 ## Asset config — raster (COG)
 
 | Field | Type | Description |

--- a/test/map-manager.set-legend.test.js
+++ b/test/map-manager.set-legend.test.js
@@ -1,0 +1,254 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest';
+import { MapManager } from '../app/map-manager.js';
+
+/**
+ * The legend mirrors the map's colors on its own (#333, #334), but nothing on
+ * the client knows what an agent-invented code *means* — that lives in the SQL
+ * that produced the layer. `set_legend` supplies exactly that missing half, and
+ * nothing that would let the legend disagree with the paint (#334).
+ */
+
+function createManager(states) {
+    const mm = Object.create(MapManager.prototype);
+    mm.layers = new Map(states.map(s => [s.layerId, s]));
+    mm._legendItems = new Map();
+    mm._legendGroups = new Map();
+    mm._hexLegendRefs = new Map();
+    mm._hexLegendReactive = true;
+    mm._legendEl = null;
+    mm._legendContent = null;
+    mm._ensureLegend = function () {
+        if (this._legendEl) return;
+        this._legendEl = document.createElement('div');
+        this._legendContent = document.createElement('div');
+        this._legendEl.appendChild(this._legendContent);
+        document.body.appendChild(this._legendEl);
+    };
+    mm._getColormapGradient = async () => 'linear-gradient(to right, #eee, #333)';
+    mm.map = {
+        on: () => {},
+        setPaintProperty: () => {},
+        getLayer: () => ({ type: 'fill' }),
+        queryRenderedFeatures: () => [{ properties: { res: 6 } }],
+    };
+    return mm;
+}
+
+const taxonPaint = {
+    'fill-color': ['match', ['get', 'dominant_taxon'],
+        1, '#1f77b4', 2, '#ff7f0e', 3, '#2ca02c', '#cccccc'],
+};
+
+/** A hex layer already recolored categorically — the #334 session's end state. */
+function recoloredHex(overrides = {}) {
+    return {
+        layerId: 'hex-abc', mapLayerId: 'hex-abc', displayName: 'Hex: dominant_taxon',
+        visible: true, type: 'vector', group: null, valueColumn: 'dominant_taxon',
+        legendType: 'hex', legendLabel: null, legendClasses: null,
+        hexValueStats: { by_res: { '7': { min: 1, max: 5 } } },
+        hexPalette: 'viridis', hexCurrentRes: null,
+        defaultPaint: { 'fill-color': ['interpolate', ['linear'], ['get', 'dominant_taxon'], 1, '#440154', 5, '#fde725'] },
+        currentPaint: taxonPaint,
+        ...overrides,
+    };
+}
+
+const rows = (mm, id) =>
+    [...mm._legendItems.get(id).querySelectorAll('.legend-item')].map(r => r.textContent);
+
+describe('setLegend labels (#334)', () => {
+    it('names the swatches of a categorically recolored hex layer', () => {
+        const mm = createManager([recoloredHex()]);
+        mm._showLegendIfVisible('hex-abc');
+        expect(rows(mm, 'hex-abc')).toEqual(['1', '2', '3']);
+
+        const result = mm.setLegend('hex-abc', {
+            labels: { 1: 'Amphibians', 2: 'Reptiles', 3: 'Birds' },
+        });
+
+        expect(result.success).toBe(true);
+        expect(rows(mm, 'hex-abc')).toEqual(['Amphibians', 'Reptiles', 'Birds']);
+    });
+
+    it('matches labels keyed as strings against numeric match values', () => {
+        // Tool args arrive as JSON, so a model naming integer codes sends string keys.
+        const mm = createManager([recoloredHex()]);
+        mm.setLegend('hex-abc', { labels: { '2': 'Reptiles' } });
+        expect(rows(mm, 'hex-abc')).toEqual(['1', 'Reptiles', '3']);
+    });
+
+    it('merges across calls instead of replacing', () => {
+        const mm = createManager([recoloredHex()]);
+        mm.setLegend('hex-abc', { labels: { 1: 'Amphibians' } });
+        mm.setLegend('hex-abc', { labels: { 3: 'Birds' } });
+        expect(rows(mm, 'hex-abc')).toEqual(['Amphibians', '2', 'Birds']);
+    });
+
+    it('leaves unlabelled classes showing their bare value', () => {
+        const mm = createManager([recoloredHex()]);
+        mm.setLegend('hex-abc', { labels: { 1: 'Amphibians' } });
+        expect(rows(mm, 'hex-abc')).toEqual(['Amphibians', '2', '3']);
+    });
+
+    it('labels a multi-value match arm by its joined key', () => {
+        const mm = createManager([recoloredHex({
+            currentPaint: { 'fill-color': ['match', ['get', 'g'], [1, 2], '#111111', 3, '#222222', '#ccc'] },
+        })]);
+        mm.setLegend('hex-abc', { labels: { '1,2': 'Vertebrates' } });
+        expect(rows(mm, 'hex-abc')).toEqual(['Vertebrates', '3']);
+    });
+
+    it('overrides config legend_classes names too', () => {
+        const mm = createManager([{
+            layerId: 'A', mapLayerId: 'layer-A', displayName: 'Conserved', visible: true,
+            type: 'vector', group: null, legendType: 'categorical',
+            legendClasses: [{ value: 1, name: 'GAP 1', 'color-hint': '#123456' }],
+            defaultPaint: { 'fill-color': '#123456' },
+        }]);
+        mm.setLegend('A', { labels: { 1: 'Strictly protected' } });
+        expect(rows(mm, 'A')).toEqual(['Strictly protected']);
+    });
+
+    it('rejects a non-object labels argument', () => {
+        const mm = createManager([recoloredHex()]);
+        expect(mm.setLegend('hex-abc', { labels: ['Amphibians'] }).success).toBe(false);
+        expect(mm.setLegend('hex-abc', { labels: { 1: 5 } }).error).toMatch(/must be a string/);
+    });
+
+    it('errors on an unknown layer', () => {
+        const mm = createManager([recoloredHex()]);
+        expect(mm.setLegend('nope', { labels: {} })).toEqual({
+            success: false, error: 'Unknown layer: nope',
+        });
+    });
+});
+
+describe('setLegend title / units / visibility (#334)', () => {
+    it('retitles the legend heading and the layer panel row', () => {
+        const mm = createManager([recoloredHex()]);
+        const row = document.createElement('div');
+        row.id = 'layer-item-hex-abc';
+        const label = document.createElement('label');
+        const span = document.createElement('span');
+        span.textContent = 'Hex: dominant_taxon';
+        label.appendChild(span);
+        row.appendChild(label);
+        document.body.appendChild(row);
+
+        mm.setLegend('hex-abc', { title: 'Dominant taxon (unprotected)' });
+        mm._showLegendIfVisible('hex-abc');
+
+        expect(mm._legendItems.get('hex-abc').querySelector('h4').textContent)
+            .toBe('Dominant taxon (unprotected)');
+        expect(span.textContent).toBe('Dominant taxon (unprotected)');
+        row.remove();
+    });
+
+    it('adds units to a colorbar\'s end values', () => {
+        const mm = createManager([{
+            layerId: 'A', mapLayerId: 'layer-A', displayName: 'Richness', visible: true,
+            type: 'vector', group: null, legendType: 'continuous', legendLabel: null,
+            legendClasses: null, legendRange: null, legendGradient: null,
+            defaultPaint: { 'fill-color': ['interpolate', ['linear'], ['get', 'v'], 0, '#eee', 42, '#333'] },
+        }]);
+        mm.setLegend('A', { units: 'species' });
+        mm._showLegendIfVisible('A');
+
+        const labels = [...mm._legendItems.get('A').querySelectorAll('.legend-labels span')]
+            .map(s => s.textContent);
+        expect(labels).toEqual(['0 species', '42 species']);
+    });
+
+    it('hides and restores a layer\'s legend section', () => {
+        const mm = createManager([recoloredHex()]);
+        mm._showLegendIfVisible('hex-abc');
+        expect(mm._legendItems.has('hex-abc')).toBe(true);
+
+        mm.setLegend('hex-abc', { visible: false });
+        expect(mm._legendItems.has('hex-abc')).toBe(false);
+
+        mm.setLegend('hex-abc', { visible: true });
+        expect(rows(mm, 'hex-abc')).toEqual(['1', '2', '3']);
+    });
+
+    it('validates title and visible', () => {
+        const mm = createManager([recoloredHex()]);
+        expect(mm.setLegend('hex-abc', { title: '  ' }).error).toMatch(/non-empty/);
+        expect(mm.setLegend('hex-abc', { visible: 'yes' }).error).toMatch(/boolean/);
+    });
+});
+
+describe('resetLegend (#334)', () => {
+    it('restores boot labels, title, units, and visibility', () => {
+        const mm = createManager([recoloredHex({ legendLabel: 'cells' })]);
+        mm.setLegend('hex-abc', {
+            labels: { 1: 'Amphibians' }, title: 'Renamed', units: 'taxa', visible: false,
+        });
+
+        const result = mm.resetLegend('hex-abc');
+
+        expect(result.success).toBe(true);
+        expect(mm.layers.get('hex-abc').displayName).toBe('Hex: dominant_taxon');
+        expect(mm.layers.get('hex-abc').legendLabel).toBe('cells');
+        expect(mm.layers.get('hex-abc').legendHidden).toBe(false);
+        expect(rows(mm, 'hex-abc')).toEqual(['1', '2', '3']);
+    });
+
+    it('leaves a restyle-derived legend derived — it is not a style reset', () => {
+        const mm = createManager([recoloredHex()]);
+        mm.setLegend('hex-abc', { labels: { 1: 'Amphibians' } });
+
+        mm.resetLegend('hex-abc');
+
+        // Still swatches from the current `match`, not the registered colorbar.
+        expect(mm.layers.get('hex-abc').currentPaint).toBe(taxonPaint);
+        expect(rows(mm, 'hex-abc')).toEqual(['1', '2', '3']);
+    });
+
+    it('errors on an unknown layer', () => {
+        const mm = createManager([recoloredHex()]);
+        expect(mm.resetLegend('nope').success).toBe(false);
+    });
+});
+
+describe('legend state in getMapState (#334)', () => {
+    it('reports the resolved type, not the declared one', () => {
+        // The layer is declared `hex` but recolored categorically: reporting
+        // 'hex' is what let the agent read a legend complaint as a paint bug.
+        const mm = createManager([recoloredHex()]);
+        const { layers } = mm.getMapState();
+        expect(layers['hex-abc'].legend.type).toBe('categorical');
+        expect(layers['hex-abc'].legend.rendered).toBe(true);
+    });
+
+    it('lists class values with the label each currently shows', () => {
+        const mm = createManager([recoloredHex()]);
+        mm.setLegend('hex-abc', { labels: { 2: 'Reptiles' } });
+
+        expect(mm.getMapState().layers['hex-abc'].legend.classes).toEqual([
+            { value: 1, label: '1' },
+            { value: 2, label: 'Reptiles' },
+            { value: 3, label: '3' },
+        ]);
+    });
+
+    it('reports units and suppression', () => {
+        const mm = createManager([recoloredHex()]);
+        mm.setLegend('hex-abc', { units: 'cells', visible: false });
+        const { legend } = mm.getMapState().layers['hex-abc'];
+        expect(legend.units).toBe('cells');
+        expect(legend.rendered).toBe(false);
+    });
+
+    it('reports a null type for a layer with no legend', () => {
+        const mm = createManager([{
+            layerId: 'A', mapLayerId: 'layer-A', displayName: 'Plain', visible: true,
+            type: 'vector', group: null, legendType: null, legendClasses: null,
+            defaultPaint: { 'fill-color': '#2E7D32' },
+        }]);
+        const { legend } = mm.getMapState().layers.A;
+        expect(legend.type).toBeNull();
+        expect(legend.rendered).toBe(false);
+    });
+});

--- a/test/map-tools.test.js
+++ b/test/map-tools.test.js
@@ -245,6 +245,67 @@ describe('get_schema MCP delegate', () => {
     });
 });
 
+describe('set_legend / reset_legend', () => {
+    const stubMapManager = () => ({
+        setLegend: vi.fn((layerId, opts) => ({ success: true, layer: layerId, opts })),
+        resetLegend: vi.fn((layerId) => ({ success: true, layer: layerId })),
+        getLayerSummaries: () => [{ id: 'hex-abc', displayName: 'Taxa', type: 'vector' }],
+    });
+    const stubCatalog = { records: new Map() };
+    const getTool = (name) => {
+        const mapManager = stubMapManager();
+        const tools = createMapTools(mapManager, stubCatalog);
+        return { tool: tools.find(t => t.name === name), mapManager };
+    };
+
+    it('forwards labels / title / units / visible as an options object', () => {
+        const { tool, mapManager } = getTool('set_legend');
+        const result = JSON.parse(tool.execute({
+            layer_id: 'hex-abc',
+            labels: { 1: 'Amphibians', 2: 'Reptiles' },
+            title: 'Dominant taxon',
+            units: 'species',
+            visible: true,
+        }));
+        expect(result.success).toBe(true);
+        expect(mapManager.setLegend).toHaveBeenCalledWith('hex-abc', {
+            labels: { 1: 'Amphibians', 2: 'Reptiles' },
+            title: 'Dominant taxon',
+            units: 'species',
+            visible: true,
+        });
+    });
+
+    it('leaves omitted fields undefined so they are not cleared', () => {
+        const { tool, mapManager } = getTool('set_legend');
+        tool.execute({ layer_id: 'hex-abc', labels: { 1: 'Amphibians' } });
+        const opts = mapManager.setLegend.mock.calls[0][1];
+        expect(opts.title).toBeUndefined();
+        expect(opts.units).toBeUndefined();
+        expect(opts.visible).toBeUndefined();
+    });
+
+    it('reset_legend forwards layer_id', () => {
+        const { tool, mapManager } = getTool('reset_legend');
+        expect(JSON.parse(tool.execute({ layer_id: 'hex-abc' })).success).toBe(true);
+        expect(mapManager.resetLegend).toHaveBeenCalledWith('hex-abc');
+    });
+
+    it('declares a typed labels schema so grammar-constrained servers can fill it (#243)', () => {
+        // An under-specified object/array param is what made set_filter emit `[]`
+        // once servers began constraining tool args to the schema.
+        const { tool } = getTool('set_legend');
+        expect(tool.inputSchema.properties.labels.type).toBe('object');
+        expect(tool.inputSchema.properties.labels.additionalProperties).toEqual({ type: 'string' });
+        expect(tool.inputSchema.required).toEqual(['layer_id']);
+    });
+
+    it('steers away from posting the color key in chat', () => {
+        const { tool } = getTool('set_legend');
+        expect(tool.description).toMatch(/color key in chat/i);
+    });
+});
+
 describe('set_tooltip / reset_tooltip', () => {
     const stubMapManager = () => ({
         setTooltip: vi.fn((layerId, fields) => ({ success: true, layer: layerId, tooltipFields: fields })),
@@ -517,9 +578,11 @@ describe('createMapTools smoke test', () => {
             'list_datasets',
             'remove_hex_tile_layer',
             'reset_filter',
+            'reset_legend',
             'reset_style',
             'reset_tooltip',
             'set_filter',
+            'set_legend',
             'set_projection',
             'set_style',
             'set_tooltip',


### PR DESCRIPTION
Closes #334. **Stacked on #339** — review that first; this PR's diff is only the second commit.

#339 gets the legend's *colors* right automatically. This adds the half no derivation can reach: what an agent-invented code **means**. When the agent writes `CASE WHEN … THEN 1` for amphibians, the tiles carry only the integer, so a derived swatch can honestly say no more than `1`.

## `set_legend(layer_id, {labels, title, units, visible})`

| field | effect |
|---|---|
| `labels` | class value → name. Merged across calls, so labelling one class at a time doesn't drop earlier names. Keys compare stringified — tool args arrive as JSON, so a model naming integer codes sends string keys. Overrides config `legend_classes` names too. |
| `title` | retitles the legend heading **and** the layer-panel row together. |
| `units` | the colorbar suffix (the existing `legend_label`). |
| `visible` | suppresses the section. |

```js
set_legend { "layer_id": "hex-1a66…",
             "labels": { "1": "Amphibians", "2": "Reptiles", "3": "Birds", "4": "Mammals", "5": "Plants" } }
```

**Colors and value ranges are deliberately not settable.** They come from the paint, so the legend structurally cannot disagree with what's rendered — that's the staleness #333 removed, and re-admitting author-supplied colors would reopen it. This is why the tool takes `labels` rather than #334's option-1 `legend_classes`: a value→name map has no way to express a swatch color that isn't on the map.

`reset_legend` mirrors `reset_style` / `reset_tooltip`: drops labels, title, units, and suppression without touching paint, so a restyle-derived legend stays derived.

## Legend state in `get_map_state`

Each layer now reports a `legend`: the **resolved** type (not the declared one), whether it's on screen, `units`, and for a categorical legend the class values with the label each currently shows.

This is the read-side gap #334 didn't mention, and it caused its own failure in the motivating session. The agent called `get_map_state` specifically to diagnose a legend complaint, got nothing about legends back, concluded the paint was wrong, and restyled an already-correct map — then told the user the legend now matched. Reporting a hex layer as `hex` when it renders `categorical` is what made that misreading available; `legend.classes` also shows at a glance which classes are still bare codes.

## Steering

`set_style` now points at `set_legend` after a `match` recolor, and `set_legend`'s description names the failure mode directly ("whenever you post a color key in chat, call this instead"). The observed behavior wasn't a capability gap — the agent produced a correct key twice — it was having nowhere to put it.

`labels` carries `additionalProperties: {type: 'string'}` rather than being an open object, per the #243 lesson about under-specified params once servers began grammar-constraining tool args.

## Tests

`npm test` → 638 passing. New `test/map-manager.set-legend.test.js` (19 cases: labelling, string/number key coercion, merge, multi-value arms, config-class override, title→panel row, units on a colorbar, hide/restore, reset, and the `get_map_state` shape) plus 6 in `test/map-tools.test.js` for arg forwarding, omitted-field semantics, and the schema shape.

Rendering is jsdom-verified; worth a visual pass on a deployed app before the release, since this touches the layer panel as well as the legend.

## Follow-ups, not in scope

- `docs/guide/configuration.md` gains a note that `set_legend` overrides these fields for the session; the tool itself needs no new config.
- #159 (`style_by_query`) should reuse this mechanism rather than add its own.